### PR TITLE
[generator] consolidation of IDE-related names in 'XtextGeneratorNaming'

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.xtend
@@ -281,7 +281,7 @@ class XtextGenerator extends AbstractWorkflowComponent2 {
 		file.path = "META-INF/services/org.eclipse.xtext.ISetup"
 		file.content = '''
 			«FOR lang : languageConfigs»
-				«naming.getIdeSetup(lang.grammar)»
+				«naming.getGenericIdeSetup(lang.grammar)»
 			«ENDFOR»
 		'''
 		file.writeTo(projectConfig.genericIde.srcGen)

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorNaming.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorNaming.xtend
@@ -50,28 +50,28 @@ class XtextGeneratorNaming {
 		new TypeReference(grammar.runtimeBasePackage, getSimpleName(grammar) + 'StandaloneSetupGenerated')
 	}
 	
-	def getIdeBasePackage(Grammar grammar) {
+	def getGenericIdeBasePackage(Grammar grammar) {
 		return grammar.runtimeBasePackage+".ide"
 	}
 	
-	def getIdeTestBasePackage(Grammar grammar) {
-		grammar.ideBasePackage + ".tests"
+	def getGenericIdeTestBasePackage(Grammar grammar) {
+		grammar.genericIdeBasePackage + ".tests"
+	}
+
+	def getGenericIdeModule(Grammar grammar) {
+		new TypeReference(grammar.genericIdeBasePackage, getSimpleName(grammar) + 'IdeModule')
 	}
 	
-	def getIdeModule(Grammar grammar) {
-		new TypeReference(grammar.ideBasePackage, getSimpleName(grammar) + 'IdeModule')
+	def getGenericIdeGenModule(Grammar grammar) {
+		new TypeReference(grammar.genericIdeBasePackage, 'Abstract' + getSimpleName(grammar) + 'IdeModule')
 	}
 	
-	def getIdeGenModule(Grammar grammar) {
-		new TypeReference(grammar.ideBasePackage, 'Abstract' + getSimpleName(grammar) + 'IdeModule')
-	}
-	
-	def getIdeDefaultModule(Grammar grammar) {
+	def getGenericIdeDefaultModule(Grammar grammar) {
 		new TypeReference('org.eclipse.xtext.ide.DefaultIdeModule')
 	}
 	
-	def getIdeSetup(Grammar grammar) {
-		new TypeReference(grammar.ideBasePackage, getSimpleName(grammar) + 'IdeSetup')
+	def getGenericIdeSetup(Grammar grammar) {
+		new TypeReference(grammar.genericIdeBasePackage, getSimpleName(grammar) + 'IdeSetup')
 	}
 	
 	def getEclipsePluginBasePackage(Grammar grammar) {
@@ -116,18 +116,6 @@ class XtextGeneratorNaming {
 		activatorName = activatorName.substring(activatorName.lastIndexOf('.') + 1).toFirstUpper + 'Activator'
 		
 		new TypeReference(pluginName + '.internal', activatorName)
-	}
-	
-	def getGenericIdeBasePackage(Grammar grammar) {
-		return getNamespace(grammar) + '.ide'
-	}
-	
-	def getGenericIdeModule(Grammar grammar) {
-		new TypeReference(grammar.genericIdeBasePackage, getSimpleName(grammar) + 'IdeModule')
-	}
-	
-	def getGenericIdeGenModule(Grammar grammar) {
-		new TypeReference(grammar.genericIdeBasePackage, 'Abstract' + getSimpleName(grammar) + 'IdeModule')
 	}
 	
 	def getIdeaBasePackage(Grammar grammar) {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
@@ -233,19 +233,19 @@ class XtextGeneratorTemplates {
 	def JavaFileAccess createIdeModule(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
 		if (langConfig.generateXtendStubs) {
-			return fileAccessFactory.createXtendFile(ideModule,'''
+			return fileAccessFactory.createXtendFile(genericIdeModule,'''
 				/**
 				 * Use this class to register ide components.
 				 */
-				class «ideModule.simpleName» extends «ideGenModule» {
+				class «genericIdeModule.simpleName» extends «genericIdeGenModule» {
 				}
 			''')
 		} else {
-			return fileAccessFactory.createJavaFile(ideModule,'''
+			return fileAccessFactory.createJavaFile(genericIdeModule,'''
 				/**
 				 * Use this class to register ide components.
 				 */
-				public class «ideModule.simpleName» extends «ideGenModule» {
+				public class «genericIdeModule.simpleName» extends «genericIdeGenModule» {
 				}
 			''')
 		}
@@ -253,18 +253,18 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createIdeGenModule(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		val superClass = langConfig.ideGenModule.superClass ?: ideDefaultModule
-		val file = fileAccessFactory.createGeneratedJavaFile(ideGenModule)
+		val superClass = langConfig.ideGenModule.superClass ?: genericIdeDefaultModule
+		val file = fileAccessFactory.createGeneratedJavaFile(genericIdeGenModule)
 		file.importNestedTypeThreshold = JavaFileAccess.DONT_IMPORT_NESTED_TYPES
 		
 		file.typeComment = '''
 			/**
-			 * Manual modifications go to {@link «ideModule.simpleName»}.
+			 * Manual modifications go to {@link «genericIdeModule.simpleName»}.
 			 */
 		'''
 		file.annotations += new SuppressWarningsAnnotation
 		file.content = '''
-			public abstract class «ideGenModule.simpleName» extends «superClass» {
+			public abstract class «genericIdeGenModule.simpleName» extends «superClass» {
 			
 				«FOR binding : langConfig.ideGenModule.bindings»
 					«binding.createBindingMethod»
@@ -279,28 +279,28 @@ class XtextGeneratorTemplates {
 	def JavaFileAccess createIdeSetup(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
 		if (langConfig.generateXtendStubs) {
-			return fileAccessFactory.createXtendFile(ideSetup,'''
+			return fileAccessFactory.createXtendFile(genericIdeSetup,'''
 				/**
 				 * Initialization support for running Xtext languages as language servers.
 				 */
-				class «ideSetup.simpleName» extends «runtimeSetup» {
+				class «genericIdeSetup.simpleName» extends «runtimeSetup» {
 				
 					override createInjector() {
-						«Guice».createInjector(«Modules2».mixin(new «runtimeModule», new «ideModule»))
+						«Guice».createInjector(«Modules2».mixin(new «runtimeModule», new «genericIdeModule»))
 					}
 					
 				}
 		 	''')
 		} else {
-			return fileAccessFactory.createJavaFile(ideSetup,'''
+			return fileAccessFactory.createJavaFile(genericIdeSetup,'''
 				/**
 				 * Initialization support for running Xtext languages as language servers.
 				 */
-				public class «ideSetup.simpleName» extends «runtimeSetup» {
+				public class «genericIdeSetup.simpleName» extends «runtimeSetup» {
 				
 					@Override
 					public «Injector» createInjector() {
-						return «Guice».createInjector(«Modules2».mixin(new «runtimeModule»(), new «ideModule»()));
+						return «Guice».createInjector(«Modules2».mixin(new «runtimeModule»(), new «genericIdeModule»()));
 					}
 					
 				}
@@ -464,7 +464,7 @@ class XtextGeneratorTemplates {
 				class «webSetup.simpleName» extends «runtimeSetup» {
 					
 					override «Injector» createInjector() {
-						return «Guice».createInjector(«Modules2».mixin(new «runtimeModule», new «ideModule», new «webModule»))
+						return «Guice».createInjector(«Modules2».mixin(new «runtimeModule», new «genericIdeModule», new «webModule»))
 					}
 					
 				}
@@ -478,7 +478,7 @@ class XtextGeneratorTemplates {
 					
 					@Override
 					public «Injector» createInjector() {
-						return «Guice».createInjector(«Modules2».mixin(new «runtimeModule»(), new «ideModule»(), new «webModule»()));
+						return «Guice».createInjector(«Modules2».mixin(new «runtimeModule»(), new «genericIdeModule»(), new «webModule»()));
 					}
 					
 				}

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGenerator.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGenerator.java
@@ -471,8 +471,8 @@ public class XtextGenerator extends AbstractWorkflowComponent2 {
         {
           for(final XtextGeneratorLanguage lang : XtextGenerator.this.languageConfigs) {
             Grammar _grammar = lang.getGrammar();
-            TypeReference _ideSetup = XtextGenerator.this.naming.getIdeSetup(_grammar);
-            _builder.append(_ideSetup, "");
+            TypeReference _genericIdeSetup = XtextGenerator.this.naming.getGenericIdeSetup(_grammar);
+            _builder.append(_genericIdeSetup, "");
             _builder.newLineIfNotEmpty();
           }
         }

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorNaming.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorNaming.java
@@ -65,40 +65,40 @@ public class XtextGeneratorNaming {
     return new TypeReference(_runtimeBasePackage, _plus);
   }
   
-  public String getIdeBasePackage(final Grammar grammar) {
+  public String getGenericIdeBasePackage(final Grammar grammar) {
     String _runtimeBasePackage = this.getRuntimeBasePackage(grammar);
     return (_runtimeBasePackage + ".ide");
   }
   
-  public String getIdeTestBasePackage(final Grammar grammar) {
-    String _ideBasePackage = this.getIdeBasePackage(grammar);
-    return (_ideBasePackage + ".tests");
+  public String getGenericIdeTestBasePackage(final Grammar grammar) {
+    String _genericIdeBasePackage = this.getGenericIdeBasePackage(grammar);
+    return (_genericIdeBasePackage + ".tests");
   }
   
-  public TypeReference getIdeModule(final Grammar grammar) {
-    String _ideBasePackage = this.getIdeBasePackage(grammar);
+  public TypeReference getGenericIdeModule(final Grammar grammar) {
+    String _genericIdeBasePackage = this.getGenericIdeBasePackage(grammar);
     String _simpleName = GrammarUtil.getSimpleName(grammar);
     String _plus = (_simpleName + "IdeModule");
-    return new TypeReference(_ideBasePackage, _plus);
+    return new TypeReference(_genericIdeBasePackage, _plus);
   }
   
-  public TypeReference getIdeGenModule(final Grammar grammar) {
-    String _ideBasePackage = this.getIdeBasePackage(grammar);
+  public TypeReference getGenericIdeGenModule(final Grammar grammar) {
+    String _genericIdeBasePackage = this.getGenericIdeBasePackage(grammar);
     String _simpleName = GrammarUtil.getSimpleName(grammar);
     String _plus = ("Abstract" + _simpleName);
     String _plus_1 = (_plus + "IdeModule");
-    return new TypeReference(_ideBasePackage, _plus_1);
+    return new TypeReference(_genericIdeBasePackage, _plus_1);
   }
   
-  public TypeReference getIdeDefaultModule(final Grammar grammar) {
+  public TypeReference getGenericIdeDefaultModule(final Grammar grammar) {
     return new TypeReference("org.eclipse.xtext.ide.DefaultIdeModule");
   }
   
-  public TypeReference getIdeSetup(final Grammar grammar) {
-    String _ideBasePackage = this.getIdeBasePackage(grammar);
+  public TypeReference getGenericIdeSetup(final Grammar grammar) {
+    String _genericIdeBasePackage = this.getGenericIdeBasePackage(grammar);
     String _simpleName = GrammarUtil.getSimpleName(grammar);
     String _plus = (_simpleName + "IdeSetup");
-    return new TypeReference(_ideBasePackage, _plus);
+    return new TypeReference(_genericIdeBasePackage, _plus);
   }
   
   public String getEclipsePluginBasePackage(final Grammar grammar) {
@@ -158,26 +158,6 @@ public class XtextGeneratorNaming {
       _xblockexpression = new TypeReference((pluginName + ".internal"), activatorName);
     }
     return _xblockexpression;
-  }
-  
-  public String getGenericIdeBasePackage(final Grammar grammar) {
-    String _namespace = GrammarUtil.getNamespace(grammar);
-    return (_namespace + ".ide");
-  }
-  
-  public TypeReference getGenericIdeModule(final Grammar grammar) {
-    String _genericIdeBasePackage = this.getGenericIdeBasePackage(grammar);
-    String _simpleName = GrammarUtil.getSimpleName(grammar);
-    String _plus = (_simpleName + "IdeModule");
-    return new TypeReference(_genericIdeBasePackage, _plus);
-  }
-  
-  public TypeReference getGenericIdeGenModule(final Grammar grammar) {
-    String _genericIdeBasePackage = this.getGenericIdeBasePackage(grammar);
-    String _simpleName = GrammarUtil.getSimpleName(grammar);
-    String _plus = ("Abstract" + _simpleName);
-    String _plus_1 = (_plus + "IdeModule");
-    return new TypeReference(_genericIdeBasePackage, _plus_1);
   }
   
   public String getIdeaBasePackage(final Grammar grammar) {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
@@ -766,7 +766,7 @@ public class XtextGeneratorTemplates {
     final Grammar it = langConfig.getGrammar();
     boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
     if (_isGenerateXtendStubs) {
-      TypeReference _ideModule = this.naming.getIdeModule(it);
+      TypeReference _genericIdeModule = this.naming.getGenericIdeModule(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
         protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
@@ -779,21 +779,21 @@ public class XtextGeneratorTemplates {
           _builder.append("*/");
           _builder.newLine();
           _builder.append("class ");
-          TypeReference _ideModule = XtextGeneratorTemplates.this.naming.getIdeModule(it);
-          String _simpleName = _ideModule.getSimpleName();
+          TypeReference _genericIdeModule = XtextGeneratorTemplates.this.naming.getGenericIdeModule(it);
+          String _simpleName = _genericIdeModule.getSimpleName();
           _builder.append(_simpleName, "");
           _builder.append(" extends ");
-          TypeReference _ideGenModule = XtextGeneratorTemplates.this.naming.getIdeGenModule(it);
-          _builder.append(_ideGenModule, "");
+          TypeReference _genericIdeGenModule = XtextGeneratorTemplates.this.naming.getGenericIdeGenModule(it);
+          _builder.append(_genericIdeGenModule, "");
           _builder.append(" {");
           _builder.newLineIfNotEmpty();
           _builder.append("}");
           _builder.newLine();
         }
       };
-      return this.fileAccessFactory.createXtendFile(_ideModule, _client);
+      return this.fileAccessFactory.createXtendFile(_genericIdeModule, _client);
     } else {
-      TypeReference _ideModule_1 = this.naming.getIdeModule(it);
+      TypeReference _genericIdeModule_1 = this.naming.getGenericIdeModule(it);
       StringConcatenationClient _client_1 = new StringConcatenationClient() {
         @Override
         protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
@@ -806,19 +806,19 @@ public class XtextGeneratorTemplates {
           _builder.append("*/");
           _builder.newLine();
           _builder.append("public class ");
-          TypeReference _ideModule = XtextGeneratorTemplates.this.naming.getIdeModule(it);
-          String _simpleName = _ideModule.getSimpleName();
+          TypeReference _genericIdeModule = XtextGeneratorTemplates.this.naming.getGenericIdeModule(it);
+          String _simpleName = _genericIdeModule.getSimpleName();
           _builder.append(_simpleName, "");
           _builder.append(" extends ");
-          TypeReference _ideGenModule = XtextGeneratorTemplates.this.naming.getIdeGenModule(it);
-          _builder.append(_ideGenModule, "");
+          TypeReference _genericIdeGenModule = XtextGeneratorTemplates.this.naming.getGenericIdeGenModule(it);
+          _builder.append(_genericIdeGenModule, "");
           _builder.append(" {");
           _builder.newLineIfNotEmpty();
           _builder.append("}");
           _builder.newLine();
         }
       };
-      return this.fileAccessFactory.createJavaFile(_ideModule_1, _client_1);
+      return this.fileAccessFactory.createJavaFile(_genericIdeModule_1, _client_1);
     }
   }
   
@@ -830,12 +830,12 @@ public class XtextGeneratorTemplates {
     if (_superClass != null) {
       _elvis = _superClass;
     } else {
-      TypeReference _ideDefaultModule = this.naming.getIdeDefaultModule(it);
-      _elvis = _ideDefaultModule;
+      TypeReference _genericIdeDefaultModule = this.naming.getGenericIdeDefaultModule(it);
+      _elvis = _genericIdeDefaultModule;
     }
     final TypeReference superClass = _elvis;
-    TypeReference _ideGenModule_1 = this.naming.getIdeGenModule(it);
-    final GeneratedJavaFileAccess file = this.fileAccessFactory.createGeneratedJavaFile(_ideGenModule_1);
+    TypeReference _genericIdeGenModule = this.naming.getGenericIdeGenModule(it);
+    final GeneratedJavaFileAccess file = this.fileAccessFactory.createGeneratedJavaFile(_genericIdeGenModule);
     file.setImportNestedTypeThreshold(JavaFileAccess.DONT_IMPORT_NESTED_TYPES);
     StringConcatenationClient _client = new StringConcatenationClient() {
       @Override
@@ -844,8 +844,8 @@ public class XtextGeneratorTemplates {
         _builder.newLine();
         _builder.append(" ");
         _builder.append("* Manual modifications go to {@link ");
-        TypeReference _ideModule = XtextGeneratorTemplates.this.naming.getIdeModule(it);
-        String _simpleName = _ideModule.getSimpleName();
+        TypeReference _genericIdeModule = XtextGeneratorTemplates.this.naming.getGenericIdeModule(it);
+        String _simpleName = _genericIdeModule.getSimpleName();
         _builder.append(_simpleName, " ");
         _builder.append("}.");
         _builder.newLineIfNotEmpty();
@@ -862,8 +862,8 @@ public class XtextGeneratorTemplates {
       @Override
       protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
         _builder.append("public abstract class ");
-        TypeReference _ideGenModule = XtextGeneratorTemplates.this.naming.getIdeGenModule(it);
-        String _simpleName = _ideGenModule.getSimpleName();
+        TypeReference _genericIdeGenModule = XtextGeneratorTemplates.this.naming.getGenericIdeGenModule(it);
+        String _simpleName = _genericIdeGenModule.getSimpleName();
         _builder.append(_simpleName, "");
         _builder.append(" extends ");
         _builder.append(superClass, "");
@@ -871,8 +871,8 @@ public class XtextGeneratorTemplates {
         _builder.newLineIfNotEmpty();
         _builder.newLine();
         {
-          GuiceModuleAccess _ideGenModule_1 = langConfig.getIdeGenModule();
-          Set<GuiceModuleAccess.Binding> _bindings = _ideGenModule_1.getBindings();
+          GuiceModuleAccess _ideGenModule = langConfig.getIdeGenModule();
+          Set<GuiceModuleAccess.Binding> _bindings = _ideGenModule.getBindings();
           for(final GuiceModuleAccess.Binding binding : _bindings) {
             _builder.append("\t");
             StringConcatenationClient _createBindingMethod = XtextGeneratorTemplates.this.createBindingMethod(binding);
@@ -895,7 +895,7 @@ public class XtextGeneratorTemplates {
     final Grammar it = langConfig.getGrammar();
     boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
     if (_isGenerateXtendStubs) {
-      TypeReference _ideSetup = this.naming.getIdeSetup(it);
+      TypeReference _genericIdeSetup = this.naming.getGenericIdeSetup(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
         protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
@@ -908,8 +908,8 @@ public class XtextGeneratorTemplates {
           _builder.append("*/");
           _builder.newLine();
           _builder.append("class ");
-          TypeReference _ideSetup = XtextGeneratorTemplates.this.naming.getIdeSetup(it);
-          String _simpleName = _ideSetup.getSimpleName();
+          TypeReference _genericIdeSetup = XtextGeneratorTemplates.this.naming.getGenericIdeSetup(it);
+          String _simpleName = _genericIdeSetup.getSimpleName();
           _builder.append(_simpleName, "");
           _builder.append(" extends ");
           TypeReference _runtimeSetup = XtextGeneratorTemplates.this.naming.getRuntimeSetup(it);
@@ -928,8 +928,8 @@ public class XtextGeneratorTemplates {
           TypeReference _runtimeModule = XtextGeneratorTemplates.this.naming.getRuntimeModule(it);
           _builder.append(_runtimeModule, "\t\t");
           _builder.append(", new ");
-          TypeReference _ideModule = XtextGeneratorTemplates.this.naming.getIdeModule(it);
-          _builder.append(_ideModule, "\t\t");
+          TypeReference _genericIdeModule = XtextGeneratorTemplates.this.naming.getGenericIdeModule(it);
+          _builder.append(_genericIdeModule, "\t\t");
           _builder.append("))");
           _builder.newLineIfNotEmpty();
           _builder.append("\t");
@@ -941,9 +941,9 @@ public class XtextGeneratorTemplates {
           _builder.newLine();
         }
       };
-      return this.fileAccessFactory.createXtendFile(_ideSetup, _client);
+      return this.fileAccessFactory.createXtendFile(_genericIdeSetup, _client);
     } else {
-      TypeReference _ideSetup_1 = this.naming.getIdeSetup(it);
+      TypeReference _genericIdeSetup_1 = this.naming.getGenericIdeSetup(it);
       StringConcatenationClient _client_1 = new StringConcatenationClient() {
         @Override
         protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
@@ -956,8 +956,8 @@ public class XtextGeneratorTemplates {
           _builder.append("*/");
           _builder.newLine();
           _builder.append("public class ");
-          TypeReference _ideSetup = XtextGeneratorTemplates.this.naming.getIdeSetup(it);
-          String _simpleName = _ideSetup.getSimpleName();
+          TypeReference _genericIdeSetup = XtextGeneratorTemplates.this.naming.getGenericIdeSetup(it);
+          String _simpleName = _genericIdeSetup.getSimpleName();
           _builder.append(_simpleName, "");
           _builder.append(" extends ");
           TypeReference _runtimeSetup = XtextGeneratorTemplates.this.naming.getRuntimeSetup(it);
@@ -982,8 +982,8 @@ public class XtextGeneratorTemplates {
           TypeReference _runtimeModule = XtextGeneratorTemplates.this.naming.getRuntimeModule(it);
           _builder.append(_runtimeModule, "\t\t");
           _builder.append("(), new ");
-          TypeReference _ideModule = XtextGeneratorTemplates.this.naming.getIdeModule(it);
-          _builder.append(_ideModule, "\t\t");
+          TypeReference _genericIdeModule = XtextGeneratorTemplates.this.naming.getGenericIdeModule(it);
+          _builder.append(_genericIdeModule, "\t\t");
           _builder.append("()));");
           _builder.newLineIfNotEmpty();
           _builder.append("\t");
@@ -995,7 +995,7 @@ public class XtextGeneratorTemplates {
           _builder.newLine();
         }
       };
-      return this.fileAccessFactory.createJavaFile(_ideSetup_1, _client_1);
+      return this.fileAccessFactory.createJavaFile(_genericIdeSetup_1, _client_1);
     }
   }
   
@@ -1465,8 +1465,8 @@ public class XtextGeneratorTemplates {
           TypeReference _runtimeModule = XtextGeneratorTemplates.this.naming.getRuntimeModule(it);
           _builder.append(_runtimeModule, "\t\t");
           _builder.append(", new ");
-          TypeReference _ideModule = XtextGeneratorTemplates.this.naming.getIdeModule(it);
-          _builder.append(_ideModule, "\t\t");
+          TypeReference _genericIdeModule = XtextGeneratorTemplates.this.naming.getGenericIdeModule(it);
+          _builder.append(_genericIdeModule, "\t\t");
           _builder.append(", new ");
           TypeReference _webModule = XtextGeneratorTemplates.this.naming.getWebModule(it);
           _builder.append(_webModule, "\t\t");
@@ -1523,8 +1523,8 @@ public class XtextGeneratorTemplates {
           TypeReference _runtimeModule = XtextGeneratorTemplates.this.naming.getRuntimeModule(it);
           _builder.append(_runtimeModule, "\t\t");
           _builder.append("(), new ");
-          TypeReference _ideModule = XtextGeneratorTemplates.this.naming.getIdeModule(it);
-          _builder.append(_ideModule, "\t\t");
+          TypeReference _genericIdeModule = XtextGeneratorTemplates.this.naming.getGenericIdeModule(it);
+          _builder.append(_genericIdeModule, "\t\t");
           _builder.append("(), new ");
           TypeReference _webModule = XtextGeneratorTemplates.this.naming.getWebModule(it);
           _builder.append(_webModule, "\t\t");


### PR DESCRIPTION
Signed-off-by: Christian Schneider <christian.schneider@typefox.io>

`XtextGeneratorNaming` contained methods like `getGenericIdeBasePackage` that were already released in 2.10 (even in 2.9 I guess). Additional methods like `getIdeBasePackage` were added as part of https://github.com/eclipse/xtext-core/issues/11 .

This PR consolidates those getters by removing the superfluous ones and switches the additional ones to the released name scheme.