### PR TITLE
[xtext.xtext.generator] moved of a generated comment in 'AbstractAntlrGrammarGenerator'

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGrammarGenerator.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGrammarGenerator.xtend
@@ -94,8 +94,6 @@ abstract class AbstractAntlrGrammarGenerator {
 		«compileTokens(options)»
 		«compileLexerHeader(options)»
 		«compileKeywordRules(options)»
-		
-		// Rules duplicated to allow inter-rule references
 		«compileTerminalRules(options)»
 	'''
 	
@@ -231,6 +229,10 @@ abstract class AbstractAntlrGrammarGenerator {
 	}
 	
 	protected def compileTerminalRules(Grammar it, AntlrOptions options) '''
+		«IF options.isBacktrackLexer»
+
+			// Rules duplicated to allow inter-rule references
+		«ENDIF»
 		«FOR rule:allTerminalRules»
 			
 			«rule.compileRule(it, options)»

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGrammarGenerator.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGrammarGenerator.java
@@ -184,9 +184,6 @@ public abstract class AbstractAntlrGrammarGenerator {
     CharSequence _compileKeywordRules = this.compileKeywordRules(it, options);
     _builder.append(_compileKeywordRules, "");
     _builder.newLineIfNotEmpty();
-    _builder.newLine();
-    _builder.append("// Rules duplicated to allow inter-rule references");
-    _builder.newLine();
     CharSequence _compileTerminalRules = this.compileTerminalRules(it, options);
     _builder.append(_compileTerminalRules, "");
     _builder.newLineIfNotEmpty();
@@ -533,6 +530,14 @@ public abstract class AbstractAntlrGrammarGenerator {
   
   protected CharSequence compileTerminalRules(final Grammar it, final AntlrOptions options) {
     StringConcatenation _builder = new StringConcatenation();
+    {
+      boolean _isBacktrackLexer = options.isBacktrackLexer();
+      if (_isBacktrackLexer) {
+        _builder.newLine();
+        _builder.append("// Rules duplicated to allow inter-rule references");
+        _builder.newLine();
+      }
+    }
     {
       List<TerminalRule> _allTerminalRules = GrammarUtil.allTerminalRules(it);
       for(final TerminalRule rule : _allTerminalRules) {


### PR DESCRIPTION
The location/condition of generating that comment was simply wrong,
should now be in line with the former template in ['ParameterizedLexerGrammar.xpt'](https://github.com/eclipse/xtext-extras/blob/master/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/ex/common/ParameterizedLexerGrammar.xpt) of the old 'org.eclipse.xtext.generator' project.

Signed-off-by: Christian Schneider christian.schneider@typefox.io
