### PR TITLE
make AbstractPartialParsrTest more strict

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/AbstractPartialParserTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/AbstractPartialParserTest.java
@@ -54,6 +54,7 @@ public abstract class AbstractPartialParserTest extends AbstractXtextTests {
 			assertTrue(secondIter.hasNext());
 			INode firstNext = firstIter.next();
 			INode secondNext = secondIter.next();
+			assertEquals(firstNext.getGrammarElement(), secondNext.getGrammarElement());
 			assertEquals(firstNext.getClass(), secondNext.getClass());
 			assertEquals(firstNext.getTotalOffset(), secondNext.getTotalOffset());
 			assertEquals(firstNext.getTotalLength(), secondNext.getTotalLength());


### PR DESCRIPTION
It should also test if node.getGrammarElement() is correct

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>