### PR TITLE
[459213] Move registration of .xtextbin 

### DIFF
--- a/org.eclipse.xtext/plugin.xml
+++ b/org.eclipse.xtext/plugin.xml
@@ -22,6 +22,11 @@
        class = "org.eclipse.xtext.XtextPackage"
        genModel = "org/eclipse/xtext/Xtext.genmodel" /> 
   </extension>
-
-
+  <extension
+       point="org.eclipse.emf.ecore.extension_parser">
+    <parser
+       class="org.eclipse.xtext.resource.impl.BinaryGrammarResourceFactoryImpl"
+       type="xtextbin">
+    </parser>
+  </extension>
 </plugin>


### PR DESCRIPTION
from plugin org.eclipse.xtext.ui to plugin org.eclipse.xtext 

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>