### PR TITLE
fixed eclipse/xtext-eclipse#100 serializer/performance fix regression

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/serializer/sequencer/EmitterNodeUtil.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/serializer/sequencer/EmitterNodeUtil.java
@@ -27,9 +27,10 @@ public class EmitterNodeUtil {
 	public static List<INode> collectEmitterNodes(INode from, INode to) {
 		List<INode> actual = collectEmitterNodesInternal(from, to);
 		// helpful code to test this implementation
-		List<INode> expected = Lists.newArrayList(new EmitterNodeIterator(from, to, false, false));
-		if (!expected.equals(actual))
-			throw new IllegalStateException();
+		// List<INode> expected = Lists.newArrayList(new
+		// EmitterNodeIterator(from, to, false, false));
+		// if (!expected.equals(actual))
+		// throw new IllegalStateException();
 		return actual;
 	}
 


### PR DESCRIPTION
This disables a check with a legacy impl. 
The check should never be active at runtime.
Unfortunately, the legacy impl has a bug when a node's parent is null.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>