### PR TITLE
[formatter/performance] Don't create stack traces

### DIFF
--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/formatter/FormatterTestHelper.java
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/formatter/FormatterTestHelper.java
@@ -92,10 +92,14 @@ public class FormatterTestHelper {
 		String document = req.getToBeFormatted().toString();
 		XtextResource parsed = parse(document);
 		if (req.isAllowSyntaxErrors()) {
-			request.setExceptionHandler(ExceptionAcceptor.IGNORING);
+			if (request.getExplicitExceptionHandler() == null) {
+				request.setExceptionHandler(ExceptionAcceptor.IGNORING);
+			}
 		} else {
 			assertNoSyntaxErrors(parsed);
-			request.setExceptionHandler(ExceptionAcceptor.THROWING);
+			if (request.getExplicitExceptionHandler() == null) {
+				request.setExceptionHandler(ExceptionAcceptor.THROWING);
+			}
 		}
 		request.setTextRegionAccess(createRegionAccess(parsed, req));
 		if (request.getPreferences() == null)

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/FormattingConflictTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/FormattingConflictTest.xtend
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.formatting2.internal
+
+import com.google.inject.Inject
+import org.eclipse.xtext.formatting2.internal.formattertestlanguage.IDList
+import org.eclipse.xtext.formatting2.internal.tests.FormatterTestLanguageInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.util.Wrapper
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author Moritz Eysholdt - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(FormatterTestLanguageInjectorProvider)
+class FormattingConflictTest {
+	@Inject extension GenericFormatterTester
+
+	// @Inject extension FormatterTestLanguageGrammarAccess
+	@Test def void enableDebugTracingTrue() {
+		val wrapper = new Wrapper<Throwable>
+		val execution = new Wrapper<Integer>(0)
+		assertFormatted[
+			toBeFormatted = '''
+				idlist a
+			'''
+			formatter = [ IDList model, extension regions, extension document |
+				execution.set(execution.get + 1)
+				model.regionFor.keyword("idlist").append[space = " "]
+				model.regionFor.keyword("idlist").append[space = "\t"]
+			]
+			request.enableDebugTracing = true
+			request.exceptionHandler = [ e |
+				wrapper.set(e)
+			]
+		]
+		val exception = wrapper.get as ConflictingRegionsException
+		Assert.assertEquals(1, execution.get)
+		Assert.assertEquals(2, exception.traces.size)
+	}
+
+	@Test def void enableDebugTracingFalse() {
+		val wrapper = new Wrapper<Throwable>
+		val execution = new Wrapper<Integer>(0)
+		assertFormatted[
+			toBeFormatted = '''
+				idlist a
+			'''
+			formatter = [ IDList model, extension regions, extension document |
+				execution.set(execution.get + 1)
+				model.regionFor.keyword("idlist").append[space = " "]
+				model.regionFor.keyword("idlist").append[space = "\t"]
+			]
+			request.enableDebugTracing = false
+			request.exceptionHandler = [ e |
+				wrapper.set(e)
+			]
+		]
+		val exception = wrapper.get as ConflictingRegionsException
+		Assert.assertEquals(2, execution.get)
+		Assert.assertEquals(2, exception.traces.size)
+	}
+
+}

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/RegionSetTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/RegionSetTest.xtend
@@ -22,7 +22,7 @@ import static org.junit.Assert.*
 class RegionSetTest {
 
 	def private void test(CharSequence expectation, (TestableTextSegmentSet)=>void test) {
-		val set = new TestableTextSegmentSet(new ArrayListTextSegmentSet(Functions.identity, Functions.toStringFunction))
+		val set = new TestableTextSegmentSet(new ArrayListTextSegmentSet(Functions.identity, Functions.toStringFunction, true))
 		try {
 			test.apply(set)
 		} catch (Throwable t) {

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/FormattingConflictTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/FormattingConflictTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.formatting2.internal;
+
+import com.google.inject.Inject;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.formatting2.FormatterRequest;
+import org.eclipse.xtext.formatting2.IFormattableDocument;
+import org.eclipse.xtext.formatting2.IHiddenRegionFormatter;
+import org.eclipse.xtext.formatting2.internal.ConflictingRegionsException;
+import org.eclipse.xtext.formatting2.internal.GenericFormatter;
+import org.eclipse.xtext.formatting2.internal.GenericFormatterTestRequest;
+import org.eclipse.xtext.formatting2.internal.GenericFormatterTester;
+import org.eclipse.xtext.formatting2.internal.formattertestlanguage.IDList;
+import org.eclipse.xtext.formatting2.internal.tests.FormatterTestLanguageInjectorProvider;
+import org.eclipse.xtext.formatting2.regionaccess.ITextRegionExtensions;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.util.IAcceptor;
+import org.eclipse.xtext.util.Wrapper;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Moritz Eysholdt - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(FormatterTestLanguageInjectorProvider.class)
+@SuppressWarnings("all")
+public class FormattingConflictTest {
+  @Inject
+  @Extension
+  private GenericFormatterTester _genericFormatterTester;
+  
+  @Test
+  public void enableDebugTracingTrue() {
+    final Wrapper<Throwable> wrapper = new Wrapper<Throwable>();
+    final Wrapper<Integer> execution = new Wrapper<Integer>(Integer.valueOf(0));
+    final Procedure1<GenericFormatterTestRequest> _function = (GenericFormatterTestRequest it) -> {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("idlist a");
+      _builder.newLine();
+      it.setToBeFormatted(_builder);
+      final GenericFormatter<IDList> _function_1 = new GenericFormatter<IDList>() {
+        @Override
+        protected void format(final IDList model, @Extension final ITextRegionExtensions regions, @Extension final IFormattableDocument document) {
+          Integer _get = execution.get();
+          int _plus = ((_get).intValue() + 1);
+          execution.set(Integer.valueOf(_plus));
+          final Procedure1<IHiddenRegionFormatter> _function = (IHiddenRegionFormatter it_1) -> {
+            it_1.setSpace(" ");
+          };
+          document.append(regions.regionFor(model).keyword("idlist"), _function);
+          final Procedure1<IHiddenRegionFormatter> _function_1 = (IHiddenRegionFormatter it_1) -> {
+            it_1.setSpace("\t");
+          };
+          document.append(regions.regionFor(model).keyword("idlist"), _function_1);
+        }
+      };
+      it.setFormatter(_function_1);
+      FormatterRequest _request = it.getRequest();
+      _request.setEnableDebugTracing(true);
+      FormatterRequest _request_1 = it.getRequest();
+      final IAcceptor<Exception> _function_2 = (Exception e) -> {
+        wrapper.set(e);
+      };
+      _request_1.setExceptionHandler(_function_2);
+    };
+    this._genericFormatterTester.assertFormatted(_function);
+    Throwable _get = wrapper.get();
+    final ConflictingRegionsException exception = ((ConflictingRegionsException) _get);
+    Assert.assertEquals(1, (execution.get()).intValue());
+    Assert.assertEquals(2, exception.getTraces().size());
+  }
+  
+  @Test
+  public void enableDebugTracingFalse() {
+    final Wrapper<Throwable> wrapper = new Wrapper<Throwable>();
+    final Wrapper<Integer> execution = new Wrapper<Integer>(Integer.valueOf(0));
+    final Procedure1<GenericFormatterTestRequest> _function = (GenericFormatterTestRequest it) -> {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("idlist a");
+      _builder.newLine();
+      it.setToBeFormatted(_builder);
+      final GenericFormatter<IDList> _function_1 = new GenericFormatter<IDList>() {
+        @Override
+        protected void format(final IDList model, @Extension final ITextRegionExtensions regions, @Extension final IFormattableDocument document) {
+          Integer _get = execution.get();
+          int _plus = ((_get).intValue() + 1);
+          execution.set(Integer.valueOf(_plus));
+          final Procedure1<IHiddenRegionFormatter> _function = (IHiddenRegionFormatter it_1) -> {
+            it_1.setSpace(" ");
+          };
+          document.append(regions.regionFor(model).keyword("idlist"), _function);
+          final Procedure1<IHiddenRegionFormatter> _function_1 = (IHiddenRegionFormatter it_1) -> {
+            it_1.setSpace("\t");
+          };
+          document.append(regions.regionFor(model).keyword("idlist"), _function_1);
+        }
+      };
+      it.setFormatter(_function_1);
+      FormatterRequest _request = it.getRequest();
+      _request.setEnableDebugTracing(false);
+      FormatterRequest _request_1 = it.getRequest();
+      final IAcceptor<Exception> _function_2 = (Exception e) -> {
+        wrapper.set(e);
+      };
+      _request_1.setExceptionHandler(_function_2);
+    };
+    this._genericFormatterTester.assertFormatted(_function);
+    Throwable _get = wrapper.get();
+    final ConflictingRegionsException exception = ((ConflictingRegionsException) _get);
+    Assert.assertEquals(2, (execution.get()).intValue());
+    Assert.assertEquals(2, exception.getTraces().size());
+  }
+}

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/RegionSetTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/RegionSetTest.java
@@ -27,7 +27,7 @@ public class RegionSetTest {
   private void test(final CharSequence expectation, final Procedure1<? super TestableTextSegmentSet> test) {
     Function<ITextSegment, ITextSegment> _identity = Functions.<ITextSegment>identity();
     Function<Object, String> _stringFunction = Functions.toStringFunction();
-    ArrayListTextSegmentSet<ITextSegment> _arrayListTextSegmentSet = new ArrayListTextSegmentSet<ITextSegment>(_identity, _stringFunction);
+    ArrayListTextSegmentSet<ITextSegment> _arrayListTextSegmentSet = new ArrayListTextSegmentSet<ITextSegment>(_identity, _stringFunction, true);
     final TestableTextSegmentSet set = new TestableTextSegmentSet(_arrayListTextSegmentSet);
     try {
       test.apply(set);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/FormatterRequest.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/FormatterRequest.java
@@ -206,6 +206,10 @@ public class FormatterRequest {
 			return ExceptionAcceptor.LOGGING;
 		return exceptionHandler;
 	}
+	
+	public IAcceptor<Exception> getExplicitExceptionHandler() {
+		return exceptionHandler;
+	}
 
 	/**
 	 * @see #exceptionHandler
@@ -213,5 +217,24 @@ public class FormatterRequest {
 	public FormatterRequest setExceptionHandler(IAcceptor<Exception> problemHandler) {
 		this.exceptionHandler = problemHandler;
 		return this;
+	}
+	
+	/**
+	 * Enable creation of Java stack traces to diagnose conflicting formatting
+	 * instructions.
+	 * 
+	 * This option is disabled for performance reasons. It is safe to leave it
+	 * disabled, because in case a conflict happens, the formatter will
+	 * automatically enable this flag and format again. The second pass of the
+	 * formatter will then lead to the desired debug information.
+	 **/
+	private boolean enableDebugTracing = false;
+
+	public boolean isEnableDebugTracing() {
+		return enableDebugTracing;
+	}
+
+	public void setEnableDebugTracing(boolean enableDebugTracing) {
+		this.enableDebugTracing = enableDebugTracing;
 	}
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/RegionTraceMissingException.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/RegionTraceMissingException.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.formatting2.internal;
+
+/**
+ * @author Moritz Eysholdt - Initial contribution and API
+ */
+public class RegionTraceMissingException extends RuntimeException {
+
+	private static final long serialVersionUID = -1151660462702454003L;
+
+	public RegionTraceMissingException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/TextReplacerContext.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/TextReplacerContext.java
@@ -66,7 +66,7 @@ public class TextReplacerContext implements ITextReplacerContext {
 					public String apply(ITextReplacement input) {
 						return input.getReplacementText();
 					}
-				});
+				}, getDocument().getRequest().isEnableDebugTracing());
 	}
 
 	@Override
@@ -223,7 +223,6 @@ public class TextReplacerContext implements ITextReplacerContext {
 			String frameTitle = replacer.getClass().getSimpleName();
 			ITextSegment frameRegion = replacer.getRegion();
 			String replacerTitle = replacement.getReplacementText();
-			@SuppressWarnings("unchecked")
 			RegionsOutsideFrameException exception = new RegionsOutsideFrameException(frameTitle, frameRegion,
 					Tuples.create(replacerTitle, (ITextSegment) replacement));
 			request.getExceptionHandler().accept(exception);


### PR DESCRIPTION
This change:
- introduces a flag that by default disables creation of stack traces
- lets the formatter do a second pass on conflict with that flag enabled

This combines the benefits of both worlds:
- performance without the need for tweaking
- debug information without the need to enable some magic config

see 
https://bugs.eclipse.org/bugs/show_bug.cgi?id=508894
https://bugs.eclipse.org/bugs/show_bug.cgi?id=507174
https://github.com/eclipse/xtext-core/pull/195

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>