### PR TITLE
[478377] Add null guard

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/nodemodel/util/NodeModelUtilsTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/nodemodel/util/NodeModelUtilsTest.java
@@ -54,6 +54,9 @@ public class NodeModelUtilsTest extends AbstractXtextTests {
 		nodes = NodeModelUtils.findNodesForFeature(declaration, XtextPackage.eINSTANCE.getGeneratedMetamodel_Name());
 		assertEquals(1, nodes.size());
 		assertEquals("foo", nodes.get(0).getText().trim());
+		
+		nodes = NodeModelUtils.findNodesForFeature(declaration, null);
+		assertEquals(0, nodes.size());
 	}
 	
 	@Test public void testFindNodesForFeature_MultipleFeature() throws Exception {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/util/NodeModelUtils.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/util/NodeModelUtils.java
@@ -164,7 +164,7 @@ public class NodeModelUtils extends InternalNodeModelUtils {
 	/* @NonNull */
 	public static List<INode> findNodesForFeature(EObject semanticObject, EStructuralFeature structuralFeature) {
 		ICompositeNode node = findActualNodeFor(semanticObject);
-		if (node != null) {
+		if (node != null && structuralFeature != null) {
 			return findNodesForFeature(semanticObject, node, structuralFeature);
 		}
 		return Collections.emptyList();


### PR DESCRIPTION
This guard adds more safety, but the actual NPE reason is fixed by
   https://github.com/eclipse/xtext-xtend/pull/26

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>