### PR TITLE
[eclipse/xtext#1089] Replace (not)equal operators by triple (not)equals

### DIFF
--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/logging/LoggingTester.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/logging/LoggingTester.xtend
@@ -53,7 +53,7 @@ import org.junit.Assert
 
 		def assertNumberOfLogEntries(int number, Level level, String... messageParts) {
 			val passed = logEntries.filter [ log |
-				(level == null || log.level == level) && messageParts.forall[log.message.contains(it)]
+				(level === null || log.level == level) && messageParts.forall[log.message.contains(it)]
 			]
 			if (passed.size != number) {
 				Assert.fail(
@@ -65,7 +65,7 @@ import org.junit.Assert
 						«ELSE»
 							Expected «number» log entries
 						«ENDIF»
-						«IF level != null»
+						«IF level !== null»
 							with «level» level
 						«ENDIF»
 						containing the phrases «messageParts.join(", ")['"' + it + '"']»
@@ -107,7 +107,7 @@ import org.junit.Assert
 
 	private static def appenderHierarchy(Logger logger) {
 		val appenders = newArrayList
-		for (var Category current = logger; current != null; current = current.parent) {
+		for (var Category current = logger; current !== null; current = current.parent) {
 			appenders.addAll(Collections.<Appender>list(current.allAppenders))
 		}
 		appenders
@@ -118,7 +118,7 @@ import org.junit.Assert
 			appender.clearFilters
 			appender.addFilter(filter.getNext)
 		} else {
-			for (var current = appender.filter; current != null; current = current.getNext) {
+			for (var current = appender.filter; current !== null; current = current.getNext) {
 				if (current.getNext == filter) {
 					current.setNext(filter.getNext)
 					return

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/util/InMemoryURIHandler.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/util/InMemoryURIHandler.xtend
@@ -39,7 +39,7 @@ class InMemoryURIHandler implements URIHandler {
 		}
 
 		def InputStream createInputStream() {
-			if (contents == null || !exists) {
+			if (contents === null || !exists) {
 				throw new IOException("File " + uri + " does not exist.")
 			}
 			return new ByteArrayInputStream(contents)
@@ -83,7 +83,7 @@ class InMemoryURIHandler implements URIHandler {
 
 	protected def getInMemoryFile(URI uri) {
 		var result = files.get(uri)
-		if (result == null) {
+		if (result === null) {
 			result = new InMemFile(uri)
 			files.put(uri, result)
 		}

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/logging/LoggingTester.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/logging/LoggingTester.java
@@ -66,7 +66,7 @@ public class LoggingTester {
     
     public void assertNumberOfLogEntries(final int number, final Level level, final String... messageParts) {
       final Function1<LoggingTester.LogEntry, Boolean> _function = (LoggingTester.LogEntry log) -> {
-        return Boolean.valueOf(((Objects.equal(level, null) || Objects.equal(log.level, level)) && IterableExtensions.<String>forall(((Iterable<String>)Conversions.doWrapArray(messageParts)), ((Function1<String, Boolean>) (String it) -> {
+        return Boolean.valueOf((((level == null) || Objects.equal(log.level, level)) && IterableExtensions.<String>forall(((Iterable<String>)Conversions.doWrapArray(messageParts)), ((Function1<String, Boolean>) (String it) -> {
           return Boolean.valueOf(log.message.contains(it));
         }))));
       };
@@ -92,8 +92,7 @@ public class LoggingTester {
           }
         }
         {
-          boolean _notEquals_1 = (!Objects.equal(level, null));
-          if (_notEquals_1) {
+          if ((level != null)) {
             _builder.append("with ");
             _builder.append(level, "");
             _builder.append(" level");
@@ -378,7 +377,7 @@ public class LoggingTester {
     ArrayList<Appender> _xblockexpression = null;
     {
       final ArrayList<Appender> appenders = CollectionLiterals.<Appender>newArrayList();
-      for (Category current = logger; (!Objects.equal(current, null)); current = current.getParent()) {
+      for (Category current = logger; (current != null); current = current.getParent()) {
         Enumeration _allAppenders = current.getAllAppenders();
         ArrayList<Appender> _list = Collections.<Appender>list(_allAppenders);
         appenders.addAll(_list);
@@ -396,7 +395,7 @@ public class LoggingTester {
       Filter _next = filter.getNext();
       appender.addFilter(_next);
     } else {
-      for (Filter current = appender.getFilter(); (!Objects.equal(current, null)); current = current.getNext()) {
+      for (Filter current = appender.getFilter(); (current != null); current = current.getNext()) {
         Filter _next_1 = current.getNext();
         boolean _equals_1 = Objects.equal(_next_1, filter);
         if (_equals_1) {

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/util/InMemoryURIHandler.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/util/InMemoryURIHandler.java
@@ -50,7 +50,7 @@ public class InMemoryURIHandler implements URIHandler {
     
     public InputStream createInputStream() {
       try {
-        if ((Objects.equal(this.contents, null) || (!this.exists))) {
+        if (((this.contents == null) || (!this.exists))) {
           throw new IOException((("File " + this.uri) + " does not exist."));
         }
         return new ByteArrayInputStream(this.contents);
@@ -138,8 +138,7 @@ public class InMemoryURIHandler implements URIHandler {
   
   protected InMemoryURIHandler.InMemFile getInMemoryFile(final URI uri) {
     InMemoryURIHandler.InMemFile result = this.files.get(uri);
-    boolean _equals = Objects.equal(result, null);
-    if (_equals) {
+    if ((result == null)) {
       InMemoryURIHandler.InMemFile _inMemFile = new InMemoryURIHandler.InMemFile(uri);
       result = _inMemFile;
       this.files.put(uri, result);

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/trace/TraceRegionMergerTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/trace/TraceRegionMergerTest.xtend
@@ -371,7 +371,7 @@ class TraceRegionMergerTest {
 		
 		def AbstractTraceRegion region(int offset, int length, int startLine, int endLine, (TraceBuilder)=>void init) {
 			val root = new TraceRegion(offset, length, startLine, endLine, true, 0,0,0,0, root, uri)
-			if (init != null) {
+			if (init !== null) {
 				val child = new TraceBuilder(testBuilder, uri, root)
 				init.apply(child)
 			}
@@ -408,7 +408,7 @@ class TraceRegionMergerTest {
 			for(uri: uris) {
 				assertTrue('Missing ' + uri, associatedLocations.contains(new SourceRelativeURI(URI.createURI(uri))))
 			}
-			if(init == null) {
+			if(init === null) {
 				assertTrue(head.nestedRegions.empty)
 			} else {
 				val child = new AssertBuilder(testBuilder, newLinkedList(head.nestedRegions))

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/generator/trace/TraceRegionMergerTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/generator/trace/TraceRegionMergerTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.generator.trace;
 
-import com.google.common.base.Objects;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -91,8 +90,7 @@ public class TraceRegionMergerTest {
       TraceRegion _xblockexpression = null;
       {
         final TraceRegion root = new TraceRegion(offset, length, startLine, endLine, true, 0, 0, 0, 0, this.root, this.uri);
-        boolean _notEquals = (!Objects.equal(init, null));
-        if (_notEquals) {
+        if ((init != null)) {
           final TraceRegionMergerTest.TraceBuilder child = new TraceRegionMergerTest.TraceBuilder(this.testBuilder, this.uri, root);
           init.apply(child);
         }
@@ -159,8 +157,7 @@ public class TraceRegionMergerTest {
           boolean _contains = associatedLocations.contains(_sourceRelativeURI);
           Assert.assertTrue(("Missing " + uri), _contains);
         }
-        boolean _equals = Objects.equal(init, null);
-        if (_equals) {
+        if ((init == null)) {
           List<AbstractTraceRegion> _nestedRegions = head.getNestedRegions();
           boolean _isEmpty = _nestedRegions.isEmpty();
           Assert.assertTrue(_isEmpty);

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/XtextVersion.xtend
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/XtextVersion.xtend
@@ -72,7 +72,7 @@ class XtextVersion {
 		} catch (Exception e) {
 			return null;
 		} finally {
-			if (is != null) {
+			if (is !== null) {
 				try {
 					is.close()
 				} catch (IOException e) {

--- a/org.eclipse.xtext.util/xtend-gen/org/eclipse/xtext/util/XtextVersion.java
+++ b/org.eclipse.xtext.util/xtend-gen/org/eclipse/xtext/util/XtextVersion.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.util;
 
-import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -107,8 +106,7 @@ public class XtextVersion {
         throw Exceptions.sneakyThrow(_t);
       }
     } finally {
-      boolean _notEquals = (!Objects.equal(is, null));
-      if (_notEquals) {
+      if ((is != null)) {
         try {
           is.close();
         } catch (final Throwable _t_1) {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/CodeConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/CodeConfig.xtend
@@ -78,7 +78,7 @@ class CodeConfig implements IGuiceAwareGeneratorComponent {
 			lineDelimiter = '\n'
 		
 		var fileHeader = fileHeaderTemplate
-		if (fileHeader != null) {
+		if (fileHeader !== null) {
 			if (fileHeader.contains(FILE_HEADER_VAR_TIME)) {
 				val dateFormat = new SimpleDateFormat('HH:mm:ss')
 				val time = dateFormat.format(new Date)
@@ -96,7 +96,7 @@ class CodeConfig implements IGuiceAwareGeneratorComponent {
 			}
 			if (fileHeader.contains(FILE_HEADER_VAR_USER)) {
 				val user = System.getProperty("user.name")
-				if (user != null) {
+				if (user !== null) {
 					fileHeader = fileHeader.replace(FILE_HEADER_VAR_USER, user)
 				}
 			}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.xtend
@@ -125,7 +125,7 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 	}
 	
 	override isGenerateXtendStubs() {
-		if (generateXtendStubs != null) generateXtendStubs.booleanValue else codeConfig.preferXtendStubs
+		if (generateXtendStubs !== null) generateXtendStubs.booleanValue else codeConfig.preferXtendStubs
 	}
 	
 	override initialize(Injector injector) {
@@ -146,7 +146,7 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 			}
 			EcoreUtil.resolveAll(resourceSet)
 		}
-		if (getGrammarUri == null) {
+		if (getGrammarUri === null) {
 			throw new IllegalStateException("No grammarUri or language name given")
 		}
 		val resource = resourceSet.getResource(URI.createURI(getGrammarUri), true) as XtextResource
@@ -186,9 +186,9 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 
 	private def void index(Resource resource, URI uri, ResourceDescriptionsData index) {
 		val serviceProvider = IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(uri)
-		if (serviceProvider != null) {
+		if (serviceProvider !== null) {
 			val resourceDescription = serviceProvider.resourceDescriptionManager.getResourceDescription(resource)
-			if (resourceDescription != null) {
+			if (resourceDescription !== null) {
 				index.addDescription(uri, resourceDescription)
 			}
 		}
@@ -203,7 +203,7 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 				override add(Diagnostic diagnostic) {
 					if (diagnostic.severity == Diagnostic.ERROR) {
 						val grammarName = "Validation Error in " + grammar.name + ": "
-						if (diagnostic.exception == null)
+						if (diagnostic.exception === null)
 							throw new IllegalStateException(grammarName + diagnostic.message)
 						else
 							throw new IllegalStateException(grammarName + diagnostic.message, diagnostic.exception)
@@ -234,7 +234,7 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 	}
 
 	protected def void validateReferencedMetamodel(ReferencedMetamodel ref) {
-		if (ref.EPackage != null && !ref.EPackage.eIsProxy) {
+		if (ref.EPackage !== null && !ref.EPackage.eIsProxy) {
 			return
 		}
 		val eref = XtextPackage.Literals.ABSTRACT_METAMODEL_DECLARATION__EPACKAGE

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorStandaloneSetup.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorStandaloneSetup.xtend
@@ -41,6 +41,6 @@ class XtextGeneratorStandaloneSetup implements IGuiceAwareGeneratorComponent {
 	}
 
 	private def getProjectMappings() {
-		projectConfig.enabledProjects.filter[name != null && root != null].map[name -> root.path]
+		projectConfig.enabledProjects.filter[name !== null && root !== null].map[name -> root.path]
 	}
 }	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
@@ -215,7 +215,7 @@ class XtextGeneratorTemplates {
 				}
 				
 				public void configureFileExtensions(«Binder» binder) {
-					if (properties == null || properties.getProperty(Constants.FILE_EXTENSIONS) == null)
+					if (properties === null || properties.getProperty(Constants.FILE_EXTENSIONS) === null)
 						binder.bind(String.class).annotatedWith(«Names».named(«Constants».FILE_EXTENSIONS)).toInstance("«langConfig.fileExtensions.join(',')»");
 				}
 				
@@ -558,7 +558,7 @@ class XtextGeneratorTemplates {
 				public «Injector» getInjector(String language) {
 					synchronized (injectors) {
 						«Injector» injector = injectors.get(language);
-						if (injector == null) {
+						if (injector === null) {
 							injectors.put(language, injector = createInjector(language));
 						}
 						return injector;

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.xtend
@@ -375,7 +375,7 @@ class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
 		}
 		for (pack : generatedPackages) {
 			val genPackage = pack.getGenPackage(rs)
-			if (projectConfig.runtime.manifest !== null && modelPluginID == null) {
+			if (projectConfig.runtime.manifest !== null && modelPluginID === null) {
 				projectConfig.runtime.manifest.exportedPackages.addAll(
 					genPackage.interfacePackageName,
 					genPackage.classPackageName,
@@ -433,7 +433,7 @@ class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
 		val result = <String, EPackage>newHashMap
 		for (nsURI : packageNsURIs) {
 			val resource = getGenModelResource(null, nsURI, resourceSet)
-			if (resource != null) {
+			if (resource !== null) {
 				val loadedGenModel = resource.contents.filter(GenModel).head
 				if (loadedGenModel !== null) {
 					val genPackage = findGenPackageByNsURI(loadedGenModel, nsURI)
@@ -672,7 +672,7 @@ class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
 	protected def void doGenerate(GenModel genModel) {
 		val generator = new Generator {
 			override getJControlModel() {
-				if (jControlModel == null) {
+				if (jControlModel === null) {
 					jControlModel = new JControlModel
 					jControlModel.initialize(null, options.mergeRulesURI)
 				}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.xtend
@@ -127,7 +127,7 @@ import org.eclipse.xtext.util.internal.Log
 		}
 		for (action : grammar.containedActions) {
 			val featureName = action.feature
-			if (featureName != null) {
+			if (featureName !== null) {
 				val type = action.type.classifier
 				if (type instanceof EClass) {
 					val feature = type.getEStructuralFeature(featureName)
@@ -152,7 +152,7 @@ import org.eclipse.xtext.util.internal.Log
 
 	protected def TypeReference getStubSuperClass() {
 		val superGrammar = language.grammar.nonTerminalsSuperGrammar
-		if (superGrammar != null)
+		if (superGrammar !== null)
 			return superGrammar.formatter2Stub
 		else
 			return AbstractFormatter2.typeRef

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.xtend
@@ -117,7 +117,7 @@ class GrammarAccessExtensions {
 
 	private def String toJavaIdentifierSegment(String text, boolean isFirst, boolean uppercaseFirst) {
 		val special = SPECIAL_CHARS.get(text);
-		if (special != null) {
+		if (special !== null) {
 			return if (uppercaseFirst) special.toFirstUpper else special
 		}
 		
@@ -128,7 +128,7 @@ class GrammarAccessExtensions {
 		val builder = new StringBuilder
 		for (c : text.toCharArray) {
 			val n = getUnicodeName(c)
-			if (n != null)
+			if (n !== null)
 				builder.append(n + ' ')
 		}
 		return toJavaIdentifierSegmentInt(builder.toString.toLowerCase.trim, isFirst, true)
@@ -542,7 +542,7 @@ class GrammarAccessExtensions {
 
 	def toStringLiteral(AbstractElement it) {
 		switch it {
-			RuleCall case rule != null: qualifiedNameAsString
+			RuleCall case rule !== null: qualifiedNameAsString
 			Keyword: '''"«value.toStringInAntlrAction»"'''
 			default:
 				"null"
@@ -552,7 +552,7 @@ class GrammarAccessExtensions {
 	private def ISerializer getSerializer() {
 		val delimiter = codeConfig.lineDelimiter
 		var result = xtextSerializerByLineDelimiter.get(delimiter)
-		if (result != null) {
+		if (result !== null) {
 			return result
 		}
 		val injector = Guice.createInjector(new LineSeparatorModule[delimiter])

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessFragment2.xtend
@@ -210,7 +210,7 @@ class GrammarAccessFragment2 extends AbstractXtextGeneratorFragment {
 				
 				protected «Grammar» internalFindGrammar(«GrammarProvider» grammarProvider) {
 					«Grammar» grammar = grammarProvider.getGrammar(this);
-					while (grammar != null) {
+					while (grammar !== null) {
 						if ("«language.grammar.name»".equals(grammar.getName())) {
 							return grammar;
 						}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/idea/IdeaPluginGenerator.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/idea/IdeaPluginGenerator.xtend
@@ -670,7 +670,7 @@ class IdeaPluginGenerator extends AbstractStubGeneratingFragment {
 				@SuppressWarnings("rawtypes")
 				public «'com.intellij.psi.PsiElement'.typeRef» createElement(«'com.intellij.lang.ASTNode'.typeRef» node) {
 					Boolean hasSemanticElement = node.getUserData(«'org.eclipse.xtext.idea.nodemodel.IASTNodeAwareNodeModelBuilder'.typeRef».HAS_SEMANTIC_ELEMENT_KEY);
-					if (hasSemanticElement != null && hasSemanticElement) {
+					if (hasSemanticElement !== null && hasSemanticElement) {
 						«'com.intellij.psi.tree.IElementType'.typeRef» elementType = node.getElementType();
 						«FOR rule : EObjectRules»
 						if (elementType == elementTypeProvider.get«rule.grammarElementIdentifier»ElementType()) {
@@ -718,7 +718,7 @@ class IdeaPluginGenerator extends AbstractStubGeneratingFragment {
 		}
 		val classifier = type?.classifier
 		val feature = if(classifier instanceof EClass) classifier.getEStructuralFeature('name')
-		feature instanceof EAttribute && !feature.many && feature?.EType?.instanceClass != null && String.isAssignableFrom(feature.EType.instanceClass)
+		feature instanceof EAttribute && !feature.many && feature?.EType?.instanceClass !== null && String.isAssignableFrom(feature.EType.instanceClass)
 	}
 	
 	def compileAbstractCompletionContributor(Grammar grammar) {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.xtend
@@ -28,7 +28,7 @@ class Junit4Fragment2 extends AbstractStubGeneratingFragment {
 	}
 	
 	override generate() {
-		if (projectConfig.runtimeTest.manifest != null) {
+		if (projectConfig.runtimeTest.manifest !== null) {
 			projectConfig.runtimeTest.manifest => [
 				requiredBundles.addAll(
 					testingPackage,
@@ -37,7 +37,7 @@ class Junit4Fragment2 extends AbstractStubGeneratingFragment {
 				exportedPackages.add(grammar.runtimeTestBasePackage+";x-internal=true")
 			]
 		}
-		if (projectConfig.eclipsePluginTest.manifest != null) {
+		if (projectConfig.eclipsePluginTest.manifest !== null) {
 			projectConfig.eclipsePluginTest.manifest => [
 				requiredBundles.addAll(
 					testingPackage,
@@ -47,7 +47,7 @@ class Junit4Fragment2 extends AbstractStubGeneratingFragment {
 				exportedPackages.add(grammar.eclipsePluginTestBasePackage+";x-internal=true")
 			]
 		}
-		if (projectConfig.eclipsePlugin.manifest != null) {
+		if (projectConfig.eclipsePlugin.manifest !== null) {
 			projectConfig.eclipsePlugin.manifest.exportedPackages.add(eclipsePluginActivator.packageName)
 		}
 		
@@ -123,7 +123,7 @@ class Junit4Fragment2 extends AbstractStubGeneratingFragment {
 			
 				@Override
 				public «Injector» getInjector() {
-					if (injector == null) {
+					if (injector === null) {
 						stateBeforeInjectorCreation = «globalRegistries».makeCopyOfGlobalState();
 						this.injector = internalCreateInjector();
 						stateAfterInjectorCreation = «globalRegistries».makeCopyOfGlobalState();

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/ManifestAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/ManifestAccess.xtend
@@ -78,7 +78,7 @@ class ManifestAccess extends TextFileAccess implements IGuiceAwareGeneratorCompo
 		}
 		this.exportedPackages.addAll(other.exportedPackages)
 		this.requiredBundles.addAll(other.requiredBundles)
-		if (symbolicName != null) {
+		if (symbolicName !== null) {
 			this.requiredBundles.remove(effectiveSymbolicName)
 		}
 		this.importedPackages.addAll(other.importedPackages)
@@ -124,7 +124,7 @@ class ManifestAccess extends TextFileAccess implements IGuiceAwareGeneratorCompo
 	'''
 	
 	override void writeTo(IFileSystemAccess2 fileSystemAccess) {
-		if (fileSystemAccess != null) {
+		if (fileSystemAccess !== null) {
 			val contentToWrite = MergeableManifest.make512Safe(new StringBuffer(content), lineDelimiter)
 			// make sure all the constraints for the manifest are respected
 			val mergableManifest = new MergeableManifest(new ByteArrayInputStream(contentToWrite.getBytes("UTF-8")))

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TextFileAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TextFileAccess.xtend
@@ -30,7 +30,7 @@ class TextFileAccess {
 	}
 
 	def void writeTo(IFileSystemAccess2 fileSystemAccess) {
-		if (fileSystemAccess != null) {
+		if (fileSystemAccess !== null) {
 			fileSystemAccess.generateFile(path, content)
 		}
 	}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGrammarGenerator.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGrammarGenerator.xtend
@@ -103,7 +103,7 @@ abstract class AbstractAntlrGrammarGenerator {
 			«IF !isCombinedGrammar»
 				tokenVocab=«grammarNaming.getLexerGrammar(it).simpleName»;
 			«ENDIF»
-			«IF grammarNaming.getInternalParserSuperClass(it) != null»
+			«IF grammarNaming.getInternalParserSuperClass(it) !== null»
 				superClass=«grammarNaming.getInternalParserSuperClass(it).simpleName»;
 			«ENDIF»
 			«IF isParserBackTracking(options) || options.memoize || options.k >= 0»
@@ -447,7 +447,7 @@ abstract class AbstractAntlrGrammarGenerator {
 	}
 	
 	def dispatch mustBeParenthesized(Group it) {
-		predicated() || firstSetPredicated || cardinality != null
+		predicated() || firstSetPredicated || cardinality !== null
 	}
 	
 	def dispatch boolean mustBeParenthesized(Assignment it) {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGrammarWithActionsGenerator.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGrammarWithActionsGenerator.xtend
@@ -229,11 +229,11 @@ abstract class AbstractAntlrGrammarWithActionsGenerator extends AbstractAntlrGra
 	}
 	
 	dispatch def mustBeParenthesized(Keyword it) {
-		predicated() || firstSetPredicated || cardinality != null
+		predicated() || firstSetPredicated || cardinality !== null
 	}
 
 	dispatch def mustBeParenthesized(RuleCall it) {
-		predicated() || firstSetPredicated || cardinality != null
+		predicated() || firstSetPredicated || cardinality !== null
 	}
 	
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrContentAssistGrammarGenerator.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrContentAssistGrammarGenerator.xtend
@@ -64,7 +64,7 @@ class AntlrContentAssistGrammarGenerator extends AbstractAntlrGrammarWithActions
 					return tokenName;
 				«ELSE»
 					String result = tokenNameToValue.get(tokenName);
-					if (result == null)
+					if (result === null)
 						result = tokenName;
 					return result;
 				«ENDIF»

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrGrammarGenerator.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrGrammarGenerator.xtend
@@ -212,7 +212,7 @@ class AntlrGrammarGenerator extends AbstractAntlrGrammarWithActionsGenerator {
 			}
 			«ENDIF»
 			{
-				$current = forceCreateModelElement«IF feature != null»And«setOrAdd.toFirstUpper»«ENDIF»(
+				$current = forceCreateModelElement«IF feature !== null»And«setOrAdd.toFirstUpper»«ENDIF»(
 					grammarAccess.«originalElement.grammarElementAccess»,
 					$current);
 			}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/XtextAntlrGeneratorFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/XtextAntlrGeneratorFragment2.xtend
@@ -95,7 +95,7 @@ class XtextAntlrGeneratorFragment2 extends AbstractAntlrGeneratorFragment2 {
 		if (debugGrammar)
 			generateDebugGrammar()
 		generateProductionGrammar()
-		if (projectConfig.genericIde.srcGen != null) {
+		if (projectConfig.genericIde.srcGen !== null) {
 			generateContentAssistGrammar()
 			addIdeBindingsAndImports()
 		}
@@ -325,7 +325,7 @@ class XtextAntlrGeneratorFragment2 extends AbstractAntlrGeneratorFragment2 {
 				«ENDIF»
 				@Override
 				protected String getRuleName(«AbstractElement» element) {
-					if (nameMappings == null) {
+					if (nameMappings === null) {
 						nameMappings = new «HashMap»<«AbstractElement», String>() {
 							private static final long serialVersionUID = 1L;
 							{

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/resourceFactory/ResourceFactoryFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/resourceFactory/ResourceFactoryFragment2.xtend
@@ -39,7 +39,7 @@ class ResourceFactoryFragment2 extends AbstractXtextGeneratorFragment {
 			«ENDFOR»
 		''')
 
-		if (projectConfig.eclipsePlugin?.pluginXml != null) {
+		if (projectConfig.eclipsePlugin?.pluginXml !== null) {
 			projectConfig.eclipsePlugin.pluginXml.entries += '''
 				<!-- adding resource factories -->
 				«FOR fileExtension : language.fileExtensions»

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/NamedSerializationContextProvider.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/NamedSerializationContextProvider.xtend
@@ -59,7 +59,7 @@ class NamedSerializationContextProvider {
 					pr = GrammarUtil.containingParserRule(action)
 				}
 			}
-			if (pr != null) {
+			if (pr !== null) {
 				val i = rules.get(pr)
 				if (i < index) {
 					index = i

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.xtend
@@ -270,7 +270,7 @@ import static extension org.eclipse.xtext.xtext.generator.util.GenModelUtil2.*
 						«ENDFOR»
 						}
 				«ENDFOR»
-				if (errorAcceptor != null)
+				if (errorAcceptor !== null)
 					errorAcceptor.accept(diagnosticProvider.createInvalidContextOrTypeDiagnostic(semanticObject, context));
 			}
 		'''
@@ -402,7 +402,7 @@ import static extension org.eclipse.xtext.xtext.generator.util.GenModelUtil2.*
 			 */
 			protected void sequence_«c.simpleName»(«ISerializationContext» context, «c.type» semanticObject) {
 				«IF states !== null»
-					if (errorAcceptor != null) {
+					if (errorAcceptor !== null) {
 						«FOR s : states»
 							if (transientValues.isValueTransient(«cast»semanticObject, «s.feature.EContainingClass.EPackage».«s.feature.getFeatureLiteral(rs)») == «ITransientValueService.ValueTransient».YES)
 								errorAcceptor.accept(diagnosticProvider.createFeatureValueMissing(«cast»semanticObject, «s.feature.EContainingClass.EPackage».«s.feature.getFeatureLiteral(rs)»));
@@ -496,7 +496,7 @@ import static extension org.eclipse.xtext.xtext.generator.util.GenModelUtil2.*
 		if (c.isEObjectRuleCall)
 			return false
 		val ass = c.containingAssignment
-		return ass == null || ass.isBooleanAssignment
+		return ass === null || ass.isBooleanAssignment
 	}
 
 	private def String defaultValue(AbstractElement ele, Set<AbstractElement> visited) {
@@ -547,7 +547,7 @@ import static extension org.eclipse.xtext.xtext.generator.util.GenModelUtil2.*
 			 * «NodeModelUtils.getNode(rule).textWithoutComments.trim.replace('\n', '\n* ').replace('*/','*&#47;')»
 			 */
 			protected String «rule.unassignedCalledTokenRuleName»(«EObject» semanticObject, «RuleCall» ruleCall, «INode» node) {
-				if (node != null)
+				if (node !== null)
 					return getTokenText(node);
 				return "«Strings.convertToJavaString(rule.alternatives.defaultValue(newHashSet))»";
 			}
@@ -574,7 +574,7 @@ import static extension org.eclipse.xtext.xtext.generator.util.GenModelUtil2.*
 		fileAccessFactory.createTextFile(grammar.grammarConstraintsPath, '''
 			«FOR e : grammar.constraints.sortedCopy.values SEPARATOR '\n'»
 				«e.contexts.join(", ")»:
-					«IF e.value.body == null»
+					«IF e.value.body === null»
 						{«e.value.type?.name»};
 					«ELSE»
 						«e.value.body»;

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/compare/CompareFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/compare/CompareFragment2.xtend
@@ -38,7 +38,7 @@ class CompareFragment2 extends AbstractXtextGeneratorFragment {
 					new TypeReference("org.eclipse.xtext.ui.compare.DefaultViewerCreator")
 				).contributeTo(language.eclipsePluginGenModule);
 
-		if (projectConfig.eclipsePlugin?.pluginXml != null) {
+		if (projectConfig.eclipsePlugin?.pluginXml !== null) {
 			projectConfig.eclipsePlugin.pluginXml.entries += '''
 			<extension point="org.eclipse.compare.contentViewers">
 				<viewer id="«grammar.name».compare.contentViewers"

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.xtend
@@ -55,7 +55,7 @@ class ContentAssistFragment2 extends AbstractInheritingFragment {
 
 	def protected TypeReference getGenProposalProviderSuperClass(Grammar g) {
 		val superGrammar = g.usedGrammars.head
-		if(inheritImplementation && superGrammar != null)
+		if(inheritImplementation && superGrammar !== null)
 			superGrammar.proposalProviderClass
 		else getDefaultGenProposalProviderSuperClass
 	}
@@ -69,7 +69,7 @@ class ContentAssistFragment2 extends AbstractInheritingFragment {
 
 	override generate() {
 		
-		if (projectConfig.eclipsePlugin.manifest != null) {
+		if (projectConfig.eclipsePlugin.manifest !== null) {
 			projectConfig.eclipsePlugin.manifest.requiredBundles += "org.eclipse.xtext.ui"
 		}
 
@@ -84,11 +84,11 @@ class ContentAssistFragment2 extends AbstractInheritingFragment {
 			generateGenJavaProposalProvider
 		}
 
-		if (isGenerateStub && projectConfig.eclipsePlugin.src != null) {
+		if (isGenerateStub && projectConfig.eclipsePlugin.src !== null) {
 			if (generateXtendStub) {
 				generateXtendProposalProviderStub
 
-				if (projectConfig.eclipsePlugin.manifest != null) {
+				if (projectConfig.eclipsePlugin.manifest !== null) {
 					projectConfig.eclipsePlugin.manifest.requiredBundles += "org.eclipse.xtext.xbase.lib"
 					projectConfig.eclipsePlugin.manifest.requiredBundles += "org.eclipse.xtend.lib;resolution:=optional"
 				}
@@ -97,7 +97,7 @@ class ContentAssistFragment2 extends AbstractInheritingFragment {
 			}
 		}
 
-		if (projectConfig.eclipsePlugin.manifest != null) {
+		if (projectConfig.eclipsePlugin.manifest !== null) {
 			projectConfig.eclipsePlugin.manifest.exportedPackages += grammar.proposalProviderClass.packageName
 		}
 	}
@@ -280,7 +280,7 @@ class ContentAssistFragment2 extends AbstractInheritingFragment {
 	}
 
 	def getFQFeatureNamesToExclude(Grammar g) {
-		if (g.nonTerminalsSuperGrammar != null) {
+		if (g.nonTerminalsSuperGrammar !== null) {
 			val thisGrammarFqFeatureNames = g.computeFQFeatureNames.toSet
 			val superGrammarsFqFeatureNames = g.allUsedGrammars.map[
 				computeFQFeatureNames

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.xtend
@@ -83,7 +83,7 @@ class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
 	override generate() {
 		if (isGenerateStub || grammar.inheritsXbase) {
 
-			if (projectConfig.eclipsePlugin.manifest != null) {
+			if (projectConfig.eclipsePlugin.manifest !== null) {
 				projectConfig.eclipsePlugin.manifest.requiredBundles += "org.eclipse.xtext.ui"
 			}
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/outline/OutlineTreeProviderFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/outline/OutlineTreeProviderFragment2.xtend
@@ -33,7 +33,7 @@ class OutlineTreeProviderFragment2 extends AbstractStubGeneratingFragment {
 	}
 
 	override generate() {
-		if (projectConfig.eclipsePlugin.manifest != null) {
+		if (projectConfig.eclipsePlugin.manifest !== null) {
 			projectConfig.eclipsePlugin.manifest.requiredBundles += "org.eclipse.xtext.ui"
 		}
 		

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/outline/QuickOutlineFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/outline/QuickOutlineFragment2.xtend
@@ -22,11 +22,11 @@ class QuickOutlineFragment2 extends AbstractXtextGeneratorFragment {
 	extension XtextGeneratorNaming
 	
 	override generate() {
-		if (projectConfig.eclipsePlugin.manifest != null) {
+		if (projectConfig.eclipsePlugin.manifest !== null) {
 			projectConfig.eclipsePlugin.manifest.requiredBundles += "org.eclipse.xtext.ui"
 		}
 		
-		if (projectConfig.eclipsePlugin.pluginXml != null) {
+		if (projectConfig.eclipsePlugin.pluginXml !== null) {
 			projectConfig.eclipsePlugin.pluginXml.entries += '''
 				<!-- Quick Outline -->
 				<extension

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/projectWizard/SimpleProjectWizardFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/projectWizard/SimpleProjectWizardFragment2.xtend
@@ -54,7 +54,7 @@ class SimpleProjectWizardFragment2 extends AbstractXtextGeneratorFragment {
 			new TypeReference(projectCreatorClassName)
 		).contributeTo(language.eclipsePluginGenModule);
 
-		if (projectConfig.eclipsePlugin?.pluginXml != null) {
+		if (projectConfig.eclipsePlugin?.pluginXml !== null) {
 			projectConfig.eclipsePlugin.pluginXml.entries += '''
 				<extension
 					point="org.eclipse.ui.newWizards">

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.xtend
@@ -43,7 +43,7 @@ class QuickfixProviderFragment2 extends AbstractInheritingFragment {
 
 	def protected TypeReference getQuickfixProviderSuperClass(Grammar g) {
 		val superGrammar = g.getNonTerminalsSuperGrammar;
-		if (inheritImplementation && superGrammar != null) 
+		if (inheritImplementation && superGrammar !== null) 
 			superGrammar.quickfixProviderClass
 		else
 			defaultQuickfixProviderSuperClass

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/refactoring/RefactorElementNameFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/refactoring/RefactorElementNameFragment2.xtend
@@ -47,7 +47,7 @@ class RefactorElementNameFragment2 extends AbstractXtextGeneratorFragment {
 	}
 
 	override generate() {
-		if (projectConfig.eclipsePlugin?.manifest != null) {
+		if (projectConfig.eclipsePlugin?.manifest !== null) {
 			projectConfig.eclipsePlugin.manifest.requiredBundles += "org.eclipse.xtext.ui"
 		}
 
@@ -108,7 +108,7 @@ class RefactorElementNameFragment2 extends AbstractXtextGeneratorFragment {
 
 		bindings.contributeTo(language.eclipsePluginGenModule);
 		
-		if (projectConfig.eclipsePlugin?.pluginXml != null) {
+		if (projectConfig.eclipsePlugin?.pluginXml !== null) {
 			projectConfig.eclipsePlugin.pluginXml.entries += '''
 				<!-- Rename Refactoring -->
 				<extension point="org.eclipse.ui.handlers">

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/templates/CodetemplatesGeneratorFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/templates/CodetemplatesGeneratorFragment2.xtend
@@ -78,7 +78,7 @@ class CodetemplatesGeneratorFragment2 extends AbstractXtextGeneratorFragment {
 				
 				.contributeTo(language.eclipsePluginGenModule);
 		
-		if (projectConfig.genericIde?.srcGen != null) {
+		if (projectConfig.genericIde?.srcGen !== null) {
 			fileAccessFactory.createGeneratedJavaFile(grammar.partialContentAssistParserClass) => [
 				content = genPartialContentAssistParser
 				writeTo(projectConfig.genericIde.srcGen)
@@ -99,7 +99,7 @@ class CodetemplatesGeneratorFragment2 extends AbstractXtextGeneratorFragment {
 		
 			@Override
 			protected «Collection»<«followElementClass»> getFollowElements(«abstractInternalContentAssistParserClass» parser) {
-				if (rule == null || rule.eIsProxy())
+				if (rule === null || rule.eIsProxy())
 					return «Collections».emptyList();
 				«String» methodName = "entryRule" + rule.getName();
 				«PolymorphicDispatcher»<Collection<FollowElement>> dispatcher = 

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/CodeConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/CodeConfig.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator;
 
-import com.google.common.base.Objects;
 import com.google.inject.Injector;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
@@ -89,8 +88,7 @@ public class CodeConfig implements IGuiceAwareGeneratorComponent {
       this.lineDelimiter = "\n";
     }
     String fileHeader = this.fileHeaderTemplate;
-    boolean _notEquals = (!Objects.equal(fileHeader, null));
-    if (_notEquals) {
+    if ((fileHeader != null)) {
       boolean _contains = fileHeader.contains(CodeConfig.FILE_HEADER_VAR_TIME);
       if (_contains) {
         final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
@@ -118,8 +116,7 @@ public class CodeConfig implements IGuiceAwareGeneratorComponent {
       boolean _contains_3 = fileHeader.contains(CodeConfig.FILE_HEADER_VAR_USER);
       if (_contains_3) {
         final String user = System.getProperty("user.name");
-        boolean _notEquals_1 = (!Objects.equal(user, null));
-        if (_notEquals_1) {
+        if ((user != null)) {
           String _replace_3 = fileHeader.replace(CodeConfig.FILE_HEADER_VAR_USER, user);
           fileHeader = _replace_3;
         }

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.java
@@ -8,7 +8,6 @@
 package org.eclipse.xtext.xtext.generator;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
@@ -176,8 +175,7 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
   @Override
   public boolean isGenerateXtendStubs() {
     boolean _xifexpression = false;
-    boolean _notEquals = (!Objects.equal(this.generateXtendStubs, null));
-    if (_notEquals) {
+    if ((this.generateXtendStubs != null)) {
       _xifexpression = this.generateXtendStubs.booleanValue();
     } else {
       _xifexpression = this.codeConfig.isPreferXtendStubs();
@@ -240,8 +238,8 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
       EcoreUtil.resolveAll(this.resourceSet);
     }
     String _grammarUri = this.getGrammarUri();
-    boolean _equals = Objects.equal(_grammarUri, null);
-    if (_equals) {
+    boolean _tripleEquals = (_grammarUri == null);
+    if (_tripleEquals) {
       throw new IllegalStateException("No grammarUri or language name given");
     }
     String _grammarUri_1 = this.getGrammarUri();
@@ -310,12 +308,10 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
   
   private void index(final Resource resource, final org.eclipse.emf.common.util.URI uri, final ResourceDescriptionsData index) {
     final IResourceServiceProvider serviceProvider = IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(uri);
-    boolean _notEquals = (!Objects.equal(serviceProvider, null));
-    if (_notEquals) {
+    if ((serviceProvider != null)) {
       IResourceDescription.Manager _resourceDescriptionManager = serviceProvider.getResourceDescriptionManager();
       final IResourceDescription resourceDescription = _resourceDescriptionManager.getResourceDescription(resource);
-      boolean _notEquals_1 = (!Objects.equal(resourceDescription, null));
-      if (_notEquals_1) {
+      if ((resourceDescription != null)) {
         index.addDescription(uri, resourceDescription);
       }
     }
@@ -335,8 +331,8 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
             String _plus = ("Validation Error in " + _name);
             final String grammarName = (_plus + ": ");
             Throwable _exception = diagnostic.getException();
-            boolean _equals_1 = Objects.equal(_exception, null);
-            if (_equals_1) {
+            boolean _tripleEquals = (_exception == null);
+            if (_tripleEquals) {
               String _message = diagnostic.getMessage();
               String _plus_1 = (grammarName + _message);
               throw new IllegalStateException(_plus_1);
@@ -379,7 +375,7 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
   }
   
   protected void validateReferencedMetamodel(final ReferencedMetamodel ref) {
-    if (((!Objects.equal(ref.getEPackage(), null)) && (!ref.getEPackage().eIsProxy()))) {
+    if (((ref.getEPackage() != null) && (!ref.getEPackage().eIsProxy()))) {
       return;
     }
     final EReference eref = XtextPackage.Literals.ABSTRACT_METAMODEL_DECLARATION__EPACKAGE;

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorStandaloneSetup.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorStandaloneSetup.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import java.util.List;
@@ -67,7 +66,7 @@ public class XtextGeneratorStandaloneSetup implements IGuiceAwareGeneratorCompon
   private Iterable<Pair<String, String>> getProjectMappings() {
     List<? extends ISubProjectConfig> _enabledProjects = this.projectConfig.getEnabledProjects();
     final Function1<ISubProjectConfig, Boolean> _function = (ISubProjectConfig it) -> {
-      return Boolean.valueOf(((!Objects.equal(it.getName(), null)) && (!Objects.equal(it.getRoot(), null))));
+      return Boolean.valueOf(((it.getName() != null) && (it.getRoot() != null)));
     };
     Iterable<? extends ISubProjectConfig> _filter = IterableExtensions.filter(_enabledProjects, _function);
     final Function1<ISubProjectConfig, Pair<String, String>> _function_1 = (ISubProjectConfig it) -> {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
@@ -724,7 +724,7 @@ public class XtextGeneratorTemplates {
         _builder.append(" binder) {");
         _builder.newLineIfNotEmpty();
         _builder.append("\t\t");
-        _builder.append("if (properties == null || properties.getProperty(Constants.FILE_EXTENSIONS) == null)");
+        _builder.append("if (properties === null || properties.getProperty(Constants.FILE_EXTENSIONS) === null)");
         _builder.newLine();
         _builder.append("\t\t\t");
         _builder.append("binder.bind(String.class).annotatedWith(");
@@ -1790,7 +1790,7 @@ public class XtextGeneratorTemplates {
         _builder.append(" injector = injectors.get(language);");
         _builder.newLineIfNotEmpty();
         _builder.append("\t\t\t");
-        _builder.append("if (injector == null) {");
+        _builder.append("if (injector === null) {");
         _builder.newLine();
         _builder.append("\t\t\t\t");
         _builder.append("injectors.put(language, injector = createInjector(language));");

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.java
@@ -604,7 +604,7 @@ public class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
     for (final EPackage pack_1 : generatedPackages) {
       {
         final GenPackage genPackage = GenModelUtil2.getGenPackage(pack_1, rs);
-        if (((this.getProjectConfig().getRuntime().getManifest() != null) && Objects.equal(this.modelPluginID, null))) {
+        if (((this.getProjectConfig().getRuntime().getManifest() != null) && (this.modelPluginID == null))) {
           IXtextProjectConfig _projectConfig_4 = this.getProjectConfig();
           IRuntimeProjectConfig _runtime_4 = _projectConfig_4.getRuntime();
           ManifestAccess _manifest_2 = _runtime_4.getManifest();
@@ -715,8 +715,7 @@ public class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
     for (final String nsURI : packageNsURIs) {
       {
         final Resource resource = GenModelUtil2.getGenModelResource(null, nsURI, resourceSet);
-        boolean _notEquals = (!Objects.equal(resource, null));
-        if (_notEquals) {
+        if ((resource != null)) {
           EList<EObject> _contents = resource.getContents();
           Iterable<GenModel> _filter = Iterables.<GenModel>filter(_contents, GenModel.class);
           final GenModel loadedGenModel = IterableExtensions.<GenModel>head(_filter);
@@ -1103,8 +1102,7 @@ public class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
     final Generator generator = new Generator() {
       @Override
       public JControlModel getJControlModel() {
-        boolean _equals = Objects.equal(this.jControlModel, null);
-        if (_equals) {
+        if ((this.jControlModel == null)) {
           JControlModel _jControlModel = new JControlModel();
           this.jControlModel = _jControlModel;
           this.jControlModel.initialize(null, this.options.mergeRulesURI);

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.formatting;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
@@ -313,8 +312,7 @@ public class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
     for (final Action action : _containedActions) {
       {
         final String featureName = action.getFeature();
-        boolean _notEquals = (!Objects.equal(featureName, null));
-        if (_notEquals) {
+        if ((featureName != null)) {
           TypeRef _type = action.getType();
           final EClassifier type = _type.getClassifier();
           if ((type instanceof EClass)) {
@@ -345,8 +343,7 @@ public class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
     IXtextGeneratorLanguage _language = this.getLanguage();
     Grammar _grammar = _language.getGrammar();
     final Grammar superGrammar = GrammarUtil2.getNonTerminalsSuperGrammar(_grammar);
-    boolean _notEquals = (!Objects.equal(superGrammar, null));
-    if (_notEquals) {
+    if ((superGrammar != null)) {
       return this.getFormatter2Stub(superGrammar);
     } else {
       return TypeReference.typeRef(AbstractFormatter2.class);

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.java
@@ -176,8 +176,7 @@ public class GrammarAccessExtensions {
   
   private String toJavaIdentifierSegment(final String text, final boolean isFirst, final boolean uppercaseFirst) {
     final String special = GrammarAccessExtensions.SPECIAL_CHARS.get(text);
-    boolean _notEquals = (!Objects.equal(special, null));
-    if (_notEquals) {
+    if ((special != null)) {
       String _xifexpression = null;
       if (uppercaseFirst) {
         _xifexpression = StringExtensions.toFirstUpper(special);
@@ -197,8 +196,7 @@ public class GrammarAccessExtensions {
     for (final char c : _charArray) {
       {
         final String n = this.getUnicodeName(c);
-        boolean _notEquals_1 = (!Objects.equal(n, null));
-        if (_notEquals_1) {
+        if ((n != null)) {
           builder.append((n + " "));
         }
       }
@@ -917,8 +915,8 @@ public class GrammarAccessExtensions {
     boolean _matched = false;
     if (it instanceof RuleCall) {
       AbstractRule _rule = ((RuleCall)it).getRule();
-      boolean _notEquals = (!Objects.equal(_rule, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_rule != null);
+      if (_tripleNotEquals) {
         _matched=true;
         _switchResult = AntlrGrammarGenUtil.getQualifiedNameAsString(((RuleCall)it));
       }
@@ -944,8 +942,7 @@ public class GrammarAccessExtensions {
   private ISerializer getSerializer() {
     final String delimiter = this.codeConfig.getLineDelimiter();
     ISerializer result = this.xtextSerializerByLineDelimiter.get(delimiter);
-    boolean _notEquals = (!Objects.equal(result, null));
-    if (_notEquals) {
+    if ((result != null)) {
       return result;
     }
     final ILineSeparatorInformation _function = () -> {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessFragment2.java
@@ -472,7 +472,7 @@ public class GrammarAccessFragment2 extends AbstractXtextGeneratorFragment {
         _builder.append(" grammar = grammarProvider.getGrammar(this);");
         _builder.newLineIfNotEmpty();
         _builder.append("\t\t");
-        _builder.append("while (grammar != null) {");
+        _builder.append("while (grammar !== null) {");
         _builder.newLine();
         _builder.append("\t\t\t");
         _builder.append("if (\"");

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/idea/IdeaPluginGenerator.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/idea/IdeaPluginGenerator.java
@@ -2267,7 +2267,7 @@ public class IdeaPluginGenerator extends AbstractStubGeneratingFragment {
             _builder.newLineIfNotEmpty();
             _builder.append("\t");
             _builder.append("\t");
-            _builder.append("if (hasSemanticElement != null && hasSemanticElement) {");
+            _builder.append("if (hasSemanticElement !== null && hasSemanticElement) {");
             _builder.newLine();
             _builder.append("\t");
             _builder.append("\t\t");
@@ -2455,8 +2455,8 @@ public class IdeaPluginGenerator extends AbstractStubGeneratingFragment {
         if (_eType!=null) {
           _instanceClass=_eType.getInstanceClass();
         }
-        boolean _notEquals = (!Objects.equal(_instanceClass, null));
-        _and_1 = _notEquals;
+        boolean _tripleNotEquals = (_instanceClass != null);
+        _and_1 = _tripleNotEquals;
       }
       if (!_and_1) {
         _and = false;

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.xtext.generator.junit;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import java.util.Collections;
@@ -61,8 +60,8 @@ public class Junit4Fragment2 extends AbstractStubGeneratingFragment {
     IXtextProjectConfig _projectConfig = this.getProjectConfig();
     IBundleProjectConfig _runtimeTest = _projectConfig.getRuntimeTest();
     ManifestAccess _manifest = _runtimeTest.getManifest();
-    boolean _notEquals = (!Objects.equal(_manifest, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_manifest != null);
+    if (_tripleNotEquals) {
       IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
       IBundleProjectConfig _runtimeTest_1 = _projectConfig_1.getRuntimeTest();
       ManifestAccess _manifest_1 = _runtimeTest_1.getManifest();
@@ -82,8 +81,8 @@ public class Junit4Fragment2 extends AbstractStubGeneratingFragment {
     IXtextProjectConfig _projectConfig_2 = this.getProjectConfig();
     IBundleProjectConfig _eclipsePluginTest = _projectConfig_2.getEclipsePluginTest();
     ManifestAccess _manifest_2 = _eclipsePluginTest.getManifest();
-    boolean _notEquals_1 = (!Objects.equal(_manifest_2, null));
-    if (_notEquals_1) {
+    boolean _tripleNotEquals_1 = (_manifest_2 != null);
+    if (_tripleNotEquals_1) {
       IXtextProjectConfig _projectConfig_3 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePluginTest_1 = _projectConfig_3.getEclipsePluginTest();
       ManifestAccess _manifest_3 = _eclipsePluginTest_1.getManifest();
@@ -104,8 +103,8 @@ public class Junit4Fragment2 extends AbstractStubGeneratingFragment {
     IXtextProjectConfig _projectConfig_4 = this.getProjectConfig();
     IBundleProjectConfig _eclipsePlugin = _projectConfig_4.getEclipsePlugin();
     ManifestAccess _manifest_4 = _eclipsePlugin.getManifest();
-    boolean _notEquals_2 = (!Objects.equal(_manifest_4, null));
-    if (_notEquals_2) {
+    boolean _tripleNotEquals_2 = (_manifest_4 != null);
+    if (_tripleNotEquals_2) {
       IXtextProjectConfig _projectConfig_5 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_1 = _projectConfig_5.getEclipsePlugin();
       ManifestAccess _manifest_5 = _eclipsePlugin_1.getManifest();
@@ -149,8 +148,8 @@ public class Junit4Fragment2 extends AbstractStubGeneratingFragment {
     IXtextProjectConfig _projectConfig_10 = this.getProjectConfig();
     IBundleProjectConfig _eclipsePlugin_2 = _projectConfig_10.getEclipsePlugin();
     IXtextGeneratorFileSystemAccess _srcGen_1 = _eclipsePlugin_2.getSrcGen();
-    boolean _tripleNotEquals = (_srcGen_1 != null);
-    if (_tripleNotEquals) {
+    boolean _tripleNotEquals_3 = (_srcGen_1 != null);
+    if (_tripleNotEquals_3) {
       JavaFileAccess _generateUiInjectorProvider = this.generateUiInjectorProvider();
       IXtextProjectConfig _projectConfig_11 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePluginTest_3 = _projectConfig_11.getEclipsePluginTest();
@@ -327,7 +326,7 @@ public class Junit4Fragment2 extends AbstractStubGeneratingFragment {
           _builder.append(" getInjector() {");
           _builder.newLineIfNotEmpty();
           _builder.append("\t\t");
-          _builder.append("if (injector == null) {");
+          _builder.append("if (injector === null) {");
           _builder.newLine();
           _builder.append("\t\t\t");
           _builder.append("stateBeforeInjectorCreation = ");

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/ManifestAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/ManifestAccess.java
@@ -113,8 +113,7 @@ public class ManifestAccess extends TextFileAccess implements IGuiceAwareGenerat
       }
       this.exportedPackages.addAll(other.exportedPackages);
       this.requiredBundles.addAll(other.requiredBundles);
-      boolean _notEquals_5 = (!Objects.equal(this.symbolicName, null));
-      if (_notEquals_5) {
+      if ((this.symbolicName != null)) {
         String _effectiveSymbolicName = this.getEffectiveSymbolicName();
         this.requiredBundles.remove(_effectiveSymbolicName);
       }
@@ -250,8 +249,7 @@ public class ManifestAccess extends TextFileAccess implements IGuiceAwareGenerat
   @Override
   public void writeTo(final IFileSystemAccess2 fileSystemAccess) {
     try {
-      boolean _notEquals = (!Objects.equal(fileSystemAccess, null));
-      if (_notEquals) {
+      if ((fileSystemAccess != null)) {
         CharSequence _content = this.getContent();
         StringBuffer _stringBuffer = new StringBuffer(_content);
         final String contentToWrite = MergeableManifest.make512Safe(_stringBuffer, this.lineDelimiter);

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/TextFileAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/TextFileAccess.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.model;
 
-import com.google.common.base.Objects;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
@@ -37,8 +36,7 @@ public class TextFileAccess {
   }
   
   public void writeTo(final IFileSystemAccess2 fileSystemAccess) {
-    boolean _notEquals = (!Objects.equal(fileSystemAccess, null));
-    if (_notEquals) {
+    if ((fileSystemAccess != null)) {
       CharSequence _content = this.getContent();
       fileSystemAccess.generateFile(this.path, _content);
     }

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGrammarGenerator.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGrammarGenerator.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.parser.antlr;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import java.util.ArrayList;
@@ -212,8 +211,8 @@ public abstract class AbstractAntlrGrammarGenerator {
     {
       GrammarNaming _grammarNaming_1 = this.getGrammarNaming();
       TypeReference _internalParserSuperClass = _grammarNaming_1.getInternalParserSuperClass(it);
-      boolean _notEquals = (!Objects.equal(_internalParserSuperClass, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_internalParserSuperClass != null);
+      if (_tripleNotEquals) {
         _builder.append("\t");
         _builder.append("superClass=");
         GrammarNaming _grammarNaming_2 = this.getGrammarNaming();
@@ -1157,7 +1156,7 @@ public abstract class AbstractAntlrGrammarGenerator {
   }
   
   protected boolean _mustBeParenthesized(final Group it) {
-    return ((this._grammarAccessExtensions.predicated(it) || it.isFirstSetPredicated()) || (!Objects.equal(it.getCardinality(), null)));
+    return ((this._grammarAccessExtensions.predicated(it) || it.isFirstSetPredicated()) || (it.getCardinality() != null));
   }
   
   protected boolean _mustBeParenthesized(final Assignment it) {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGrammarWithActionsGenerator.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGrammarWithActionsGenerator.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.parser.antlr;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import java.util.Arrays;
 import java.util.List;
@@ -629,11 +628,11 @@ public abstract class AbstractAntlrGrammarWithActionsGenerator extends AbstractA
   }
   
   protected boolean _mustBeParenthesized(final Keyword it) {
-    return ((this._grammarAccessExtensions.predicated(it) || it.isFirstSetPredicated()) || (!Objects.equal(it.getCardinality(), null)));
+    return ((this._grammarAccessExtensions.predicated(it) || it.isFirstSetPredicated()) || (it.getCardinality() != null));
   }
   
   protected boolean _mustBeParenthesized(final RuleCall it) {
-    return ((this._grammarAccessExtensions.predicated(it) || it.isFirstSetPredicated()) || (!Objects.equal(it.getCardinality(), null)));
+    return ((this._grammarAccessExtensions.predicated(it) || it.isFirstSetPredicated()) || (it.getCardinality() != null));
   }
   
   protected CharSequence compileInitHiddenTokens(final AbstractRule it, final AntlrOptions options) {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrContentAssistGrammarGenerator.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrContentAssistGrammarGenerator.java
@@ -161,7 +161,7 @@ public class AntlrContentAssistGrammarGenerator extends AbstractAntlrGrammarWith
         _builder.append("String result = tokenNameToValue.get(tokenName);");
         _builder.newLine();
         _builder.append("\t\t");
-        _builder.append("if (result == null)");
+        _builder.append("if (result === null)");
         _builder.newLine();
         _builder.append("\t\t");
         _builder.append("\t");

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrGrammarGenerator.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrGrammarGenerator.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.parser.antlr;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -581,8 +580,8 @@ public class AntlrGrammarGenerator extends AbstractAntlrGrammarWithActionsGenera
       _builder.append("$current = forceCreateModelElement");
       {
         String _feature = it.getFeature();
-        boolean _notEquals = (!Objects.equal(_feature, null));
-        if (_notEquals) {
+        boolean _tripleNotEquals = (_feature != null);
+        if (_tripleNotEquals) {
           _builder.append("And");
           String _setOrAdd = this._grammarAccessExtensions.setOrAdd(it);
           String _firstUpper = StringExtensions.toFirstUpper(_setOrAdd);

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/XtextAntlrGeneratorFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/XtextAntlrGeneratorFragment2.java
@@ -164,8 +164,8 @@ public class XtextAntlrGeneratorFragment2 extends AbstractAntlrGeneratorFragment
     IXtextProjectConfig _projectConfig = this.getProjectConfig();
     IBundleProjectConfig _genericIde = _projectConfig.getGenericIde();
     IXtextGeneratorFileSystemAccess _srcGen = _genericIde.getSrcGen();
-    boolean _notEquals = (!Objects.equal(_srcGen, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_srcGen != null);
+    if (_tripleNotEquals) {
       this.generateContentAssistGrammar();
       this.addIdeBindingsAndImports();
     }
@@ -918,7 +918,7 @@ public class XtextAntlrGeneratorFragment2 extends AbstractAntlrGeneratorFragment
           _builder.append(" element) {");
           _builder.newLineIfNotEmpty();
           _builder.append("\t\t");
-          _builder.append("if (nameMappings == null) {");
+          _builder.append("if (nameMappings === null) {");
           _builder.newLine();
           _builder.append("\t\t\t");
           _builder.append("nameMappings = new ");

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/resourceFactory/ResourceFactoryFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/resourceFactory/ResourceFactoryFragment2.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.resourceFactory;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.List;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -84,8 +83,8 @@ public class ResourceFactoryFragment2 extends AbstractXtextGeneratorFragment {
     if (_eclipsePlugin!=null) {
       _pluginXml=_eclipsePlugin.getPluginXml();
     }
-    boolean _notEquals = (!Objects.equal(_pluginXml, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_pluginXml != null);
+    if (_tripleNotEquals) {
       IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_1 = _projectConfig_1.getEclipsePlugin();
       PluginXmlAccess _pluginXml_1 = _eclipsePlugin_1.getPluginXml();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/serializer/NamedSerializationContextProvider.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/serializer/NamedSerializationContextProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.serializer;
 
-import com.google.common.base.Objects;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -105,8 +104,7 @@ public class NamedSerializationContextProvider {
             pr = _containingParserRule;
           }
         }
-        boolean _notEquals = (!Objects.equal(pr, null));
-        if (_notEquals) {
+        if ((pr != null)) {
           final Integer i = this.rules.get(pr);
           if (((i).intValue() < index)) {
             index = (i).intValue();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.java
@@ -742,7 +742,7 @@ public class SerializerFragment2 extends AbstractStubGeneratingFragment {
             }
           }
           _builder.append("\t");
-          _builder.append("if (errorAcceptor != null)");
+          _builder.append("if (errorAcceptor !== null)");
           _builder.newLine();
           _builder.append("\t\t");
           _builder.append("errorAcceptor.accept(diagnosticProvider.createInvalidContextOrTypeDiagnostic(semanticObject, context));");
@@ -1179,7 +1179,7 @@ public class SerializerFragment2 extends AbstractStubGeneratingFragment {
           {
             if ((states != null)) {
               _builder.append("\t");
-              _builder.append("if (errorAcceptor != null) {");
+              _builder.append("if (errorAcceptor !== null) {");
               _builder.newLine();
               {
                 for(final ISemanticSequencerNfaProvider.ISemState s : states) {
@@ -1559,7 +1559,7 @@ public class SerializerFragment2 extends AbstractStubGeneratingFragment {
       return false;
     }
     final Assignment ass = GrammarUtil.containingAssignment(c);
-    return (Objects.equal(ass, null) || GrammarUtil.isBooleanAssignment(ass));
+    return ((ass == null) || GrammarUtil.isBooleanAssignment(ass));
   }
   
   private String defaultValue(final AbstractElement ele, final Set<AbstractElement> visited) {
@@ -1777,7 +1777,7 @@ public class SerializerFragment2 extends AbstractStubGeneratingFragment {
         _builder.append(" node) {");
         _builder.newLineIfNotEmpty();
         _builder.append("\t");
-        _builder.append("if (node != null)");
+        _builder.append("if (node !== null)");
         _builder.newLine();
         _builder.append("\t\t");
         _builder.append("return getTokenText(node);");
@@ -1909,8 +1909,8 @@ public class SerializerFragment2 extends AbstractStubGeneratingFragment {
             {
               IGrammarConstraintProvider.IConstraint _value = e.getValue();
               IGrammarConstraintProvider.IConstraintElement _body = _value.getBody();
-              boolean _equals = Objects.equal(_body, null);
-              if (_equals) {
+              boolean _tripleEquals = (_body == null);
+              if (_tripleEquals) {
                 _builder.append("\t");
                 _builder.append("{");
                 IGrammarConstraintProvider.IConstraint _value_1 = e.getValue();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/compare/CompareFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/compare/CompareFragment2.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.ui.compare;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import java.util.Collections;
@@ -69,8 +68,8 @@ public class CompareFragment2 extends AbstractXtextGeneratorFragment {
     if (_eclipsePlugin_2!=null) {
       _pluginXml=_eclipsePlugin_2.getPluginXml();
     }
-    boolean _notEquals = (!Objects.equal(_pluginXml, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals_1 = (_pluginXml != null);
+    if (_tripleNotEquals_1) {
       IXtextProjectConfig _projectConfig_3 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_3 = _projectConfig_3.getEclipsePlugin();
       PluginXmlAccess _pluginXml_1 = _eclipsePlugin_3.getPluginXml();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.java
@@ -93,7 +93,7 @@ public class ContentAssistFragment2 extends AbstractInheritingFragment {
       EList<Grammar> _usedGrammars = g.getUsedGrammars();
       final Grammar superGrammar = IterableExtensions.<Grammar>head(_usedGrammars);
       TypeReference _xifexpression = null;
-      if ((this.isInheritImplementation() && (!Objects.equal(superGrammar, null)))) {
+      if ((this.isInheritImplementation() && (superGrammar != null))) {
         _xifexpression = this.getProposalProviderClass(superGrammar);
       } else {
         _xifexpression = this.getDefaultGenProposalProviderSuperClass();
@@ -115,8 +115,8 @@ public class ContentAssistFragment2 extends AbstractInheritingFragment {
     IXtextProjectConfig _projectConfig = this.getProjectConfig();
     IBundleProjectConfig _eclipsePlugin = _projectConfig.getEclipsePlugin();
     ManifestAccess _manifest = _eclipsePlugin.getManifest();
-    boolean _notEquals = (!Objects.equal(_manifest, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_manifest != null);
+    if (_tripleNotEquals) {
       IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_1 = _projectConfig_1.getEclipsePlugin();
       ManifestAccess _manifest_1 = _eclipsePlugin_1.getManifest();
@@ -134,19 +134,19 @@ public class ContentAssistFragment2 extends AbstractInheritingFragment {
     IXtextProjectConfig _projectConfig_2 = this.getProjectConfig();
     IBundleProjectConfig _eclipsePlugin_2 = _projectConfig_2.getEclipsePlugin();
     IXtextGeneratorFileSystemAccess _srcGen = _eclipsePlugin_2.getSrcGen();
-    boolean _tripleNotEquals = (_srcGen != null);
-    if (_tripleNotEquals) {
+    boolean _tripleNotEquals_1 = (_srcGen != null);
+    if (_tripleNotEquals_1) {
       this.generateGenJavaProposalProvider();
     }
-    if ((this.isGenerateStub() && (!Objects.equal(this.getProjectConfig().getEclipsePlugin().getSrc(), null)))) {
+    if ((this.isGenerateStub() && (this.getProjectConfig().getEclipsePlugin().getSrc() != null))) {
       boolean _isGenerateXtendStub = this.isGenerateXtendStub();
       if (_isGenerateXtendStub) {
         this.generateXtendProposalProviderStub();
         IXtextProjectConfig _projectConfig_3 = this.getProjectConfig();
         IBundleProjectConfig _eclipsePlugin_3 = _projectConfig_3.getEclipsePlugin();
         ManifestAccess _manifest_2 = _eclipsePlugin_3.getManifest();
-        boolean _notEquals_1 = (!Objects.equal(_manifest_2, null));
-        if (_notEquals_1) {
+        boolean _tripleNotEquals_2 = (_manifest_2 != null);
+        if (_tripleNotEquals_2) {
           IXtextProjectConfig _projectConfig_4 = this.getProjectConfig();
           IBundleProjectConfig _eclipsePlugin_4 = _projectConfig_4.getEclipsePlugin();
           ManifestAccess _manifest_3 = _eclipsePlugin_4.getManifest();
@@ -165,8 +165,8 @@ public class ContentAssistFragment2 extends AbstractInheritingFragment {
     IXtextProjectConfig _projectConfig_6 = this.getProjectConfig();
     IBundleProjectConfig _eclipsePlugin_6 = _projectConfig_6.getEclipsePlugin();
     ManifestAccess _manifest_5 = _eclipsePlugin_6.getManifest();
-    boolean _notEquals_2 = (!Objects.equal(_manifest_5, null));
-    if (_notEquals_2) {
+    boolean _tripleNotEquals_3 = (_manifest_5 != null);
+    if (_tripleNotEquals_3) {
       IXtextProjectConfig _projectConfig_7 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_7 = _projectConfig_7.getEclipsePlugin();
       ManifestAccess _manifest_6 = _eclipsePlugin_7.getManifest();
@@ -641,8 +641,8 @@ public class ContentAssistFragment2 extends AbstractInheritingFragment {
   public Set<String> getFQFeatureNamesToExclude(final Grammar g) {
     Set<String> _xifexpression = null;
     Grammar _nonTerminalsSuperGrammar = GrammarUtil2.getNonTerminalsSuperGrammar(g);
-    boolean _notEquals = (!Objects.equal(_nonTerminalsSuperGrammar, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_nonTerminalsSuperGrammar != null);
+    if (_tripleNotEquals) {
       Sets.SetView<String> _xblockexpression = null;
       {
         Iterable<String> _computeFQFeatureNames = this.computeFQFeatureNames(g);

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.ui.labeling;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Set;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
@@ -110,8 +109,8 @@ public class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
       IXtextProjectConfig _projectConfig = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin = _projectConfig.getEclipsePlugin();
       ManifestAccess _manifest = _eclipsePlugin.getManifest();
-      boolean _notEquals = (!Objects.equal(_manifest, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_manifest != null);
+      if (_tripleNotEquals) {
         IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
         IBundleProjectConfig _eclipsePlugin_1 = _projectConfig_1.getEclipsePlugin();
         ManifestAccess _manifest_1 = _eclipsePlugin_1.getManifest();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/outline/OutlineTreeProviderFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/outline/OutlineTreeProviderFragment2.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.ui.outline;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Set;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
@@ -53,8 +52,8 @@ public class OutlineTreeProviderFragment2 extends AbstractStubGeneratingFragment
     IXtextProjectConfig _projectConfig = this.getProjectConfig();
     IBundleProjectConfig _eclipsePlugin = _projectConfig.getEclipsePlugin();
     ManifestAccess _manifest = _eclipsePlugin.getManifest();
-    boolean _notEquals = (!Objects.equal(_manifest, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_manifest != null);
+    if (_tripleNotEquals) {
       IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_1 = _projectConfig_1.getEclipsePlugin();
       ManifestAccess _manifest_1 = _eclipsePlugin_1.getManifest();
@@ -69,8 +68,8 @@ public class OutlineTreeProviderFragment2 extends AbstractStubGeneratingFragment
     IXtextProjectConfig _projectConfig_2 = this.getProjectConfig();
     IBundleProjectConfig _eclipsePlugin_2 = _projectConfig_2.getEclipsePlugin();
     IXtextGeneratorFileSystemAccess _src = _eclipsePlugin_2.getSrc();
-    boolean _tripleNotEquals = (_src != null);
-    if (_tripleNotEquals) {
+    boolean _tripleNotEquals_1 = (_src != null);
+    if (_tripleNotEquals_1) {
       boolean _isGenerateXtendStub = this.isGenerateXtendStub();
       if (_isGenerateXtendStub) {
         this.generateXtendOutlineTreeProvider();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/outline/QuickOutlineFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/outline/QuickOutlineFragment2.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.ui.outline;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.List;
 import java.util.Set;
@@ -38,8 +37,8 @@ public class QuickOutlineFragment2 extends AbstractXtextGeneratorFragment {
     IXtextProjectConfig _projectConfig = this.getProjectConfig();
     IBundleProjectConfig _eclipsePlugin = _projectConfig.getEclipsePlugin();
     ManifestAccess _manifest = _eclipsePlugin.getManifest();
-    boolean _notEquals = (!Objects.equal(_manifest, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_manifest != null);
+    if (_tripleNotEquals) {
       IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_1 = _projectConfig_1.getEclipsePlugin();
       ManifestAccess _manifest_1 = _eclipsePlugin_1.getManifest();
@@ -49,8 +48,8 @@ public class QuickOutlineFragment2 extends AbstractXtextGeneratorFragment {
     IXtextProjectConfig _projectConfig_2 = this.getProjectConfig();
     IBundleProjectConfig _eclipsePlugin_2 = _projectConfig_2.getEclipsePlugin();
     PluginXmlAccess _pluginXml = _eclipsePlugin_2.getPluginXml();
-    boolean _notEquals_1 = (!Objects.equal(_pluginXml, null));
-    if (_notEquals_1) {
+    boolean _tripleNotEquals_1 = (_pluginXml != null);
+    if (_tripleNotEquals_1) {
       IXtextProjectConfig _projectConfig_3 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_3 = _projectConfig_3.getEclipsePlugin();
       PluginXmlAccess _pluginXml_1 = _eclipsePlugin_3.getPluginXml();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/projectWizard/SimpleProjectWizardFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/projectWizard/SimpleProjectWizardFragment2.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.ui.projectWizard;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import java.util.Collections;
@@ -89,8 +88,8 @@ public class SimpleProjectWizardFragment2 extends AbstractXtextGeneratorFragment
     if (_eclipsePlugin_2!=null) {
       _pluginXml=_eclipsePlugin_2.getPluginXml();
     }
-    boolean _notEquals = (!Objects.equal(_pluginXml, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals_1 = (_pluginXml != null);
+    if (_tripleNotEquals_1) {
       IXtextProjectConfig _projectConfig_3 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_3 = _projectConfig_3.getEclipsePlugin();
       PluginXmlAccess _pluginXml_1 = _eclipsePlugin_3.getPluginXml();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.ui.quickfix;
 
-import com.google.common.base.Objects;
 import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
@@ -65,7 +64,7 @@ public class QuickfixProviderFragment2 extends AbstractInheritingFragment {
     {
       final Grammar superGrammar = GrammarUtil2.getNonTerminalsSuperGrammar(g);
       TypeReference _xifexpression = null;
-      if ((this.isInheritImplementation() && (!Objects.equal(superGrammar, null)))) {
+      if ((this.isInheritImplementation() && (superGrammar != null))) {
         _xifexpression = this.getQuickfixProviderClass(superGrammar);
       } else {
         _xifexpression = this.getDefaultQuickfixProviderSuperClass();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/refactoring/RefactorElementNameFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/refactoring/RefactorElementNameFragment2.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.ui.refactoring;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.name.Names;
 import java.util.List;
@@ -70,8 +69,8 @@ public class RefactorElementNameFragment2 extends AbstractXtextGeneratorFragment
     if (_eclipsePlugin!=null) {
       _manifest=_eclipsePlugin.getManifest();
     }
-    boolean _notEquals = (!Objects.equal(_manifest, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_manifest != null);
+    if (_tripleNotEquals) {
       IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_1 = _projectConfig_1.getEclipsePlugin();
       ManifestAccess _manifest_1 = _eclipsePlugin_1.getManifest();
@@ -160,8 +159,8 @@ public class RefactorElementNameFragment2 extends AbstractXtextGeneratorFragment
     if (_eclipsePlugin_2!=null) {
       _pluginXml=_eclipsePlugin_2.getPluginXml();
     }
-    boolean _notEquals_1 = (!Objects.equal(_pluginXml, null));
-    if (_notEquals_1) {
+    boolean _tripleNotEquals_1 = (_pluginXml != null);
+    if (_tripleNotEquals_1) {
       IXtextProjectConfig _projectConfig_3 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_3 = _projectConfig_3.getEclipsePlugin();
       PluginXmlAccess _pluginXml_1 = _eclipsePlugin_3.getPluginXml();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/templates/CodetemplatesGeneratorFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/templates/CodetemplatesGeneratorFragment2.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator.ui.templates;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Collection;
 import java.util.Collections;
@@ -121,8 +120,8 @@ public class CodetemplatesGeneratorFragment2 extends AbstractXtextGeneratorFragm
     if (_genericIde!=null) {
       _srcGen=_genericIde.getSrcGen();
     }
-    boolean _notEquals = (!Objects.equal(_srcGen, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_srcGen != null);
+    if (_tripleNotEquals) {
       Grammar _grammar_1 = this.getGrammar();
       TypeReference _partialContentAssistParserClass_1 = this.getPartialContentAssistParserClass(_grammar_1);
       GeneratedJavaFileAccess _createGeneratedJavaFile = this.fileAccessFactory.createGeneratedJavaFile(_partialContentAssistParserClass_1);
@@ -191,7 +190,7 @@ public class CodetemplatesGeneratorFragment2 extends AbstractXtextGeneratorFragm
         _builder.append(" parser) {");
         _builder.newLineIfNotEmpty();
         _builder.append("\t\t");
-        _builder.append("if (rule == null || rule.eIsProxy())");
+        _builder.append("if (rule === null || rule.eIsProxy())");
         _builder.newLine();
         _builder.append("\t\t\t");
         _builder.append("return ");

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/GradleBuildFile.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/GradleBuildFile.xtend
@@ -41,7 +41,7 @@ class GradleBuildFile extends TextFile {
 	}
 	
 	private def getMavenDependencies() {
-		project.externalDependencies.map[maven].filter[artifactId != null]
+		project.externalDependencies.map[maven].filter[artifactId !== null]
 	}
 	
 	private def getAllDependencies() {

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/PomFile.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/PomFile.xtend
@@ -49,7 +49,7 @@ class PomFile extends TextFile {
 						<version>${project.version}</version>
 					</dependency>
 				«ENDFOR»
-				«FOR dep : project.externalDependencies.map[maven].filter[artifactId != null]»
+				«FOR dep : project.externalDependencies.map[maven].filter[artifactId !== null]»
 					<dependency>
 						<groupId>«dep.groupId»</groupId>
 						<artifactId>«dep.artifactId»</artifactId>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ProjectDescriptor.xtend
@@ -107,7 +107,7 @@ abstract class ProjectDescriptor {
 		Bundle-Vendor: My Company
 		Bundle-Version: 1.0.0.qualifier
 		Bundle-SymbolicName: «name»; singleton:=true
-		«IF activatorClassName != null»
+		«IF activatorClassName !== null»
 			Bundle-Activator: «activatorClassName»
 		«ENDIF»
 		Bundle-ActivationPolicy: lazy
@@ -130,8 +130,8 @@ abstract class ProjectDescriptor {
 	def Set<String> getRequiredBundles() {
 		val bundles = newLinkedHashSet
 		bundles += upstreamProjects.map[name]
-		bundles += externalDependencies.map[p2].filter[bundleId != null]
-			.map[bundleId + if (version == null) "" else ';bundle-version="' +version+ '"']
+		bundles += externalDependencies.map[p2].filter[bundleId !== null]
+			.map[bundleId + if (version === null) "" else ';bundle-version="' +version+ '"']
 		bundles
 	}
 

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextExtensions.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextExtensions.xtend
@@ -21,7 +21,7 @@ import org.eclipse.xtext.xtext.wizard.Ecore2XtextConfiguration
 
 class Ecore2XtextExtensions {
 	def static allConcreteRuleClassifiers(Ecore2XtextConfiguration it) {
-		if (rootElementClass == null) {
+		if (rootElementClass === null) {
 			getEPackageInfos.map([allReferencedClassifiers(getEPackage, false)]).flatten.toSet.filter([
 				needsConcreteRule(it)
 			])
@@ -33,7 +33,7 @@ class Ecore2XtextExtensions {
 	}
 
 	def static Collection<EClass> allDispatcherRuleClasses(Ecore2XtextConfiguration it) {
-		if (rootElementClass == null)
+		if (rootElementClass === null)
 			getEPackageInfos.map([allReferencedClassifiers(getEPackage, false)]).flatten.toSet.filter([c|
 				needsDispatcherRule(c)
 			]).filter(EClass).toSet
@@ -76,7 +76,7 @@ class Ecore2XtextExtensions {
 	}
 
 	def static fqn(EClassifier it) {
-		if (getEPackage?.uniqueName == null)
+		if (getEPackage?.uniqueName === null)
 			quoteIfNeccesary(name)
 		else
 			getEPackage.uniqueName + "::" + quoteIfNeccesary(name)
@@ -177,7 +177,7 @@ class Ecore2XtextExtensions {
 
 	def static idAttribute(EClass it) {
 		val idAttr = idAttributeInternal(it)
-		if (idAttr != null)
+		if (idAttr !== null)
 			idAttr
 		else
 			getEAllAttributes.findFirst([a|
@@ -244,7 +244,7 @@ class Ecore2XtextExtensions {
 	}
 
 	def static subClasses(EClass it) {
-		if (getEPackage == null)
+		if (getEPackage === null)
 			emptyList
 		else
 			getEPackage.getEClassifiers.filter(EClass).filter(c|c.getEAllSuperTypes.contains(it));

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextGrammarCreator.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextGrammarCreator.xtend
@@ -29,7 +29,7 @@ import org.eclipse.xtext.xtext.wizard.WizardConfiguration
 		grammar «config.language.name» with org.eclipse.xtext.common.Terminals
 		
 		«FOR it: allReferencedEPackages»
-		import "«nsURI»" «IF uniqueName != null && uniqueName != ""»as «uniqueName»«ENDIF»
+		import "«nsURI»" «IF uniqueName !== null && uniqueName != ""»as «uniqueName»«ENDIF»
 		«ENDFOR»
 		
 		«rootElementClass.rules»
@@ -97,7 +97,7 @@ import org.eclipse.xtext.xtext.wizard.WizardConfiguration
 	}
 
 	def rules(EClassifier it) {
-		if (it != null && it.needsConcreteRule) {
+		if (it !== null && it.needsConcreteRule) {
 			rule(it)
 		}
 	}

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/GradleBuildFile.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/GradleBuildFile.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.wizard;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import java.util.Set;
 import org.eclipse.xtend.lib.annotations.Accessors;
@@ -107,7 +106,7 @@ public class GradleBuildFile extends TextFile {
     Iterable<ExternalDependency.MavenCoordinates> _map = IterableExtensions.<ExternalDependency, ExternalDependency.MavenCoordinates>map(_externalDependencies, _function);
     final Function1<ExternalDependency.MavenCoordinates, Boolean> _function_1 = (ExternalDependency.MavenCoordinates it) -> {
       String _artifactId = it.getArtifactId();
-      return Boolean.valueOf((!Objects.equal(_artifactId, null)));
+      return Boolean.valueOf((_artifactId != null));
     };
     return IterableExtensions.<ExternalDependency.MavenCoordinates>filter(_map, _function_1);
   }

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/PomFile.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/PomFile.java
@@ -183,7 +183,7 @@ public class PomFile extends TextFile {
           Iterable<ExternalDependency.MavenCoordinates> _map = IterableExtensions.<ExternalDependency, ExternalDependency.MavenCoordinates>map(_externalDependencies, _function);
           final Function1<ExternalDependency.MavenCoordinates, Boolean> _function_1 = (ExternalDependency.MavenCoordinates it) -> {
             String _artifactId = it.getArtifactId();
-            return Boolean.valueOf((!Objects.equal(_artifactId, null)));
+            return Boolean.valueOf((_artifactId != null));
           };
           Iterable<ExternalDependency.MavenCoordinates> _filter = IterableExtensions.<ExternalDependency.MavenCoordinates>filter(_map, _function_1);
           for(final ExternalDependency.MavenCoordinates dep : _filter) {

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ProjectDescriptor.java
@@ -205,8 +205,8 @@ public abstract class ProjectDescriptor {
     _builder.newLineIfNotEmpty();
     {
       Object _activatorClassName = this.getActivatorClassName();
-      boolean _notEquals = (!Objects.equal(_activatorClassName, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_activatorClassName != null);
+      if (_tripleNotEquals) {
         _builder.append("Bundle-Activator: ");
         Object _activatorClassName_1 = this.getActivatorClassName();
         _builder.append(_activatorClassName_1, "");
@@ -265,15 +265,15 @@ public abstract class ProjectDescriptor {
       Iterable<ExternalDependency.P2Coordinates> _map_1 = IterableExtensions.<ExternalDependency, ExternalDependency.P2Coordinates>map(_externalDependencies, _function_1);
       final Function1<ExternalDependency.P2Coordinates, Boolean> _function_2 = (ExternalDependency.P2Coordinates it) -> {
         String _bundleId = it.getBundleId();
-        return Boolean.valueOf((!Objects.equal(_bundleId, null)));
+        return Boolean.valueOf((_bundleId != null));
       };
       Iterable<ExternalDependency.P2Coordinates> _filter = IterableExtensions.<ExternalDependency.P2Coordinates>filter(_map_1, _function_2);
       final Function1<ExternalDependency.P2Coordinates, String> _function_3 = (ExternalDependency.P2Coordinates it) -> {
         String _bundleId = it.getBundleId();
         String _xifexpression = null;
         String _version = it.getVersion();
-        boolean _equals = Objects.equal(_version, null);
-        if (_equals) {
+        boolean _tripleEquals = (_version == null);
+        if (_tripleEquals) {
           _xifexpression = "";
         } else {
           String _version_1 = it.getVersion();

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextExtensions.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextExtensions.java
@@ -34,8 +34,8 @@ public class Ecore2XtextExtensions {
   public static Iterable<EClassifier> allConcreteRuleClassifiers(final Ecore2XtextConfiguration it) {
     Iterable<EClassifier> _xifexpression = null;
     EClass _rootElementClass = it.getRootElementClass();
-    boolean _equals = Objects.equal(_rootElementClass, null);
-    if (_equals) {
+    boolean _tripleEquals = (_rootElementClass == null);
+    if (_tripleEquals) {
       Set<EPackageInfo> _ePackageInfos = it.getEPackageInfos();
       final Function1<EPackageInfo, Set<EClassifier>> _function = (EPackageInfo it_1) -> {
         EPackage _ePackage = it_1.getEPackage();
@@ -70,8 +70,8 @@ public class Ecore2XtextExtensions {
   public static Collection<EClass> allDispatcherRuleClasses(final Ecore2XtextConfiguration it) {
     Set<EClass> _xifexpression = null;
     EClass _rootElementClass = it.getRootElementClass();
-    boolean _equals = Objects.equal(_rootElementClass, null);
-    if (_equals) {
+    boolean _tripleEquals = (_rootElementClass == null);
+    if (_tripleEquals) {
       Set<EPackageInfo> _ePackageInfos = it.getEPackageInfos();
       final Function1<EPackageInfo, Set<EClassifier>> _function = (EPackageInfo it_1) -> {
         EPackage _ePackage = it_1.getEPackage();
@@ -188,8 +188,8 @@ public class Ecore2XtextExtensions {
     if (_ePackage!=null) {
       _uniqueName=UniqueNameUtil.uniqueName(_ePackage);
     }
-    boolean _equals = Objects.equal(_uniqueName, null);
-    if (_equals) {
+    boolean _tripleEquals = (_uniqueName == null);
+    if (_tripleEquals) {
       String _name = it.getName();
       _xifexpression = Ecore2XtextExtensions.quoteIfNeccesary(_name);
     } else {
@@ -400,8 +400,7 @@ public class Ecore2XtextExtensions {
     {
       final EAttribute idAttr = Ecore2XtextExtensions.idAttributeInternal(it);
       EAttribute _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(idAttr, null));
-      if (_notEquals) {
+      if ((idAttr != null)) {
         _xifexpression = idAttr;
       } else {
         EList<EAttribute> _eAllAttributes = it.getEAllAttributes();
@@ -507,8 +506,8 @@ public class Ecore2XtextExtensions {
   public static Iterable<EClass> subClasses(final EClass it) {
     Iterable<EClass> _xifexpression = null;
     EPackage _ePackage = it.getEPackage();
-    boolean _equals = Objects.equal(_ePackage, null);
-    if (_equals) {
+    boolean _tripleEquals = (_ePackage == null);
+    if (_tripleEquals) {
       _xifexpression = CollectionLiterals.<EClass>emptyList();
     } else {
       EPackage _ePackage_1 = it.getEPackage();

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextGrammarCreator.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextGrammarCreator.java
@@ -60,7 +60,7 @@ public class Ecore2XtextGrammarCreator {
           _builder.append(_nsURI, "");
           _builder.append("\" ");
           {
-            if (((!Objects.equal(UniqueNameUtil.uniqueName(it_1), null)) && (!Objects.equal(UniqueNameUtil.uniqueName(it_1), "")))) {
+            if (((UniqueNameUtil.uniqueName(it_1) != null) && (!Objects.equal(UniqueNameUtil.uniqueName(it_1), "")))) {
               _builder.append("as ");
               String _uniqueName = UniqueNameUtil.uniqueName(it_1);
               _builder.append(_uniqueName, "");
@@ -286,7 +286,7 @@ public class Ecore2XtextGrammarCreator {
   
   public CharSequence rules(final EClassifier it) {
     CharSequence _xifexpression = null;
-    if (((!Objects.equal(it, null)) && Ecore2XtextExtensions.needsConcreteRule(it))) {
+    if (((it != null) && Ecore2XtextExtensions.needsConcreteRule(it))) {
       _xifexpression = this.rule(it);
     }
     return _xifexpression;


### PR DESCRIPTION
For comparison with null the triple (not) equal operator should be used.
Resolved compiler warnings
