### PR TITLE
Fixed CrossReferenceSerializer regression for special proxy URI formats

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/SequencerTestLanguageStandaloneSetup.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/SequencerTestLanguageStandaloneSetup.java
@@ -5,7 +5,7 @@ package org.eclipse.xtext.serializer;
  * Initialization support for running Xtext languages 
  * without equinox extension registry
  */
-public class SequencerTestLanguageStandaloneSetup extends SequencerTestLanguageStandaloneSetupGenerated{
+public class SequencerTestLanguageStandaloneSetup extends SequencerTestLanguageStandaloneSetupGenerated {
 
 	public static void doSetup() {
 		new SequencerTestLanguageStandaloneSetup().createInjectorAndDoEMFRegistration();

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/SyntacticSequencerTestLanguageInjectorProvider.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/SyntacticSequencerTestLanguageInjectorProvider.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.serializer;
+
+import org.eclipse.xtext.testing.GlobalRegistries;
+import org.eclipse.xtext.testing.GlobalRegistries.GlobalStateMemento;
+import org.eclipse.xtext.testing.IInjectorProvider;
+import org.eclipse.xtext.testing.IRegistryConfigurator;
+
+import com.google.inject.Injector;
+
+public class SyntacticSequencerTestLanguageInjectorProvider implements IInjectorProvider, IRegistryConfigurator {
+
+	protected GlobalStateMemento stateBeforeInjectorCreation;
+	protected GlobalStateMemento stateAfterInjectorCreation;
+	protected Injector injector;
+
+	static {
+		GlobalRegistries.initializeDefaults();
+	}
+
+	@Override
+	public Injector getInjector() {
+		if (injector == null) {
+			stateBeforeInjectorCreation = GlobalRegistries.makeCopyOfGlobalState();
+			this.injector = internalCreateInjector();
+			stateAfterInjectorCreation = GlobalRegistries.makeCopyOfGlobalState();
+		}
+		return injector;
+	}
+
+	protected Injector internalCreateInjector() {
+		return new SyntacticSequencerTestLanguageStandaloneSetup().createInjectorAndDoEMFRegistration();
+	}
+
+	@Override
+	public void restoreRegistry() {
+		stateBeforeInjectorCreation.restoreGlobalState();
+	}
+
+	@Override
+	public void setupRegistry() {
+		getInjector();
+		stateAfterInjectorCreation.restoreGlobalState();
+	}
+}

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/TokenSerializerTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/TokenSerializerTest.xtend
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.serializer
+
+import com.google.inject.Inject
+import com.google.inject.Provider
+import org.eclipse.emf.common.util.URI
+import org.eclipse.emf.ecore.InternalEObject
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.xtext.resource.DefaultFragmentProvider
+import org.eclipse.xtext.resource.FileExtensionProvider
+import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.resource.XtextResourceSet
+import org.eclipse.xtext.serializer.syntacticsequencertest.Model
+import org.eclipse.xtext.serializer.syntacticsequencertest.SyntacticsequencertestFactory
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static org.junit.Assert.*
+
+@RunWith(XtextRunner)
+@InjectWith(SyntacticSequencerTestLanguageInjectorProvider)
+class TokenSerializerTest {
+	
+	@Inject extension ISerializer
+	
+	@Inject FileExtensionProvider fileExtensionProvider
+	
+	@Inject Provider<XtextResourceSet> resourceSetProvider
+	
+	val factory = SyntacticsequencertestFactory.eINSTANCE
+	
+	private def assertSerializesTo(Model model, CharSequence expectation) {
+		assertEquals(expectation.toString.trim, model.serialize.trim)
+	}
+	
+	private def getFileURI(String name) {
+		URI.createFileURI(name + '.' + fileExtensionProvider.primaryFileExtension)
+	}
+	
+	@Test
+	def void testConstructedCrossReferenceWithProxy() {
+		val resourceSet = resourceSetProvider.get
+		val resource = resourceSet.createResource('dummy'.fileURI) as XtextResource
+		val model = factory.createModel => [
+			x5 = factory.createSingleCrossReference => [
+				name = 'myref'
+			]
+		]
+		resource.contents += model
+		model.x5.ref3 = factory.createSingleCrossReference => [
+			(it as InternalEObject).eSetProxyURI(resource.URI.appendFragment('foo'))
+		]
+		resource.fragmentProvider = new DefaultFragmentProvider {
+			override getEObject(Resource resource, String fragment, Fallback fallback) {
+				if (fragment == 'foo')
+					model.x5
+				else
+					super.getEObject(resource, fragment, fallback)
+			}
+		}
+		model.assertSerializesTo('''
+			#5 myref kw3 myref
+		''')
+	}
+	
+}

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/serializer/TokenSerializerTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/serializer/TokenSerializerTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.serializer;
+
+import com.google.common.base.Objects;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.resource.DefaultFragmentProvider;
+import org.eclipse.xtext.resource.FileExtensionProvider;
+import org.eclipse.xtext.resource.IFragmentProvider;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.resource.XtextResourceSet;
+import org.eclipse.xtext.serializer.ISerializer;
+import org.eclipse.xtext.serializer.SyntacticSequencerTestLanguageInjectorProvider;
+import org.eclipse.xtext.serializer.syntacticsequencertest.Model;
+import org.eclipse.xtext.serializer.syntacticsequencertest.SingleCrossReference;
+import org.eclipse.xtext.serializer.syntacticsequencertest.SyntacticsequencertestFactory;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(XtextRunner.class)
+@InjectWith(SyntacticSequencerTestLanguageInjectorProvider.class)
+@SuppressWarnings("all")
+public class TokenSerializerTest {
+  @Inject
+  @Extension
+  private ISerializer _iSerializer;
+  
+  @Inject
+  private FileExtensionProvider fileExtensionProvider;
+  
+  @Inject
+  private Provider<XtextResourceSet> resourceSetProvider;
+  
+  private final SyntacticsequencertestFactory factory = SyntacticsequencertestFactory.eINSTANCE;
+  
+  private void assertSerializesTo(final Model model, final CharSequence expectation) {
+    Assert.assertEquals(expectation.toString().trim(), this._iSerializer.serialize(model).trim());
+  }
+  
+  private URI getFileURI(final String name) {
+    String _primaryFileExtension = this.fileExtensionProvider.getPrimaryFileExtension();
+    String _plus = ((name + ".") + _primaryFileExtension);
+    return URI.createFileURI(_plus);
+  }
+  
+  @Test
+  public void testConstructedCrossReferenceWithProxy() {
+    final XtextResourceSet resourceSet = this.resourceSetProvider.get();
+    Resource _createResource = resourceSet.createResource(this.getFileURI("dummy"));
+    final XtextResource resource = ((XtextResource) _createResource);
+    Model _createModel = this.factory.createModel();
+    final Procedure1<Model> _function = (Model it) -> {
+      SingleCrossReference _createSingleCrossReference = this.factory.createSingleCrossReference();
+      final Procedure1<SingleCrossReference> _function_1 = (SingleCrossReference it_1) -> {
+        it_1.setName("myref");
+      };
+      SingleCrossReference _doubleArrow = ObjectExtensions.<SingleCrossReference>operator_doubleArrow(_createSingleCrossReference, _function_1);
+      it.setX5(_doubleArrow);
+    };
+    final Model model = ObjectExtensions.<Model>operator_doubleArrow(_createModel, _function);
+    EList<EObject> _contents = resource.getContents();
+    _contents.add(model);
+    SingleCrossReference _x5 = model.getX5();
+    SingleCrossReference _createSingleCrossReference = this.factory.createSingleCrossReference();
+    final Procedure1<SingleCrossReference> _function_1 = (SingleCrossReference it) -> {
+      ((InternalEObject) it).eSetProxyURI(resource.getURI().appendFragment("foo"));
+    };
+    SingleCrossReference _doubleArrow = ObjectExtensions.<SingleCrossReference>operator_doubleArrow(_createSingleCrossReference, _function_1);
+    _x5.setRef3(_doubleArrow);
+    resource.setFragmentProvider(new DefaultFragmentProvider() {
+      @Override
+      public EObject getEObject(final Resource resource, final String fragment, final IFragmentProvider.Fallback fallback) {
+        EObject _xifexpression = null;
+        boolean _equals = Objects.equal(fragment, "foo");
+        if (_equals) {
+          _xifexpression = model.getX5();
+        } else {
+          _xifexpression = super.getEObject(resource, fragment, fallback);
+        }
+        return _xifexpression;
+      }
+    });
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("#5 myref kw3 myref");
+    _builder.newLine();
+    this.assertSerializesTo(model, _builder);
+  }
+}


### PR DESCRIPTION
The new TokenSerializerTest reveals the regression: output without the fix is

```
java.lang.RuntimeException: No EObjectDescription could be found in Scope SingleCrossReference.ref3 for SingleCrossReference
Semantic Object: Model.x5->SingleCrossReference'myref'
URI: dummy.syntacticsequencertestlanguage
EStructuralFeature: syntacticsequencertest::SingleCrossReference.ref3
	at org.eclipse.xtext.serializer.diagnostic.ISerializationDiagnostic$ExceptionThrowingAcceptor.accept(ISerializationDiagnostic.java:131)
	at org.eclipse.xtext.serializer.tokens.CrossReferenceSerializer.getCrossReferenceNameFromScope(CrossReferenceSerializer.java:140)
	at org.eclipse.xtext.serializer.tokens.CrossReferenceSerializer.serializeCrossRef(CrossReferenceSerializer.java:113)
	at org.eclipse.xtext.serializer.acceptor.SequenceFeeder.getToken(SequenceFeeder.java:481)
	at org.eclipse.xtext.serializer.acceptor.SequenceFeeder.accept(SequenceFeeder.java:244)
	at org.eclipse.xtext.serializer.sequencer.BacktrackingSemanticSequencer.accept(BacktrackingSemanticSequencer.java:441)
	at org.eclipse.xtext.serializer.sequencer.BacktrackingSemanticSequencer.createSequence(BacktrackingSemanticSequencer.java:501)
	at org.eclipse.xtext.serializer.serializer.AbstractSyntacticSequencerTestLanguageSemanticSequencer.sequence_SingleCrossReference(AbstractSyntacticSequencerTestLanguageSemanticSequencer.java:550)
	at org.eclipse.xtext.serializer.serializer.AbstractSyntacticSequencerTestLanguageSemanticSequencer.sequence(AbstractSyntacticSequencerTestLanguageSemanticSequencer.java:108)
	at org.eclipse.xtext.serializer.sequencer.AbstractSemanticSequencer.createSequence(AbstractSemanticSequencer.java:67)
	at org.eclipse.xtext.serializer.acceptor.SequenceFeeder.acceptEObjectRuleCall(SequenceFeeder.java:325)
	at org.eclipse.xtext.serializer.acceptor.SequenceFeeder.acceptRuleCall(SequenceFeeder.java:352)
	at org.eclipse.xtext.serializer.acceptor.SequenceFeeder.accept(SequenceFeeder.java:246)
	at org.eclipse.xtext.serializer.sequencer.BacktrackingSemanticSequencer.accept(BacktrackingSemanticSequencer.java:441)
	at org.eclipse.xtext.serializer.sequencer.BacktrackingSemanticSequencer.createSequence(BacktrackingSemanticSequencer.java:501)
	at org.eclipse.xtext.serializer.serializer.AbstractSyntacticSequencerTestLanguageSemanticSequencer.sequence_Model(AbstractSyntacticSequencerTestLanguageSemanticSequencer.java:405)
	at org.eclipse.xtext.serializer.serializer.AbstractSyntacticSequencerTestLanguageSemanticSequencer.sequence(AbstractSyntacticSequencerTestLanguageSemanticSequencer.java:96)
	at org.eclipse.xtext.serializer.sequencer.AbstractSemanticSequencer.createSequence(AbstractSemanticSequencer.java:67)
	at org.eclipse.xtext.serializer.impl.Serializer.serialize(Serializer.java:115)
	at org.eclipse.xtext.serializer.impl.Serializer.serialize(Serializer.java:128)
	at org.eclipse.xtext.serializer.impl.Serializer.serialize(Serializer.java:178)
	at org.eclipse.xtext.serializer.impl.Serializer.serialize(Serializer.java:55)
	at org.eclipse.xtext.serializer.TokenSerializerTest.assertSerializesTo(TokenSerializerTest.java:55)
	at org.eclipse.xtext.serializer.TokenSerializerTest.testConstructedCrossReferenceWithProxy(TokenSerializerTest.java:104)
```