### PR TITLE
[generator] Some fixes

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/LanguageModule.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/LanguageModule.xtend
@@ -18,19 +18,19 @@ package class LanguageModule extends AbstractGenericModule {
 	
 	val XtextGeneratorLanguage language
 	
-	def configureLanguage(Binder binder) {
-		binder.bind(IXtextGeneratorLanguage).toInstance(language)
+	def void configureLanguage(Binder binder) {
+		binder.bind(IXtextGeneratorLanguage).toProvider[language]
 	}
 	
-	def configureGrammar(Binder binder) {
+	def void configureGrammar(Binder binder) {
 		binder.bind(Grammar).toProvider[language.grammar]
 	}
 	
-	def configureRuleNames(Binder binder) {
+	def void configureRuleNames(Binder binder) {
 		binder.bind(RuleNames).toProvider[language.ruleNames]
 	}
 	
-	def configureAdditionalBindings(Binder binder) {
+	def void configureAdditionalBindings(Binder binder) {
 		binder.install(language.guiceModule)
 	}
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.xtend
@@ -130,7 +130,7 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 	
 	override initialize(Injector injector) {
 		fragments.addAll(0, implicitFragments)
-		injector.injectMembers(XtextGeneratorLanguage)
+		injector.injectMembers(this)
 		if (resourceSet === null)
 			resourceSet = resourceSetProvider.get()
 		resourceSetInitializer.initialize(resourceSet, referencedResources)
@@ -167,7 +167,7 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 	protected def List<? extends IXtextGeneratorFragment> getImplicitFragments() {
 		val fragments = newArrayList
 		fragments += new ImplicitFragment
-		fragments
+		return fragments
 	}
 	
 	def void initialize(Grammar grammar) {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/LanguageModule.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/LanguageModule.java
@@ -9,7 +9,6 @@ package org.eclipse.xtext.xtext.generator;
 
 import com.google.inject.Binder;
 import com.google.inject.Provider;
-import com.google.inject.binder.ScopedBindingBuilder;
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 import org.eclipse.xtext.Grammar;
 import org.eclipse.xtext.service.AbstractGenericModule;
@@ -23,21 +22,24 @@ class LanguageModule extends AbstractGenericModule {
   private final XtextGeneratorLanguage language;
   
   public void configureLanguage(final Binder binder) {
-    binder.<IXtextGeneratorLanguage>bind(IXtextGeneratorLanguage.class).toInstance(this.language);
+    final Provider<IXtextGeneratorLanguage> _function = () -> {
+      return this.language;
+    };
+    binder.<IXtextGeneratorLanguage>bind(IXtextGeneratorLanguage.class).toProvider(_function);
   }
   
-  public ScopedBindingBuilder configureGrammar(final Binder binder) {
+  public void configureGrammar(final Binder binder) {
     final Provider<Grammar> _function = () -> {
       return this.language.getGrammar();
     };
-    return binder.<Grammar>bind(Grammar.class).toProvider(_function);
+    binder.<Grammar>bind(Grammar.class).toProvider(_function);
   }
   
-  public ScopedBindingBuilder configureRuleNames(final Binder binder) {
+  public void configureRuleNames(final Binder binder) {
     final Provider<RuleNames> _function = () -> {
       return this.language.getRuleNames();
     };
-    return binder.<RuleNames>bind(RuleNames.class).toProvider(_function);
+    binder.<RuleNames>bind(RuleNames.class).toProvider(_function);
   }
   
   public void configureAdditionalBindings(final Binder binder) {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.java
@@ -174,7 +174,7 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
   @Override
   public void initialize(final Injector injector) {
     this.getFragments().addAll(0, this.getImplicitFragments());
-    injector.injectMembers(XtextGeneratorLanguage.class);
+    injector.injectMembers(this);
     if ((this.resourceSet == null)) {
       this.resourceSet = this.resourceSetProvider.get();
     }
@@ -248,14 +248,10 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
   }
   
   protected List<? extends IXtextGeneratorFragment> getImplicitFragments() {
-    ArrayList<ImplicitFragment> _xblockexpression = null;
-    {
-      final ArrayList<ImplicitFragment> fragments = CollectionLiterals.<ImplicitFragment>newArrayList();
-      ImplicitFragment _implicitFragment = new ImplicitFragment();
-      fragments.add(_implicitFragment);
-      _xblockexpression = fragments;
-    }
-    return _xblockexpression;
+    final ArrayList<ImplicitFragment> fragments = CollectionLiterals.<ImplicitFragment>newArrayList();
+    ImplicitFragment _implicitFragment = new ImplicitFragment();
+    fragments.add(_implicitFragment);
+    return fragments;
   }
   
   public void initialize(final Grammar grammar) {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.java
@@ -89,7 +89,6 @@ import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment;
 import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess;
-import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess;
 import org.eclipse.xtext.xtext.generator.model.ManifestAccess;
 import org.eclipse.xtext.xtext.generator.model.PluginXmlAccess;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
@@ -1026,17 +1025,23 @@ public class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
       if ((((!this.updateBuildProperties) || (this.modelPluginID != null)) || (this.getProjectConfig().getRuntime().getManifest() == null))) {
         return;
       }
-      final IXtextGeneratorFileSystemAccess rootOutlet = this.getProjectConfig().getRuntime().getRoot();
-      String _path = rootOutlet.getPath();
+      String _path = this.getProjectConfig().getRuntime().getRoot().getPath();
       final String buildPropertiesPath = (_path + "/build.properties");
-      final String modelContainer = this.getProjectConfig().getRuntime().getEcoreModelFolder();
-      final Properties buildProperties = new Properties();
-      File _file = new File(buildPropertiesPath);
-      FileInputStream _fileInputStream = new FileInputStream(_file);
-      Charset _forName = Charset.forName(this.codeConfig.getEncoding());
-      final InputStreamReader reader = new InputStreamReader(_fileInputStream, _forName);
-      try {
-        String existingContent = CharStreams.toString(reader);
+      final File buildPropertiesFile = new File(buildPropertiesPath);
+      boolean _exists = buildPropertiesFile.exists();
+      if (_exists) {
+        final String modelContainer = this.getProjectConfig().getRuntime().getEcoreModelFolder();
+        final Properties buildProperties = new Properties();
+        final Charset charset = Charset.forName(this.codeConfig.getEncoding());
+        FileInputStream _fileInputStream = new FileInputStream(buildPropertiesFile);
+        final InputStreamReader reader = new InputStreamReader(_fileInputStream, charset);
+        String _xtrycatchfinallyexpression = null;
+        try {
+          _xtrycatchfinallyexpression = CharStreams.toString(reader);
+        } finally {
+          reader.close();
+        }
+        String existingContent = _xtrycatchfinallyexpression;
         StringInputStream _stringInputStream = new StringInputStream(existingContent, "ISO-8859-1");
         buildProperties.load(_stringInputStream);
         final String binIncludes = buildProperties.getProperty("bin.includes");
@@ -1060,15 +1065,14 @@ public class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
           }
         }
         if (changed) {
-          File _file_1 = new File(buildPropertiesPath);
-          FileOutputStream _fileOutputStream = new FileOutputStream(_file_1);
-          Charset _forName_1 = Charset.forName(this.codeConfig.getEncoding());
-          final OutputStreamWriter writer = new OutputStreamWriter(_fileOutputStream, _forName_1);
-          writer.write(existingContent);
-          writer.close();
+          FileOutputStream _fileOutputStream = new FileOutputStream(buildPropertiesFile);
+          final OutputStreamWriter writer = new OutputStreamWriter(_fileOutputStream, charset);
+          try {
+            writer.write(existingContent);
+          } finally {
+            writer.close();
+          }
         }
-      } finally {
-        reader.close();
       }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);


### PR DESCRIPTION
 - XtextGeneratorLanguage was injecting its members incorrectly.
 - LanguageModule must bind the language to a provider to prevent Guice from injecting its members implicitly (masking the previous bug).
 - `EMFGeneratorFragment2.updateBuildProperties()` should do nothing when build.properties does not exist.