### PR TITLE
[eclipse/xtext/#1088] Add xtextBuilder command as first build command

### DIFF
--- a/gradle/java-compiler-settings.gradle
+++ b/gradle/java-compiler-settings.gradle
@@ -54,6 +54,6 @@ eclipse {
 
 	project {
 		natures 'org.eclipse.xtext.ui.shared.xtextNature'
-		buildCommand 'org.eclipse.xtext.ui.shared.xtextBuilder'
+		buildCommands.add(0,new org.gradle.plugins.ide.eclipse.model.BuildCommand('org.eclipse.xtext.ui.shared.xtextBuilder'))
 	}
 }


### PR DESCRIPTION
This should be the change that ensures that the xtextBuilder is added before javabuilder. But with the current Gradle/Buildship version the order is changed back afterwards.

This PR can be applied only after clarification of the cause.