### PR TITLE
[MANIFEST.MF-cleanup] splitting lines should also work on UNIX newlines

### DIFF
--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/MergeableManifest.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/MergeableManifest.java
@@ -61,7 +61,7 @@ public class MergeableManifest extends Manifest {
     public static String make512Safe(StringBuffer lines) {
         if (lines.length() > 512) {
         	StringBuilder result = new StringBuilder(lines.length());
-        	String[] splitted = lines.toString().split("\\r\\n");
+        	String[] splitted = lines.toString().split("\\r?\\n");
         	for(String string: splitted) {
         		if (string.length() > 512) {
         			int idx = 510;


### PR DESCRIPTION
Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>