### PR TITLE
[eclipse/xtext#1089] Replace (not)equal operators by triple (not)equals

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
@@ -153,8 +153,8 @@ class XtextGeneratorTemplates {
 		«ELSEIF value.statements.isEmpty»
 			// contributed by «contributedBy»
 			«IF key.singleton»@«SingletonBinding»«IF key.eagerSingleton»(eager=true)«ENDIF»«ENDIF»
-			public «IF value.expression==null»Class<? extends «Provider»<? extends «key.type»>>«ELSE»«Provider»<? extends «key.type»>«ENDIF» «bindMethodName»() {
-				return «IF value.expression!=null»«value.expression»«ELSE»«value.type».class«ENDIF»;
+			public «IF value.expression===null»Class<? extends «Provider»<? extends «key.type»>>«ELSE»«Provider»<? extends «key.type»>«ENDIF» «bindMethodName»() {
+				return «IF value.expression!==null»«value.expression»«ELSE»«value.type».class«ENDIF»;
 			}
 		«ELSE»
 			// contributed by «contributedBy»

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
@@ -484,8 +483,8 @@ public class XtextGeneratorTemplates {
               {
                 GuiceModuleAccess.BindValue _value_5 = it.getValue();
                 Object _expression_3 = _value_5.getExpression();
-                boolean _equals = Objects.equal(_expression_3, null);
-                if (_equals) {
+                boolean _tripleEquals_1 = (_expression_3 == null);
+                if (_tripleEquals_1) {
                   _builder.append("Class<? extends ");
                   _builder.append(Provider.class, "");
                   _builder.append("<? extends ");
@@ -512,8 +511,8 @@ public class XtextGeneratorTemplates {
               {
                 GuiceModuleAccess.BindValue _value_6 = it.getValue();
                 Object _expression_4 = _value_6.getExpression();
-                boolean _notEquals = (!Objects.equal(_expression_4, null));
-                if (_notEquals) {
+                boolean _tripleNotEquals_1 = (_expression_4 != null);
+                if (_tripleNotEquals_1) {
                   GuiceModuleAccess.BindValue _value_7 = it.getValue();
                   Object _expression_5 = _value_7.getExpression();
                   _builder.append(_expression_5, "\t");

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextGrammarCreator.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextGrammarCreator.xtend
@@ -67,7 +67,7 @@ import org.eclipse.xtext.xtext.wizard.WizardConfiguration
 	
 	def idAssignment(EClass it) {
 		val idAttr = idAttribute
-		if(idAttr!=null) {
+		if(idAttr!==null) {
 			'''«idAttr.name»=«assignedRuleCall(idAttr)»'''
 		}
 	}

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextGrammarCreator.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextGrammarCreator.java
@@ -154,8 +154,7 @@ public class Ecore2XtextGrammarCreator {
     {
       final EAttribute idAttr = Ecore2XtextExtensions.idAttribute(it);
       CharSequence _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(idAttr, null));
-      if (_notEquals) {
+      if ((idAttr != null)) {
         StringConcatenation _builder = new StringConcatenation();
         String _name = idAttr.getName();
         _builder.append(_name, "");


### PR DESCRIPTION
For comparison with null the triple (not) equal operator should be used.
Resolved compiler warnings


Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>