### PR TITLE
fixed #12: [formatter] IllegalArgumentException in NodeRegion.toString()

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/regionaccess/internal/RegionAccessBuilderTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/regionaccess/internal/RegionAccessBuilderTest.xtend
@@ -23,6 +23,10 @@ import org.eclipse.xtext.testing.validation.ValidationTestHelper
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.eclipse.xtext.formatting2.regionaccess.ITextRegionAccess
+import org.eclipse.xtext.formatting2.regionaccess.IHiddenRegion
+import org.eclipse.xtext.formatting2.regionaccess.ISequentialRegion
+import org.eclipse.xtext.formatting2.regionaccess.ISemanticRegion
 
 /**
  * @author Moritz Eysholdt - Initial contribution and API
@@ -661,8 +665,26 @@ class RegionAccessBuilderTest {
 		validationTestHelper.assertNoErrors(obj)
 		val access1 = obj.createFromNodeModel
 		val access2 = obj.serializeToRegions
+		assertToStringDoesNotCrash(access1)
+		assertToStringDoesNotCrash(access2)
 		Assert.assertEquals(exp, new TextRegionAccessToString().withRegionAccess(access1).cfg() + "\n")
 		Assert.assertEquals(exp, new TextRegionAccessToString().withRegionAccess(access2).cfg() + "\n")
+	}
+
+	private def assertToStringDoesNotCrash(ITextRegionAccess access) {
+		var current = access.regionForRootEObject.previousHiddenRegion as ISequentialRegion
+		while (current !== null) {
+			Assert.assertNotNull(current.toString)
+			switch current {
+				IHiddenRegion: {
+					current = current.nextSemanticRegion
+				}
+				ISemanticRegion: {
+					Assert.assertNotNull(current.EObjectRegion.toString)
+					current = current.nextHiddenRegion
+				}
+			}
+		}
 	}
 
 	private def TextRegionAccessToString cfg(TextRegionAccessToString toStr) {

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/regionaccess/internal/RegionAccessBuilderTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/regionaccess/internal/RegionAccessBuilderTest.java
@@ -13,6 +13,9 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.formatting2.debug.TextRegionAccessToString;
+import org.eclipse.xtext.formatting2.regionaccess.IHiddenRegion;
+import org.eclipse.xtext.formatting2.regionaccess.ISemanticRegion;
+import org.eclipse.xtext.formatting2.regionaccess.ISequentialRegion;
 import org.eclipse.xtext.formatting2.regionaccess.ITextRegionAccess;
 import org.eclipse.xtext.formatting2.regionaccess.TextRegionAccessBuilder;
 import org.eclipse.xtext.formatting2.regionaccess.internal.regionaccesstestlanguage.Root;
@@ -1433,6 +1436,8 @@ public class RegionAccessBuilderTest {
       this.validationTestHelper.assertNoErrors(obj);
       final ITextRegionAccess access1 = this.createFromNodeModel(obj);
       final ITextRegionAccess access2 = this.serializer.serializeToRegions(obj);
+      this.assertToStringDoesNotCrash(access1);
+      this.assertToStringDoesNotCrash(access2);
       TextRegionAccessToString _cfg = this.cfg(new TextRegionAccessToString().withRegionAccess(access1));
       String _plus = (_cfg + "\n");
       Assert.assertEquals(exp, _plus);
@@ -1441,6 +1446,28 @@ public class RegionAccessBuilderTest {
       Assert.assertEquals(exp, _plus_1);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  private void assertToStringDoesNotCrash(final ITextRegionAccess access) {
+    IHiddenRegion _previousHiddenRegion = access.regionForRootEObject().getPreviousHiddenRegion();
+    ISequentialRegion current = ((ISequentialRegion) _previousHiddenRegion);
+    while ((current != null)) {
+      {
+        Assert.assertNotNull(current.toString());
+        boolean _matched = false;
+        if (current instanceof IHiddenRegion) {
+          _matched=true;
+          current = ((IHiddenRegion)current).getNextSemanticRegion();
+        }
+        if (!_matched) {
+          if (current instanceof ISemanticRegion) {
+            _matched=true;
+            Assert.assertNotNull(((ISemanticRegion)current).getEObjectRegion().toString());
+            current = ((ISemanticRegion)current).getNextHiddenRegion();
+          }
+        }
+      }
     }
   }
   

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/debug/TextRegionAccessToString.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/debug/TextRegionAccessToString.java
@@ -79,8 +79,8 @@ public class TextRegionAccessToString {
 	private static final String HIDDEN_PADDED = Strings.padEnd(HIDDEN, TITLE_WIDTH, ' ');
 	private static final String SEMANTIC_PADDED = Strings.padEnd("S", TITLE_WIDTH, ' ');
 
-	private Function<AbstractElement, String> grammarToString = new GrammarElementTitleSwitch().showRule().showAssignments()
-			.showQualified();
+	private Function<AbstractElement, String> grammarToString = new GrammarElementTitleSwitch().showRule()
+			.showAssignments().showQualified();
 
 	private boolean hideColumnExplanation = false;
 
@@ -180,7 +180,23 @@ public class TextRegionAccessToString {
 		}
 		for (String error : errors)
 			result.add(error, false);
-		int indentation = 0;
+		int indentation = 0, min = 0;
+		for (ITextSegment region : list) {
+			if (region instanceof IHiddenRegion) {
+				Collection<IEObjectRegion> found = hiddens.get((IHiddenRegion) region);
+				for (IEObjectRegion obj : found) {
+					boolean p = obj.getNextHiddenRegion().equals(region);
+					boolean n = obj.getPreviousHiddenRegion().equals(region);
+					if (p)
+						indentation--;
+					else if (n)
+						indentation++;
+					if (indentation < min)
+						min = indentation;
+				}
+			}
+		}
+		indentation = min < 0 ? min * -1 : 0;
 		for (ITextSegment region : list) {
 			List<IEObjectRegion> previous = Lists.newArrayList();
 			List<IEObjectRegion> next = Lists.newArrayList();


### PR DESCRIPTION
see https://github.com/eclipse/xtext-core/issues/12

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>