### PR TITLE
[xtext.wizard] minor improvement of runtime project build file templates

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full/build.gradle
@@ -10,6 +10,7 @@ configurations {
 
 dependencies {
 	mwe2 "org.eclipse.emf:org.eclipse.emf.mwe2.launch:2.8.3"
+	mwe2 "org.eclipse.xtext:org.eclipse.xtext.common.types:${xtextVersion}"
 	mwe2 "org.eclipse.xtext:org.eclipse.xtext.xtext.generator:${xtextVersion}"
 }
 

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full/pom.xml
@@ -43,6 +43,11 @@
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>
+						<artifactId>org.eclipse.xtext.common.types</artifactId>
+						<version>${xtextVersion}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.xtext</groupId>
 						<artifactId>org.eclipse.xtext.xtext.generator</artifactId>
 						<version>${xtextVersion}</version>
 					</dependency>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.gradle/org.xtext.example.gradle.parent/org.xtext.example.gradle/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.gradle/org.xtext.example.gradle.parent/org.xtext.example.gradle/build.gradle
@@ -12,6 +12,7 @@ configurations {
 
 dependencies {
 	mwe2 "org.eclipse.emf:org.eclipse.emf.mwe2.launch:2.8.3"
+	mwe2 "org.eclipse.xtext:org.eclipse.xtext.common.types:${xtextVersion}"
 	mwe2 "org.eclipse.xtext:org.eclipse.xtext.xtext.generator:${xtextVersion}"
 }
 

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho/pom.xml
@@ -43,6 +43,11 @@
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>
+						<artifactId>org.eclipse.xtext.common.types</artifactId>
+						<version>${xtextVersion}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.xtext</groupId>
 						<artifactId>org.eclipse.xtext.xtext.generator</artifactId>
 						<version>${xtextVersion}</version>
 					</dependency>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2/pom.xml
@@ -43,6 +43,11 @@
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>
+						<artifactId>org.eclipse.xtext.common.types</artifactId>
+						<version>${xtextVersion}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.xtext</groupId>
 						<artifactId>org.eclipse.xtext.xtext.generator</artifactId>
 						<version>${xtextVersion}</version>
 					</dependency>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
@@ -275,6 +275,7 @@ class RuntimeProjectDescriptor extends TestedProjectDescriptor {
 
 				dependencies {
 					mwe2 "org.eclipse.emf:org.eclipse.emf.mwe2.launch:«config.xtextVersion.mweVersion»"
+					mwe2 "org.eclipse.xtext:org.eclipse.xtext.common.types:${xtextVersion}"
 					mwe2 "org.eclipse.xtext:org.eclipse.xtext.xtext.generator:${xtextVersion}"
 					«IF fromExistingEcoreModels»
 						mwe2 "org.eclipse.xtext:org.eclipse.xtext.generator:${xtextVersion}"
@@ -351,6 +352,11 @@ class RuntimeProjectDescriptor extends TestedProjectDescriptor {
 										<groupId>org.eclipse.emf</groupId>
 										<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
 										<version>«config.xtextVersion.mweVersion»</version>
+									</dependency>
+									<dependency>
+										<groupId>org.eclipse.xtext</groupId>
+										<artifactId>org.eclipse.xtext.common.types</artifactId>
+										<version>${xtextVersion}</version>
 									</dependency>
 									<dependency>
 										<groupId>org.eclipse.xtext</groupId>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
@@ -652,6 +652,9 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
       _builder.append("\"");
       _builder.newLineIfNotEmpty();
       _builder.append("\t");
+      _builder.append("mwe2 \"org.eclipse.xtext:org.eclipse.xtext.common.types:${xtextVersion}\"");
+      _builder.newLine();
+      _builder.append("\t");
       _builder.append("mwe2 \"org.eclipse.xtext:org.eclipse.xtext.xtext.generator:${xtextVersion}\"");
       _builder.newLine();
       {
@@ -911,6 +914,26 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
           _builder.append(_mweVersion, "\t\t\t\t\t");
           _builder.append("</version>");
           _builder.newLineIfNotEmpty();
+          _builder.append("\t\t\t");
+          _builder.append("\t");
+          _builder.append("</dependency>");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t");
+          _builder.append("<dependency>");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t\t");
+          _builder.append("<groupId>org.eclipse.xtext</groupId>");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t\t");
+          _builder.append("<artifactId>org.eclipse.xtext.common.types</artifactId>");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t\t");
+          _builder.append("<version>${xtextVersion}</version>");
+          _builder.newLine();
           _builder.append("\t\t\t");
           _builder.append("\t");
           _builder.append("</dependency>");


### PR DESCRIPTION
This PR adds `org.eclipse.xtext.common.types` to the dependencies of MWE executions in 'RuntimeProjectDescriptor's build file templates.
Currently `org.eclipse.xtext.xbase` is added to the compile dependencies of runtime projects by default, but if people decide not including xbase anymore the workflow execution doesn't work anymore.

Signed-off-by: Christian Schneider <christian.schneider@typefox.io>