### PR TITLE
[#170] [Formatter2] Typo in the AbstractEObjectRegion class

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/AbstractEObjectRegion.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/AbstractEObjectRegion.java
@@ -27,7 +27,7 @@ public abstract class AbstractEObjectRegion extends AbstractTextSegment implemen
 	private EObject grammarElement;
 	private IHiddenRegion nextHidden;
 	private IHiddenRegion previousHidden;
-	private EObject semantcElement;
+	private EObject semanticElement;
 	private final List<ISemanticRegion> semanticRegions = Lists.newArrayList();
 
 	public AbstractEObjectRegion(AbstractRegionAccess access) {
@@ -76,7 +76,7 @@ public abstract class AbstractEObjectRegion extends AbstractTextSegment implemen
 
 	@Override
 	public EObject getSemanticElement() {
-		return semantcElement;
+		return semanticElement;
 	}
 
 	@Override
@@ -128,8 +128,8 @@ public abstract class AbstractEObjectRegion extends AbstractTextSegment implemen
 		this.previousHidden = leading;
 	}
 
-	protected void setSemantcElement(EObject semantcElement) {
-		this.semantcElement = semantcElement;
+	protected void setSemanticElement(EObject semanticElement) {
+		this.semanticElement = semanticElement;
 	}
 
 	protected void setTrailingHiddenRegion(IHiddenRegion trailing) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/NodeModelBasedRegionAccessBuilder.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/NodeModelBasedRegionAccessBuilder.java
@@ -190,13 +190,13 @@ public class NodeModelBasedRegionAccessBuilder {
 		}
 		if (tokens.getSemanticElement() == null) {
 			if (node.getParent() == null) {
-				tokens.setSemantcElement(resource.getContents().get(0));
+				tokens.setSemanticElement(resource.getContents().get(0));
 				EObject element = node.getGrammarElement();
 				if (element instanceof Action)
 					element = ((ICompositeNode) node).getFirstChild().getGrammarElement();
 				tokens.setGrammarElement(element);
 			} else if (node.hasDirectSemanticElement()) {
-				tokens.setSemantcElement(node.getSemanticElement());
+				tokens.setSemanticElement(node.getSemanticElement());
 				tokens.setGrammarElement(findGrammarElement(node, tokens.getSemanticElement()));
 			}
 		}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/StringEObjectRegion.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/StringEObjectRegion.java
@@ -17,6 +17,6 @@ public class StringEObjectRegion extends AbstractEObjectRegion {
 	public StringEObjectRegion(StringBasedRegionAccess access, EObject grammarElement, EObject semanticElement) {
 		super(access);
 		this.setGrammarElement(grammarElement);
-		this.setSemantcElement(semanticElement);
+		this.setSemanticElement(semanticElement);
 	}
 }


### PR DESCRIPTION
[#170] [Formatter2] Typo in the AbstractEObjectRegion class

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>