### PR TITLE
[web] Fix for broken bracket matching in Orion

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/syntaxcoloring/IEditorHighlightingConfigurationProvider.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/syntaxcoloring/IEditorHighlightingConfigurationProvider.xtend
@@ -52,6 +52,7 @@ interface IEditorHighlightingConfigurationProvider {
             {include: "orion.c-like#comment_block"},
             {include: "orion.lib#string_doubleQuote"},
             {include: "orion.lib#string_singleQuote"},
+            {include: "orion.lib#doc_block"},
             {include: "orion.lib#number_decimal"},
             {include: "orion.lib#number_hex"},
             {include: "orion.lib#brace_open"},
@@ -61,7 +62,6 @@ interface IEditorHighlightingConfigurationProvider {
             {include: "orion.lib#parenthesis_open"},
             {include: "orion.lib#parenthesis_close"},
             {include: "orion.lib#operator"},
-            {include: "orion.lib#doc_block"},
         '''
 
         def Iterable<String> getKeywords() {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/editor/syntaxcoloring/IEditorHighlightingConfigurationProvider.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/editor/syntaxcoloring/IEditorHighlightingConfigurationProvider.java
@@ -83,6 +83,8 @@ public interface IEditorHighlightingConfigurationProvider {
       _builder.newLine();
       _builder.append("{include: \"orion.lib#string_singleQuote\"},");
       _builder.newLine();
+      _builder.append("{include: \"orion.lib#doc_block\"},");
+      _builder.newLine();
       _builder.append("{include: \"orion.lib#number_decimal\"},");
       _builder.newLine();
       _builder.append("{include: \"orion.lib#number_hex\"},");
@@ -100,8 +102,6 @@ public interface IEditorHighlightingConfigurationProvider {
       _builder.append("{include: \"orion.lib#parenthesis_close\"},");
       _builder.newLine();
       _builder.append("{include: \"orion.lib#operator\"},");
-      _builder.newLine();
-      _builder.append("{include: \"orion.lib#doc_block\"},");
       _builder.newLine();
       return _builder;
     }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.xtend
@@ -392,6 +392,9 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 				|| (inheritsTerminals || inheritsXbase) && !suppressedPatterns.contains('string_singleQuote'))
 			patterns += '{include: "orion.lib#string_singleQuote"}'
 		
+		if (enabledPatterns.contains('doc_block'))
+			patterns += '{include: "orion.lib#doc_block"}'
+		
 		if (enabledPatterns.contains('number_decimal')
 				|| (inheritsTerminals || inheritsXbase) && !suppressedPatterns.contains('number_decimal'))
 			patterns += '{include: "orion.lib#number_decimal"}'
@@ -423,9 +426,6 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 		if (enabledPatterns.contains('parenthesis_close')
 				|| keywords.contains(')') && !suppressedPatterns.contains('parenthesis_close'))
 			patterns += '{include: "orion.lib#parenthesis_close"}'
-		
-		if (enabledPatterns.contains('doc_block'))
-			patterns += '{include: "orion.lib#doc_block"}'
 		
 		return patterns
 	}

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.java
@@ -797,6 +797,10 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
     if ((this.enabledPatterns.contains("string_singleQuote") || ((inheritsTerminals || inheritsXbase) && (!this.suppressedPatterns.contains("string_singleQuote"))))) {
       patterns.add("{include: \"orion.lib#string_singleQuote\"}");
     }
+    boolean _contains = this.enabledPatterns.contains("doc_block");
+    if (_contains) {
+      patterns.add("{include: \"orion.lib#doc_block\"}");
+    }
     if ((this.enabledPatterns.contains("number_decimal") || ((inheritsTerminals || inheritsXbase) && (!this.suppressedPatterns.contains("number_decimal"))))) {
       patterns.add("{include: \"orion.lib#number_decimal\"}");
     }
@@ -820,10 +824,6 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
     }
     if ((this.enabledPatterns.contains("parenthesis_close") || (keywords.contains(")") && (!this.suppressedPatterns.contains("parenthesis_close"))))) {
       patterns.add("{include: \"orion.lib#parenthesis_close\"}");
-    }
-    boolean _contains = this.enabledPatterns.contains("doc_block");
-    if (_contains) {
-      patterns.add("{include: \"orion.lib#doc_block\"}");
     }
     return patterns;
   }


### PR DESCRIPTION
In Orion's highlighting configuration all patterns that precede the last block pattern are treated as block patterns. Up to now the position of the `doc_block` pattern in the generated grammar causes all section patterns to become block patterns which breaks the bracket matching.

See also Orion bug #497097

Signed-off-by: Alex Tugarev <alex.tugarev@typefox.io>