### PR TITLE
Apply Xtend Gradle plugin during the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,8 @@
 import java.time.format.DateTimeFormatter
 import java.time.LocalDateTime
 
-apply from: "${rootDir}/gradle/versions.gradle"
-apply from: "${rootDir}/gradle/bootstrap-setup.gradle"
-
 buildscript {
+	apply from: "${rootDir}/gradle/versions.gradle"
 	repositories {
 		jcenter()
 		maven {
@@ -16,12 +14,13 @@ buildscript {
 		}
 	}
 	dependencies {
-		classpath 'org.xtext:xtext-gradle-plugin:1.0.14'
+		classpath "org.xtext:xtext-gradle-plugin:$versions.xtend_plugin"
 		classpath 'io.typefox.gradle:io.typefox.gradle.p2gen:0.1.0'
 	}
 }
 
 apply from: "${rootDir}/gradle/versions.gradle"
+apply from: "${rootDir}/gradle/bootstrap-setup.gradle"
 apply from: "${rootDir}/gradle/p2-deployment.gradle"
 
 ext.buildTime = DateTimeFormatter.ofPattern('yyyyMMdd-HHmm').format(LocalDateTime.now())

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,12 @@
  * Root project for xtext-core.
  */
 
+import java.time.format.DateTimeFormatter
+import java.time.LocalDateTime
+
+apply from: "${rootDir}/gradle/versions.gradle"
+apply from: "${rootDir}/gradle/bootstrap-setup.gradle"
+
 buildscript {
 	repositories {
 		jcenter()
@@ -10,6 +16,7 @@ buildscript {
 		}
 	}
 	dependencies {
+		classpath 'org.xtext:xtext-gradle-plugin:1.0.12'
 		classpath 'io.typefox.gradle:io.typefox.gradle.p2gen:0.1.0'
 	}
 }
@@ -17,18 +24,20 @@ buildscript {
 apply from: "${rootDir}/gradle/versions.gradle"
 apply from: "${rootDir}/gradle/p2-deployment.gradle"
 
-ext.buildTime = new java.text.SimpleDateFormat('yyyyMMdd-HHmm').format(new Date())
+ext.buildTime = DateTimeFormatter.ofPattern('yyyyMMdd-HHmm').format(LocalDateTime.now())
 
 subprojects {
 	group = 'org.eclipse.xtext'
 	version = rootProject.version
 	
 	apply plugin: 'java'
+	apply plugin: 'org.xtext.xtend'
 	apply plugin: 'eclipse'
 	apply plugin: 'maven'
 	
 	apply from: "${rootDir}/gradle/upstream-repositories.gradle"
 	apply from: "${rootDir}/gradle/java-compiler-settings.gradle"
+	apply from: "${rootDir}/gradle/xtend-compiler-settings.gradle"
 	apply from: "${rootDir}/gradle/maven-deployment.gradle"
 	apply from: "${rootDir}/gradle/eclipse-project-layout.gradle"
 	apply from: "${rootDir}/gradle/manifest-gen.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 		}
 	}
 	dependencies {
-		classpath 'org.xtext:xtext-gradle-plugin:1.0.12'
+		classpath 'org.xtext:xtext-gradle-plugin:1.0.14'
 		classpath 'io.typefox.gradle:io.typefox.gradle.p2gen:0.1.0'
 	}
 }

--- a/gradle/bootstrap-setup.gradle
+++ b/gradle/bootstrap-setup.gradle
@@ -1,0 +1,25 @@
+/*
+ * Root project configuration that is reused by subprojects to apply the Xtend compiler.
+ */
+
+repositories.jcenter()
+
+configurations {
+	xtendCompiler {
+		description 'Bootstrap dependencies for the Xtend compiler'
+		resolutionStrategy {
+			eachDependency {
+				if (requested.group == 'org.eclipse.xtext' || requested.group == 'org.eclipse.xtend')
+					useVersion(versions.xtext_bootstrap)
+				if (requested.group == 'com.google.inject' && requested.name == 'guice')
+					useVersion(versions.guice)
+			}
+		}
+		exclude group: 'asm'
+	}
+}
+
+dependencies {
+	xtendCompiler "org.eclipse.xtend:org.eclipse.xtend.core:$versions.xtext_bootstrap"
+	xtendCompiler "org.xtext:xtext-gradle-builder:$versions.xtend_plugin"
+}

--- a/gradle/bootstrap-setup.gradle
+++ b/gradle/bootstrap-setup.gradle
@@ -2,7 +2,14 @@
  * Root project configuration that is reused by subprojects to apply the Xtend compiler.
  */
 
-repositories.jcenter()
+// The repositories to query when constructing the Xtend compiler classpath
+repositories {
+	jcenter()
+	maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+}
+
+// The Xtend compiler version to use
+def bootstrapXtendVersion = versions.xtext
 
 configurations {
 	xtendCompiler {
@@ -10,7 +17,7 @@ configurations {
 		resolutionStrategy {
 			eachDependency {
 				if (requested.group == 'org.eclipse.xtext' || requested.group == 'org.eclipse.xtend')
-					useVersion(versions.xtext_bootstrap)
+					useVersion(bootstrapXtendVersion)
 				if (requested.group == 'com.google.inject' && requested.name == 'guice')
 					useVersion(versions.guice)
 			}
@@ -20,6 +27,6 @@ configurations {
 }
 
 dependencies {
-	xtendCompiler "org.eclipse.xtend:org.eclipse.xtend.core:$versions.xtext_bootstrap"
+	xtendCompiler "org.eclipse.xtend:org.eclipse.xtend.core:$bootstrapXtendVersion"
 	xtendCompiler "org.xtext:xtext-gradle-builder:$versions.xtend_plugin"
 }

--- a/gradle/eclipse-project-layout.gradle
+++ b/gradle/eclipse-project-layout.gradle
@@ -4,17 +4,18 @@
  */
 
 def isTestProject = name.endsWith('tests')
-def sourceDirs = ['src', 'xtend-gen', 'src-gen', 'emf-gen']
+def sourceDirs = ['src', 'src-gen', 'emf-gen']
 
 sourceSets {
 	configure(isTestProject? test : main) {
 		java {
 			srcDirs = sourceDirs
 			include '**/*.java', '**/*.xtend'
+			xtendOutputDir = 'xtend-gen'
 		}
 		resources {
 			srcDirs = sourceDirs
-			exclude '**/*.java', '**/*.xtend', '**/*.xtendbin', '**/*._trace'
+			exclude '**/*.java', '**/*.xtend'
 		}
 	}
 	configure(isTestProject? main : test) {
@@ -47,18 +48,10 @@ if (isTestProject || name.contains('testlanguage')) {
 	artifacts.archives javadocJar
 }
 
-eclipse {
-	classpath {
-		file {
-			whenMerged {
-				entries.each {
-					source ->
-					if (source.kind == 'src' && source.path.endsWith('-gen') && !source.path.equals('xtend-gen') ) {
-						source.entryAttributes['ignore_optional_problems'] = 'true'
-					}
-					
-				}
-			}
+eclipse.classpath.file.whenMerged {
+	entries.each { source ->
+		if (source.kind == 'src' && source.path.endsWith('-gen') && !source.path.equals('xtend-gen') ) {
+			source.entryAttributes['ignore_optional_problems'] = 'true'
 		}
 	}
 }

--- a/gradle/eclipse-project-layout.gradle
+++ b/gradle/eclipse-project-layout.gradle
@@ -11,12 +11,12 @@ sourceSets {
 		java {
 			srcDirs = sourceDirs
 			include '**/*.java', '**/*.xtend'
-			xtendOutputDir = 'xtend-gen'
 		}
 		resources {
 			srcDirs = sourceDirs
 			exclude '**/*.java', '**/*.xtend'
 		}
+		xtendOutputDir = 'xtend-gen'
 	}
 	configure(isTestProject? main : test) {
 		java.srcDirs = []
@@ -35,6 +35,15 @@ jar {
 sourcesJar {
 	from ('.') {
 		include 'about*.*'
+	}
+	if (isTestProject) {
+		from (sourceSets.test.xtendOutputDir) {
+			include '**/*._trace'
+		}
+	} else {
+		from (sourceSets.main.xtendOutputDir) {
+			include '**/*._trace'
+		}
 	}
 }
 

--- a/gradle/eclipse-project-layout.gradle
+++ b/gradle/eclipse-project-layout.gradle
@@ -36,15 +36,6 @@ sourcesJar {
 	from ('.') {
 		include 'about*.*'
 	}
-	if (isTestProject) {
-		from (sourceSets.test.xtendOutputDir) {
-			include '**/*._trace'
-		}
-	} else {
-		from (sourceSets.main.xtendOutputDir) {
-			include '**/*._trace'
-		}
-	}
 }
 
 if (isTestProject || name.contains('testlanguage')) {
@@ -57,10 +48,21 @@ if (isTestProject || name.contains('testlanguage')) {
 	artifacts.archives javadocJar
 }
 
-eclipse.classpath.file.whenMerged {
-	entries.each { source ->
-		if (source.kind == 'src' && source.path.endsWith('-gen') && !source.path.equals('xtend-gen') ) {
-			source.entryAttributes['ignore_optional_problems'] = 'true'
+// Configuration of meta data required by the Eclipse IDE
+eclipse {
+	classpath {
+		plusConfigurations += [configurations.optional]
+		plusConfigurations += [configurations.mwe2Runtime]
+		file.whenMerged {
+			entries.each { source ->
+				if (source.kind == 'src' && source.path.endsWith('-gen') && !source.path.equals('xtend-gen') ) {
+					source.entryAttributes['ignore_optional_problems'] = 'true'
+				}
+			}
 		}
+	}
+	project {
+		natures 'org.eclipse.xtext.ui.shared.xtextNature'
+		buildCommands.add(0,new org.gradle.plugins.ide.eclipse.model.BuildCommand('org.eclipse.xtext.ui.shared.xtextBuilder'))
 	}
 }

--- a/gradle/java-compiler-settings.gradle
+++ b/gradle/java-compiler-settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Configuration of Java compiler, Javadoc, and additional dependency configurations.
+ * Configuration of Java compiler, Javadoc, additional archives, and additional dependency configurations.
  */
 
 plugins.withType(JavaBasePlugin) {
@@ -16,6 +16,24 @@ tasks.withType(Javadoc) {
 	options.addStringOption('Xdoclint:none', '-quiet')
 }
 
+task sourcesJar(type: Jar, dependsOn: classes) {
+	group 'Build'
+	description 'Assembles a jar archive containing the sources.'
+	classifier = 'sources'
+	from sourceSets.main.allSource
+	from ('.') {
+		include 'schema/**', 'model/**'
+	}
+}
+artifacts.archives sourcesJar
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+	group 'Build'
+	description 'Assembles a jar archive containing the JavaDoc output.'
+	classifier = 'javadoc'
+	from javadoc.destinationDir
+}
+
 sourceSets {
 	mwe2 {}
 }
@@ -28,9 +46,7 @@ configurations {
 	mwe2Compile.extendsFrom mainCompile
 	mwe2Runtime.extendsFrom mainRuntime
 	
-	/*
-	 * Put any unwanted transitive dependencies here, they will be excluded from all projects
-	 */
+	// Put any unwanted transitive dependencies here, they will be excluded from all projects.
 	all {
 		exclude group: 'org.apache.felix', module: 'org.osgi.foundation'
 		exclude group: 'org.antlr', module: 'stringtemplate'
@@ -42,13 +58,3 @@ sourceSets.main.compileClasspath += configurations.optional
 sourceSets.test.compileClasspath += configurations.optional
 sourceSets.test.runtimeClasspath += configurations.optional
 javadoc.classpath += configurations.optional
-
-eclipse {
-	classpath.plusConfigurations += [configurations.optional]
-	classpath.plusConfigurations += [configurations.mwe2Runtime]
-
-	project {
-		natures 'org.eclipse.xtext.ui.shared.xtextNature'
-		buildCommands.add(0,new org.gradle.plugins.ide.eclipse.model.BuildCommand('org.eclipse.xtext.ui.shared.xtextBuilder'))
-	}
-}

--- a/gradle/java-compiler-settings.gradle
+++ b/gradle/java-compiler-settings.gradle
@@ -2,9 +2,7 @@
  * Configuration of Java compiler, Javadoc, additional archives, and additional dependency configurations.
  */
 
-plugins.withType(JavaBasePlugin) {
-	sourceCompatibility = '1.8'
-}
+sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'ISO-8859-1'

--- a/gradle/maven-deployment.gradle
+++ b/gradle/maven-deployment.gradle
@@ -1,24 +1,6 @@
 /*
- * Configuration of artifacts to be deployed in Maven repositories.
+ * Configuration of deployment to Maven repositories.
  */
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-	group 'Build'
-	description 'Assembles a jar archive containing the sources.'
-	classifier = 'sources'
-	from sourceSets.main.allSource
-	from ('.') {
-		include 'schema/**', 'model/**'
-	}
-}
-artifacts.archives sourcesJar
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-	group 'Build'
-	description 'Assembles a jar archive containing the JavaDoc output.'
-	classifier = 'javadoc'
-	from javadoc.destinationDir
-}
 
 // Configuration function for generated POMs
 def configurePom = { pom ->

--- a/gradle/maven-deployment.gradle
+++ b/gradle/maven-deployment.gradle
@@ -53,7 +53,7 @@ afterEvaluate {
 		description = 'Create or update the local Maven repository'
 		configuration = configurations.archives
 		repositories.mavenDeployer {
-			repository(url: "file:" + file("../build/maven-repository"))
+			repository(url: "file:" + file("${rootDir}/build/maven-repository"))
 			configurePom(pom)
 		}
 	}

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -6,7 +6,8 @@ version = '2.11.0-SNAPSHOT'
 
 ext.versions = [
 	'xtext': version,
-	'xtext_bootstrap': '2.10.0',
+	'xtext_bootstrap': '2.11.0.beta2',
+	'xtend_plugin': '1.0.12',
 	'lsp4j': '0.1.0-SNAPSHOT',
 	'log4j': '1.2.16',
 	'equinoxCommon' : '3.6.0',

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -7,7 +7,7 @@ version = '2.11.0-SNAPSHOT'
 ext.versions = [
 	'xtext': version,
 	'xtext_bootstrap': '2.11.0.beta2',
-	'xtend_plugin': '1.0.12',
+	'xtend_plugin': '1.0.14',
 	'lsp4j': '0.1.0-SNAPSHOT',
 	'log4j': '1.2.16',
 	'equinoxCommon' : '3.6.0',

--- a/gradle/xtend-compiler-settings.gradle
+++ b/gradle/xtend-compiler-settings.gradle
@@ -1,0 +1,7 @@
+/*
+ * Configuration of Xtend compiler.
+ */
+
+xtext.version = versions.xtext_bootstrap
+
+generateXtext.xtextClasspath = rootProject.configurations.getByName('xtendCompiler')

--- a/gradle/xtend-compiler-settings.gradle
+++ b/gradle/xtend-compiler-settings.gradle
@@ -2,6 +2,18 @@
  * Configuration of Xtend compiler.
  */
 
-xtext.version = versions.xtext_bootstrap
-
 generateXtext.xtextClasspath = rootProject.configurations.getByName('xtendCompiler')
+
+def isTestProject = name.endsWith('tests')
+
+sourcesJar {
+	if (isTestProject) {
+		from (sourceSets.test.xtendOutputDir) {
+			include '**/*._trace'
+		}
+	} else {
+		from (sourceSets.main.xtendOutputDir) {
+			include '**/*._trace'
+		}
+	}
+}

--- a/gradle/xtend-compiler-settings.gradle
+++ b/gradle/xtend-compiler-settings.gradle
@@ -2,17 +2,16 @@
  * Configuration of Xtend compiler.
  */
 
-generateXtext.xtextClasspath = rootProject.configurations.getByName('xtendCompiler')
-
-def isTestProject = name.endsWith('tests')
+[generateXtext, generateTestXtext].each { gen ->
+	gen.xtextClasspath = rootProject.configurations.getByName('xtendCompiler')
+}
 
 sourcesJar {
-	if (isTestProject) {
+	from (sourceSets.main.xtendOutputDir) {
+		include '**/*._trace'
+	}
+	if (name.endsWith('tests')) {
 		from (sourceSets.test.xtendOutputDir) {
-			include '**/*._trace'
-		}
-	} else {
-		from (sourceSets.main.xtendOutputDir) {
 			include '**/*._trace'
 		}
 	}

--- a/org.eclipse.xtext.xtext.bootstrap/build.gradle
+++ b/org.eclipse.xtext.xtext.bootstrap/build.gradle
@@ -1,41 +1,34 @@
-// re-configure the 'main' and 'mwe2' sourceSets as the content of this project's
-//  source folders need to be compiled before the generator execution
+// Re-configure the 'main' and 'mwe2' sourceSets as the content of this project's
+// source folders need to be compiled before the generator execution.
 sourceSets {
 	main.java.srcDirs = []
 	main.resources.srcDirs = []
-	
-	// the 'mwe2' sourceSet is declared in '../gradle/java-compiler-settings.gradle' 
-	mwe2.java.srcDirs = [ 'src', 'xtend-gen' ]
+	mwe2.java.srcDirs = [ 'src' ]
 }
 
 dependencies {
-	// we cannot use the projects within the workspace, as we would have
-	//  to compile them before generating the code, so we need to stick to the bootstrapping version
-	// buildship, however, links the workspace projects anyway (as yet)  
+	// We cannot use the projects within the workspace, as we would have
+	// to compile them before generating the code, so we need to stick to the bootstrapping version.
+	// Buildship, however, links the workspace projects anyway (as yet).
 	mwe2Compile "org.eclipse.xtext:org.eclipse.xtext:$versions.xtext_bootstrap"
 	mwe2Compile "org.eclipse.xtext:org.eclipse.xtext.xtext.generator:$versions.xtext_bootstrap"
 	
-	// dependencies required for successfully executing the Xtext generation workflow
+	// Dependencies required for successfully executing the Xtext generation workflow
 	mwe2Runtime "org.eclipse.emf:org.eclipse.emf.mwe2.launch:$versions.emfMwe2"
 	mwe2Runtime "org.eclipse.xtext:org.eclipse.xtext.common.types:$versions.xtext_bootstrap"
 	mwe2Runtime "org.eclipse.xtext:org.eclipse.xtext.ecore:$versions.xtext_bootstrap"
 }
 
-/**
- * Call this task for generating the 'Xtext' language implementation.
- * The employed version of the Xtext generator is determined by '$versions.xtext_bootstrap', see above.
- */
+// Call this task for generating the 'Xtext' language implementation.
+// The employed version of the Xtext generator is determined by '$versions.xtext_bootstrap', see above.
 task generateXtextLanguage(type: JavaExec) {
 	main = 'org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher'
-	
 	classpath = sourceSets.mwe2.runtimeClasspath
-				// includes mwe2Runtime+mwe2Compile dependencies + the classes obtained from sourceSets.mwe2.java.srcDirs
-	
 	args += "src/org/eclipse/xtext/xtext/bootstrap/GenerateXtext.mwe2"
 	args += "-p"
 	args += "rootPath=/${projectDir}/.."
 }
 
-// the following setting would cause 'generateXtextLanguage' to be executed as part of 'build',
-//  namely before compiling the classes of the 'main' sourceSet, which however is empty here
+// The following setting would cause 'generateXtextLanguage' to be executed as part of 'build',
+// namely before compiling the classes of the 'main' sourceSet, which however is empty here.
 // classes.dependsOn(generateXtextLanguage)

--- a/org.eclipse.xtext.xtext.bootstrap/build.gradle
+++ b/org.eclipse.xtext.xtext.bootstrap/build.gradle
@@ -1,17 +1,9 @@
-// Re-configure the 'main' and 'mwe2' sourceSets as the content of this project's
-// source folders need to be compiled before the generator execution.
-sourceSets {
-	main.java.srcDirs = []
-	main.resources.srcDirs = []
-	mwe2.java.srcDirs = [ 'src' ]
-}
-
 dependencies {
 	// We cannot use the projects within the workspace, as we would have
 	// to compile them before generating the code, so we need to stick to the bootstrapping version.
 	// Buildship, however, links the workspace projects anyway (as yet).
-	mwe2Compile "org.eclipse.xtext:org.eclipse.xtext:$versions.xtext_bootstrap"
-	mwe2Compile "org.eclipse.xtext:org.eclipse.xtext.xtext.generator:$versions.xtext_bootstrap"
+	compile "org.eclipse.xtext:org.eclipse.xtext:$versions.xtext_bootstrap"
+	compile "org.eclipse.xtext:org.eclipse.xtext.xtext.generator:$versions.xtext_bootstrap"
 	
 	// Dependencies required for successfully executing the Xtext generation workflow
 	mwe2Runtime "org.eclipse.emf:org.eclipse.emf.mwe2.launch:$versions.emfMwe2"


### PR DESCRIPTION
This ensures that the source mapping is set up correctly in the build artifacts.