### PR TITLE
Don't add spaces before/after ML comments

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/CommentFormatterTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/CommentFormatterTest.xtend
@@ -8,8 +8,10 @@
 package org.eclipse.xtext.formatting2.internal
 
 import com.google.inject.Inject
+import org.eclipse.xtext.formatting2.IFormattableDocument
 import org.eclipse.xtext.formatting2.internal.formattertestlanguage.IDList
 import org.eclipse.xtext.formatting2.internal.tests.FormatterTestLanguageInjectorProvider
+import org.eclipse.xtext.formatting2.regionaccess.ITextRegionExtensions
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.junit.Test
@@ -22,7 +24,12 @@ import org.junit.runner.RunWith
 @InjectWith(FormatterTestLanguageInjectorProvider)
 class CommentFormatterTest {
 	@Inject extension GenericFormatterTester
-	//@Inject extension FormatterTestLanguageGrammarAccess
+
+	static class CustomFormatter extends GenericFormatter<IDList> {
+		override format(IDList model, ITextRegionExtensions regionAccess, extension IFormattableDocument document) {
+			model.regionFor.keyword("idlist").append[oneSpace]
+		}
+	}
 
 	@Test def void SL_inline() {
 		assertFormatted[
@@ -30,9 +37,7 @@ class CommentFormatterTest {
 				idlist  //x
 				a
 			'''
-			formatter = [ IDList model, extension regions, extension document |
-				model.regionFor.keyword("idlist").append[oneSpace]
-			]
+			formatter = new CustomFormatter()
 			expectation = '''
 				idlist //x
 				a
@@ -50,9 +55,7 @@ class CommentFormatterTest {
 				
 				a
 			'''
-			formatter = [ IDList model, extension regions, extension document |
-				model.regionFor.keyword("idlist").append[oneSpace]
-			]
+			formatter = new CustomFormatter()
 			expectation = '''
 				idlist //x
 				a
@@ -65,11 +68,21 @@ class CommentFormatterTest {
 			toBeFormatted = '''
 				idlist  /*x*/  a
 			'''
-			formatter = [ IDList model, extension regions, extension document |
-				model.regionFor.keyword("idlist").append[oneSpace]
-			]
+			formatter = new CustomFormatter()
 			expectation = '''
 				idlist /*x*/ a
+			'''
+		]
+	}
+
+	@Test def void MLSL_double_inline() {
+		assertFormatted[
+			toBeFormatted = '''
+				idlist  /*x*//*y*/  a
+			'''
+			formatter = new CustomFormatter()
+			expectation = '''
+				idlist /*x*/ /*y*/ a
 			'''
 		]
 	}
@@ -85,9 +98,7 @@ class CommentFormatterTest {
 				
 				a
 			'''
-			formatter = [ IDList model, extension regions, extension document |
-				model.regionFor.keyword("idlist").append[oneSpace]
-			]
+			formatter = new CustomFormatter()
 			expectation = '''
 				idlist /*x*/
 				a
@@ -102,9 +113,7 @@ class CommentFormatterTest {
 				x
 				*/  a
 			'''
-			formatter = [ IDList model, extension regions, extension document |
-				model.regionFor.keyword("idlist").append[oneSpace]
-			]
+			formatter = new CustomFormatter()
 			expectation = '''
 				idlist
 				/*
@@ -128,9 +137,7 @@ class CommentFormatterTest {
 				
 				a
 			'''
-			formatter = [ IDList model, extension regions, extension document |
-				model.regionFor.keyword("idlist").append[oneSpace]
-			]
+			formatter = new CustomFormatter()
 			expectation = '''
 				idlist
 				
@@ -142,6 +149,4 @@ class CommentFormatterTest {
 			'''
 		]
 	}
-
-
 }

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/CommentWithSpacesFormatterTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/CommentWithSpacesFormatterTest.xtend
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.formatting2.internal
+
+import com.google.inject.Inject
+import org.eclipse.xtext.formatting2.IFormattableDocument
+import org.eclipse.xtext.formatting2.IHiddenRegionFormatting
+import org.eclipse.xtext.formatting2.ITextReplacer
+import org.eclipse.xtext.formatting2.ITextReplacerContext
+import org.eclipse.xtext.formatting2.internal.formattertestlanguage.IDList
+import org.eclipse.xtext.formatting2.internal.tests.FormatterTestLanguageInjectorProvider
+import org.eclipse.xtext.formatting2.regionaccess.ITextRegionExtensions
+import org.eclipse.xtext.formatting2.regionaccess.ITextSegment
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author Moritz Eysholdt - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(FormatterTestLanguageInjectorProvider)
+class CommentWithSpacesFormatterTest {
+
+	@Inject extension GenericFormatterTester
+
+	static class TabsAndSpacesSupportingFormatter extends GenericFormatter<IDList> {
+		override format(IDList model, ITextRegionExtensions regionAccess, extension IFormattableDocument document) {
+			model.regionFor.keyword("idlist").append[oneSpace].append[newLines = 0 highPriority]
+		}
+
+		override ITextReplacer createWhitespaceReplacer(ITextSegment hiddens, IHiddenRegionFormatting formatting) {
+			return new TabAndSpacesSupportingWhiteSpaceReplacer(hiddens, formatting);
+		}
+	}
+
+	@Test def void SL_inline() {
+		assertFormatted[
+			toBeFormatted = '''
+				idlist  //x
+				a
+			'''
+			formatter = new TabsAndSpacesSupportingFormatter()
+			// space before a because we replace by newline + indentation + space
+			// in the TabAndSpacesSupportingWhiteSpaceReplacer
+			expectation = '''
+				idlist //x
+				 a
+			'''
+		]
+	}
+
+	@Test def void SL_multiline() {
+		assertFormatted[
+			toBeFormatted = '''
+				idlist  
+				
+				//x
+				
+				
+				a
+			'''
+			formatter = new TabsAndSpacesSupportingFormatter()
+			expectation = '''
+				idlist //x
+				a
+			'''
+		]
+	}
+
+	@Test def void MLSL_inline() {
+		assertFormatted[
+			toBeFormatted = '''
+				idlist  /*x*/  a
+			'''
+			formatter = new TabsAndSpacesSupportingFormatter()
+			expectation = '''
+				idlist /*x*/ a
+			'''
+		]
+	}
+
+	@Test def void MLSL_paragraph() {
+		assertFormatted[
+			toBeFormatted = '''
+				idlist
+				
+				
+				/*x*/
+				
+				
+				a
+			'''
+			formatter = new TabsAndSpacesSupportingFormatter()
+			expectation = '''
+				idlist /*x*/
+				a
+			'''
+		]
+	}
+
+	@Test def void MLML_inline() {
+		assertFormatted[
+			toBeFormatted = '''
+				idlist  /*
+				x
+				*/  a
+			'''
+			formatter = new TabsAndSpacesSupportingFormatter()
+			expectation = '''
+				idlist
+				/*
+				 * x
+				 */ a
+			'''
+		]
+	}
+
+	@Test def void MLML_paragraph() {
+		assertFormatted[
+			toBeFormatted = '''
+				idlist
+				
+				
+				/*
+				x
+				*/
+				
+				
+				a
+				b
+			'''
+			formatter = new TabsAndSpacesSupportingFormatter()
+
+			expectation = '''
+				idlist /*
+				 * x
+				 */
+				a
+				b
+			'''
+		]
+	}
+
+	private static class TabAndSpacesSupportingWhiteSpaceReplacer extends WhitespaceReplacer {
+
+		new(ITextSegment whitespace, IHiddenRegionFormatting formatting) {
+			super(whitespace, formatting)
+		}
+
+		/**
+		 * Copied from {@link WhitespaceReplacer}
+		 */
+		override ITextReplacerContext createReplacements(ITextReplacerContext context) {
+			if (formatting.getAutowrap() !== null && formatting.getAutowrap() >= 0)
+				context.setCanAutowrap(formatting.getAutowrap());
+			val space = formatting.getSpace();
+			val trailingNewLinesOfPreviousRegion = trailingNewLinesOfPreviousRegion();
+			val computedNewLineCount = computeNewLineCount(context);
+			var newLineCount = Math.max(computedNewLineCount - trailingNewLinesOfPreviousRegion, 0);
+
+			if (newLineCount == 0 && context.isAutowrap()) {
+				val onAutowrap = formatting.getOnAutowrap();
+				if (onAutowrap !== null) {
+					onAutowrap.format(region, formatting, context.getDocument());
+				}
+				newLineCount = 1;
+			}
+			val indentationCount = computeNewIndentation(context);
+			if (newLineCount == 0 && trailingNewLinesOfPreviousRegion == 0) {
+				if (space !== null)
+					context.addReplacement(region.replaceWith(space));
+			} else {
+				val noIndentation = formatting.getNoIndentation() == Boolean.TRUE;
+				val newLines = context.getNewLinesString(newLineCount);
+				val indentation = if(noIndentation) "" else context.getIndentationString(indentationCount);
+				// START CHANGE
+				// Added "+ space" on the next line
+				context.addReplacement(region.replaceWith(newLines + indentation + (space ?: "")));
+			// END CHANGE
+			}
+			return context.withIndentation(indentationCount)
+		}
+	}
+}

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/CommentWithSpacesFormatterTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/CommentWithSpacesFormatterTest.java
@@ -7,16 +7,23 @@
  */
 package org.eclipse.xtext.formatting2.internal;
 
+import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.formatting2.IAutowrapFormatter;
 import org.eclipse.xtext.formatting2.IFormattableDocument;
 import org.eclipse.xtext.formatting2.IHiddenRegionFormatter;
+import org.eclipse.xtext.formatting2.IHiddenRegionFormatting;
+import org.eclipse.xtext.formatting2.ITextReplacer;
+import org.eclipse.xtext.formatting2.ITextReplacerContext;
 import org.eclipse.xtext.formatting2.internal.GenericFormatter;
 import org.eclipse.xtext.formatting2.internal.GenericFormatterTestRequest;
 import org.eclipse.xtext.formatting2.internal.GenericFormatterTester;
+import org.eclipse.xtext.formatting2.internal.WhitespaceReplacer;
 import org.eclipse.xtext.formatting2.internal.formattertestlanguage.IDList;
 import org.eclipse.xtext.formatting2.internal.tests.FormatterTestLanguageInjectorProvider;
 import org.eclipse.xtext.formatting2.regionaccess.ITextRegionExtensions;
+import org.eclipse.xtext.formatting2.regionaccess.ITextSegment;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.xbase.lib.Extension;
@@ -30,14 +37,77 @@ import org.junit.runner.RunWith;
 @RunWith(XtextRunner.class)
 @InjectWith(FormatterTestLanguageInjectorProvider.class)
 @SuppressWarnings("all")
-public class CommentFormatterTest {
-  public static class CustomFormatter extends GenericFormatter<IDList> {
+public class CommentWithSpacesFormatterTest {
+  public static class TabsAndSpacesSupportingFormatter extends GenericFormatter<IDList> {
     @Override
     public void format(final IDList model, final ITextRegionExtensions regionAccess, @Extension final IFormattableDocument document) {
       final Procedure1<IHiddenRegionFormatter> _function = (IHiddenRegionFormatter it) -> {
         it.oneSpace();
       };
-      document.append(this.textRegionExtensions.regionFor(model).keyword("idlist"), _function);
+      final Procedure1<IHiddenRegionFormatter> _function_1 = (IHiddenRegionFormatter it) -> {
+        it.setNewLines(0);
+        it.highPriority();
+      };
+      document.append(document.append(this.textRegionExtensions.regionFor(model).keyword("idlist"), _function), _function_1);
+    }
+    
+    @Override
+    public ITextReplacer createWhitespaceReplacer(final ITextSegment hiddens, final IHiddenRegionFormatting formatting) {
+      return new CommentWithSpacesFormatterTest.TabAndSpacesSupportingWhiteSpaceReplacer(hiddens, formatting);
+    }
+  }
+  
+  private static class TabAndSpacesSupportingWhiteSpaceReplacer extends WhitespaceReplacer {
+    public TabAndSpacesSupportingWhiteSpaceReplacer(final ITextSegment whitespace, final IHiddenRegionFormatting formatting) {
+      super(whitespace, formatting);
+    }
+    
+    /**
+     * Copied from {@link WhitespaceReplacer}
+     */
+    @Override
+    public ITextReplacerContext createReplacements(final ITextReplacerContext context) {
+      if (((this.getFormatting().getAutowrap() != null) && ((this.getFormatting().getAutowrap()).intValue() >= 0))) {
+        context.setCanAutowrap(this.getFormatting().getAutowrap());
+      }
+      final String space = this.getFormatting().getSpace();
+      final int trailingNewLinesOfPreviousRegion = this.trailingNewLinesOfPreviousRegion();
+      final int computedNewLineCount = this.computeNewLineCount(context);
+      int newLineCount = Math.max((computedNewLineCount - trailingNewLinesOfPreviousRegion), 0);
+      if (((newLineCount == 0) && context.isAutowrap())) {
+        final IAutowrapFormatter onAutowrap = this.getFormatting().getOnAutowrap();
+        if ((onAutowrap != null)) {
+          onAutowrap.format(this.getRegion(), this.getFormatting(), context.getDocument());
+        }
+        newLineCount = 1;
+      }
+      final int indentationCount = this.computeNewIndentation(context);
+      if (((newLineCount == 0) && (trailingNewLinesOfPreviousRegion == 0))) {
+        if ((space != null)) {
+          context.addReplacement(this.getRegion().replaceWith(space));
+        }
+      } else {
+        Boolean _noIndentation = this.getFormatting().getNoIndentation();
+        final boolean noIndentation = Objects.equal(_noIndentation, Boolean.TRUE);
+        final String newLines = context.getNewLinesString(newLineCount);
+        String _xifexpression = null;
+        if (noIndentation) {
+          _xifexpression = "";
+        } else {
+          _xifexpression = context.getIndentationString(indentationCount);
+        }
+        final String indentation = _xifexpression;
+        ITextSegment _region = this.getRegion();
+        String _elvis = null;
+        if (space != null) {
+          _elvis = space;
+        } else {
+          _elvis = "";
+        }
+        String _plus = ((newLines + indentation) + _elvis);
+        context.addReplacement(_region.replaceWith(_plus));
+      }
+      return context.withIndentation(indentationCount);
     }
   }
   
@@ -54,11 +124,12 @@ public class CommentFormatterTest {
       _builder.append("a");
       _builder.newLine();
       it.setToBeFormatted(_builder);
-      CommentFormatterTest.CustomFormatter _customFormatter = new CommentFormatterTest.CustomFormatter();
-      it.setFormatter(_customFormatter);
+      CommentWithSpacesFormatterTest.TabsAndSpacesSupportingFormatter _tabsAndSpacesSupportingFormatter = new CommentWithSpacesFormatterTest.TabsAndSpacesSupportingFormatter();
+      it.setFormatter(_tabsAndSpacesSupportingFormatter);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("idlist //x");
       _builder_1.newLine();
+      _builder_1.append(" ");
       _builder_1.append("a");
       _builder_1.newLine();
       it.setExpectation(_builder_1);
@@ -80,8 +151,8 @@ public class CommentFormatterTest {
       _builder.append("a");
       _builder.newLine();
       it.setToBeFormatted(_builder);
-      CommentFormatterTest.CustomFormatter _customFormatter = new CommentFormatterTest.CustomFormatter();
-      it.setFormatter(_customFormatter);
+      CommentWithSpacesFormatterTest.TabsAndSpacesSupportingFormatter _tabsAndSpacesSupportingFormatter = new CommentWithSpacesFormatterTest.TabsAndSpacesSupportingFormatter();
+      it.setFormatter(_tabsAndSpacesSupportingFormatter);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("idlist //x");
       _builder_1.newLine();
@@ -99,27 +170,10 @@ public class CommentFormatterTest {
       _builder.append("idlist  /*x*/  a");
       _builder.newLine();
       it.setToBeFormatted(_builder);
-      CommentFormatterTest.CustomFormatter _customFormatter = new CommentFormatterTest.CustomFormatter();
-      it.setFormatter(_customFormatter);
+      CommentWithSpacesFormatterTest.TabsAndSpacesSupportingFormatter _tabsAndSpacesSupportingFormatter = new CommentWithSpacesFormatterTest.TabsAndSpacesSupportingFormatter();
+      it.setFormatter(_tabsAndSpacesSupportingFormatter);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("idlist /*x*/ a");
-      _builder_1.newLine();
-      it.setExpectation(_builder_1);
-    };
-    this._genericFormatterTester.assertFormatted(_function);
-  }
-  
-  @Test
-  public void MLSL_double_inline() {
-    final Procedure1<GenericFormatterTestRequest> _function = (GenericFormatterTestRequest it) -> {
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("idlist  /*x*//*y*/  a");
-      _builder.newLine();
-      it.setToBeFormatted(_builder);
-      CommentFormatterTest.CustomFormatter _customFormatter = new CommentFormatterTest.CustomFormatter();
-      it.setFormatter(_customFormatter);
-      StringConcatenation _builder_1 = new StringConcatenation();
-      _builder_1.append("idlist /*x*/ /*y*/ a");
       _builder_1.newLine();
       it.setExpectation(_builder_1);
     };
@@ -141,8 +195,8 @@ public class CommentFormatterTest {
       _builder.append("a");
       _builder.newLine();
       it.setToBeFormatted(_builder);
-      CommentFormatterTest.CustomFormatter _customFormatter = new CommentFormatterTest.CustomFormatter();
-      it.setFormatter(_customFormatter);
+      CommentWithSpacesFormatterTest.TabsAndSpacesSupportingFormatter _tabsAndSpacesSupportingFormatter = new CommentWithSpacesFormatterTest.TabsAndSpacesSupportingFormatter();
+      it.setFormatter(_tabsAndSpacesSupportingFormatter);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("idlist /*x*/");
       _builder_1.newLine();
@@ -164,8 +218,8 @@ public class CommentFormatterTest {
       _builder.append("*/  a");
       _builder.newLine();
       it.setToBeFormatted(_builder);
-      CommentFormatterTest.CustomFormatter _customFormatter = new CommentFormatterTest.CustomFormatter();
-      it.setFormatter(_customFormatter);
+      CommentWithSpacesFormatterTest.TabsAndSpacesSupportingFormatter _tabsAndSpacesSupportingFormatter = new CommentWithSpacesFormatterTest.TabsAndSpacesSupportingFormatter();
+      it.setFormatter(_tabsAndSpacesSupportingFormatter);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("idlist");
       _builder_1.newLine();
@@ -175,9 +229,7 @@ public class CommentFormatterTest {
       _builder_1.append("* x");
       _builder_1.newLine();
       _builder_1.append(" ");
-      _builder_1.append("*/");
-      _builder_1.newLine();
-      _builder_1.append("a");
+      _builder_1.append("*/ a");
       _builder_1.newLine();
       it.setExpectation(_builder_1);
     };
@@ -202,15 +254,13 @@ public class CommentFormatterTest {
       _builder.newLine();
       _builder.append("a");
       _builder.newLine();
+      _builder.append("b");
+      _builder.newLine();
       it.setToBeFormatted(_builder);
-      CommentFormatterTest.CustomFormatter _customFormatter = new CommentFormatterTest.CustomFormatter();
-      it.setFormatter(_customFormatter);
+      CommentWithSpacesFormatterTest.TabsAndSpacesSupportingFormatter _tabsAndSpacesSupportingFormatter = new CommentWithSpacesFormatterTest.TabsAndSpacesSupportingFormatter();
+      it.setFormatter(_tabsAndSpacesSupportingFormatter);
       StringConcatenation _builder_1 = new StringConcatenation();
-      _builder_1.append("idlist");
-      _builder_1.newLine();
-      _builder_1.newLine();
-      _builder_1.newLine();
-      _builder_1.append("/*");
+      _builder_1.append("idlist /*");
       _builder_1.newLine();
       _builder_1.append(" ");
       _builder_1.append("* x");
@@ -219,6 +269,8 @@ public class CommentFormatterTest {
       _builder_1.append("*/");
       _builder_1.newLine();
       _builder_1.append("a");
+      _builder_1.newLine();
+      _builder_1.append("b");
       _builder_1.newLine();
       it.setExpectation(_builder_1);
     };

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/HiddenRegionReplacer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/HiddenRegionReplacer.java
@@ -44,7 +44,19 @@ public class HiddenRegionReplacer implements ITextReplacer {
 	protected void applyHiddenRegionFormatting(List<ITextReplacer> replacers) {
 		IHiddenRegionFormatting separator = findWhitespaceThatSeparatesSemanticRegions(replacers).getFormatting();
 
-		// 1. apply indentation 
+		applyIndentation(replacers, separator);
+
+		applySeparatorConfiguration(separator);
+
+		applyPriorityAndDefaultFormatting(replacers, separator);
+
+		introduceNewlinesAroundMLComments(replacers);
+	}
+
+	/**
+	 * @since 2.15
+	 */
+	protected void applyIndentation(List<ITextReplacer> replacers, IHiddenRegionFormatting separator) {
 		Integer inc = formatting.getIndentationIncrease();
 		Integer dec = formatting.getIndentationDecrease();
 		if (inc != null && dec != null) {
@@ -55,26 +67,52 @@ public class HiddenRegionReplacer implements ITextReplacer {
 		} else if (dec != null) {
 			separator.setIndentationDecrease(dec);
 		}
+	}
 
-		// 2. apply NewLine and space configuration to the first whitespace region that follows or contains a linewrap.  
+	/**
+	 * Apply NewLine and space configuration to the first whitespace region that follows or contains a linewrap.
+	 * @since 2.15 
+	 */
+	protected void applySeparatorConfiguration(IHiddenRegionFormatting separator) {
 		separator.setNewLinesDefault(formatting.getNewLineDefault());
 		separator.setNewLinesMax(formatting.getNewLineMax());
 		separator.setNewLinesMin(formatting.getNewLineMin());
 		separator.setSpace(formatting.getSpace());
+	}
 
-		// 3. apply the 'priority' configuration for all and set a default formatting
-		for (ITextReplacer replacer : replacers)
+	/**
+	 * @since 2.15
+	 */
+	protected void applyPriorityAndDefaultFormatting(List<ITextReplacer> replacers, IHiddenRegionFormatting separator) {
+		for (int i = 0; i < replacers.size(); i++) {
+			ITextReplacer replacer = replacers.get(i);
 			if (replacer instanceof WhitespaceReplacer) {
 				IHiddenRegionFormatting formatting2 = ((WhitespaceReplacer) replacer).getFormatting();
 				formatting2.setPriority(formatting.getPriority());
 				if (formatting2 != separator) {
-					formatting2.setSpace(replacer.getRegion().getOffset() > 0 ? " " : "");
+					ITextReplacer previous = (i == 0) ? null : replacers.get(i - 1);
+					ITextReplacer next = (i + 1 >= replacers.size()) ? null : replacers.get(i + 1);
+					// Don't add single spaces after comments
+					if (previous == null || !(previous instanceof CommentReplacer)) {
+						// Don't add spaces before ML comments because in the next step
+						// a newline will be added in front of ML comments.
+						// You don't want to end up with a ML comment on a newline that
+						// starts with a space
+						if (next == null || !(next instanceof MultilineCommentReplacer)) {
+							formatting2.setSpace(replacer.getRegion().getOffset() > 0 ? " " : "");
+						}
+					}
 					formatting2.setNewLinesMin(0);
 					formatting2.setNewLinesMax(1);
 				}
 			}
+		}
+	}
 
-		// 4. make sure whitespace before and after multiline comments introduce a NewLine 
+	/**
+	 * @since 2.15
+	 */
+	protected void introduceNewlinesAroundMLComments(List<ITextReplacer> replacers) {
 		for (int i = 0; i < replacers.size(); i++) {
 			ITextReplacer replacer = replacers.get(i);
 			if (replacer instanceof CommentReplacer) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/MultilineCommentReplacer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/MultilineCommentReplacer.java
@@ -35,8 +35,12 @@ public class MultilineCommentReplacer extends CommentReplacer {
 			enforceNewLine(leading);
 			enforceNewLine(trailing);
 		} else {
-			enforceSingleSpace(leading);
-			enforceSingleSpace(trailing);
+			if (!leading.getRegion().isMultiline()) {
+				enforceSingleSpace(leading);
+			}
+			if (!trailing.getRegion().isMultiline()) {
+				enforceSingleSpace(trailing);
+			}
 		}
 	}
 


### PR DESCRIPTION
Prevents spaces from being added on the newline before or after a ML comment