### PR TITLE
[378980] Make line delimiter for Manifest configurable by CodeConfig

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.xtend
@@ -71,6 +71,8 @@ class XtextGenerator extends AbstractWorkflowComponent2 {
 	
 	@Inject XtextGeneratorNaming naming
 	
+	@Inject CodeConfig codeConfig
+	
 	new() {
 		new XtextStandaloneSetup().createInjectorAndDoEMFRegistration()
 	}
@@ -251,6 +253,7 @@ class XtextGenerator extends AbstractWorkflowComponent2 {
 		try {
 			in = metaInf.readBinaryFile(manifest.path)
 			val merge = new MergeableManifest(in, manifest.bundleName)
+			merge.lineDelimiter = codeConfig.lineDelimiter
 			merge.addExportedPackages(manifest.exportedPackages)
 			merge.addRequiredBundles(manifest.requiredBundles)
 			merge.addImportedPackages(manifest.importedPackages)

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/ManifestAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/ManifestAccess.xtend
@@ -17,6 +17,7 @@ import org.eclipse.xtext.util.MergeableManifest
 import org.eclipse.xtext.util.internal.Log
 import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent
 import com.google.inject.Injector
+import org.eclipse.xtext.util.Strings
 
 @Log
 @Accessors
@@ -37,6 +38,8 @@ class ManifestAccess extends TextFileAccess implements IGuiceAwareGeneratorCompo
 	val Set<String> importedPackages = newHashSet
 	
 	TypeReference activator
+	
+	String lineDelimiter = Strings.newLine();
 	
 	new() {
 		path = 'MANIFEST.MF'
@@ -122,9 +125,10 @@ class ManifestAccess extends TextFileAccess implements IGuiceAwareGeneratorCompo
 	
 	override void writeTo(IFileSystemAccess2 fileSystemAccess) {
 		if (fileSystemAccess != null) {
-			val contentToWrite = MergeableManifest.make512Safe(new StringBuffer(content))
+			val contentToWrite = MergeableManifest.make512Safe(new StringBuffer(content), lineDelimiter)
 			// make sure all the constraints for the manifest are respected
 			val mergableManifest = new MergeableManifest(new ByteArrayInputStream(contentToWrite.getBytes("UTF-8")))
+			mergableManifest.lineDelimiter = lineDelimiter
 			var bout = new ByteArrayOutputStream()
 			mergableManifest.write(bout)
 			fileSystemAccess.generateFile(path, new ByteArrayInputStream(bout.toByteArray))

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/XtextProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/XtextProjectConfig.xtend
@@ -9,7 +9,9 @@ package org.eclipse.xtext.xtext.generator.model.project
 
 import com.google.inject.Injector
 import java.util.List
+import javax.inject.Inject
 import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtext.xtext.generator.Issues
 import org.eclipse.xtext.xtext.generator.model.ManifestAccess
 import org.eclipse.xtext.xtext.generator.model.PluginXmlAccess
@@ -27,6 +29,8 @@ class XtextProjectConfig implements IXtextProjectConfig {
 	BundleProjectConfig eclipsePluginTest = new BundleProjectConfig
 	SubProjectConfig ideaPlugin = new SubProjectConfig
 	WebProjectConfig web = new WebProjectConfig
+	
+	@Inject CodeConfig codeConfig
 	
 	def void checkConfiguration(Issues issues) {
 		enabledProjects.forEach[checkConfiguration(issues)]
@@ -74,7 +78,7 @@ class XtextProjectConfig implements IXtextProjectConfig {
 	}
 	
 	protected def newManifestAccess() {
-		new ManifestAccess
+		new ManifestAccess => [lineDelimiter = codeConfig.lineDelimiter]
 	}
 	
 	protected def newPluginXmlAccess() {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGenerator.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGenerator.java
@@ -112,6 +112,9 @@ public class XtextGenerator extends AbstractWorkflowComponent2 {
   @Inject
   private XtextGeneratorNaming naming;
   
+  @Inject
+  private CodeConfig codeConfig;
+  
   public XtextGenerator() {
     XtextStandaloneSetup _xtextStandaloneSetup = new XtextStandaloneSetup();
     _xtextStandaloneSetup.createInjectorAndDoEMFRegistration();
@@ -427,6 +430,8 @@ public class XtextGenerator extends AbstractWorkflowComponent2 {
       in = _readBinaryFile;
       String _bundleName = manifest.getBundleName();
       final MergeableManifest merge = new MergeableManifest(in, _bundleName);
+      String _lineDelimiter = this.codeConfig.getLineDelimiter();
+      merge.setLineDelimiter(_lineDelimiter);
       Set<String> _exportedPackages = manifest.getExportedPackages();
       merge.addExportedPackages(_exportedPackages);
       Set<String> _requiredBundles = manifest.getRequiredBundles();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/ManifestAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/ManifestAccess.java
@@ -19,6 +19,7 @@ import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.generator.IFileSystemAccess2;
 import org.eclipse.xtext.util.MergeableManifest;
+import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.util.internal.Log;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Exceptions;
@@ -49,6 +50,8 @@ public class ManifestAccess extends TextFileAccess implements IGuiceAwareGenerat
   private final Set<String> importedPackages = CollectionLiterals.<String>newHashSet();
   
   private TypeReference activator;
+  
+  private String lineDelimiter = Strings.newLine();
   
   public ManifestAccess() {
     this.setPath("MANIFEST.MF");
@@ -251,10 +254,11 @@ public class ManifestAccess extends TextFileAccess implements IGuiceAwareGenerat
       if (_notEquals) {
         CharSequence _content = this.getContent();
         StringBuffer _stringBuffer = new StringBuffer(_content);
-        final String contentToWrite = MergeableManifest.make512Safe(_stringBuffer);
+        final String contentToWrite = MergeableManifest.make512Safe(_stringBuffer, this.lineDelimiter);
         byte[] _bytes = contentToWrite.getBytes("UTF-8");
         ByteArrayInputStream _byteArrayInputStream = new ByteArrayInputStream(_bytes);
         final MergeableManifest mergableManifest = new MergeableManifest(_byteArrayInputStream);
+        mergableManifest.setLineDelimiter(this.lineDelimiter);
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         mergableManifest.write(bout);
         String _path = this.getPath();
@@ -332,5 +336,14 @@ public class ManifestAccess extends TextFileAccess implements IGuiceAwareGenerat
   
   public void setActivator(final TypeReference activator) {
     this.activator = activator;
+  }
+  
+  @Pure
+  public String getLineDelimiter() {
+    return this.lineDelimiter;
+  }
+  
+  public void setLineDelimiter(final String lineDelimiter) {
+    this.lineDelimiter = lineDelimiter;
   }
 }

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/XtextProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/XtextProjectConfig.java
@@ -13,11 +13,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
+import javax.inject.Inject;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.Issues;
 import org.eclipse.xtext.xtext.generator.model.ManifestAccess;
 import org.eclipse.xtext.xtext.generator.model.PluginXmlAccess;
@@ -47,6 +51,9 @@ public class XtextProjectConfig implements IXtextProjectConfig {
   private SubProjectConfig ideaPlugin = new SubProjectConfig();
   
   private WebProjectConfig web = new WebProjectConfig();
+  
+  @Inject
+  private CodeConfig codeConfig;
   
   public void checkConfiguration(final Issues issues) {
     List<? extends SubProjectConfig> _enabledProjects = this.getEnabledProjects();
@@ -116,7 +123,12 @@ public class XtextProjectConfig implements IXtextProjectConfig {
   }
   
   protected ManifestAccess newManifestAccess() {
-    return new ManifestAccess();
+    ManifestAccess _manifestAccess = new ManifestAccess();
+    final Procedure1<ManifestAccess> _function = (ManifestAccess it) -> {
+      String _lineDelimiter = this.codeConfig.getLineDelimiter();
+      it.setLineDelimiter(_lineDelimiter);
+    };
+    return ObjectExtensions.<ManifestAccess>operator_doubleArrow(_manifestAccess, _function);
   }
   
   protected PluginXmlAccess newPluginXmlAccess() {
@@ -188,5 +200,14 @@ public class XtextProjectConfig implements IXtextProjectConfig {
   
   public void setWeb(final WebProjectConfig web) {
     this.web = web;
+  }
+  
+  @Pure
+  public CodeConfig getCodeConfig() {
+    return this.codeConfig;
+  }
+  
+  public void setCodeConfig(final CodeConfig codeConfig) {
+    this.codeConfig = codeConfig;
   }
 }


### PR DESCRIPTION
Line delimiter is determined by CodeConfig and reached into MergeableManifest.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>