### PR TITLE
fixed #60.

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/GenerateSerializerLanguages.mwe2
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/GenerateSerializerLanguages.mwe2
@@ -18,8 +18,23 @@ var lineDelimiter = '\n'
 
 Workflow {
 	bean = StandaloneSetup {
+		ignoreBrokenProjectFiles = true
 		platformUri = "${runtimeProject}/.."
+		scanClassPath = true
+		uriMap = {
+			from = "platform:/plugin/org.eclipse.emf.ecore/model/Ecore.ecore"
+			to = "platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore"
+		}
+		uriMap = {
+			from = "platform:/plugin/org.eclipse.emf.ecore/model/Ecore.genmodel"
+			to = "platform:/resource/org.eclipse.emf.ecore/model/Ecore.genmodel"
+		}
+		registerGenModelFile = "platform:/resource/org.eclipse.emf.ecore/model/Ecore.genmodel"
+		registerGeneratedEPackage = "org.eclipse.emf.ecore.EcorePackage"
 	}
+	
+	bean = tests.ecore.EcoreSupportStandaloneSetup {}
+	
 
 	component = DirectoryCleaner {
 		directory = "${runtimeProject}/src-gen/org/eclipse/xtext/serializer"


### PR DESCRIPTION
 GenerateSerializerLanguages.mwe2 should behave like GenerateAllTestLanguages.mwe2

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>