### PR TITLE
Generate Xtext languages from Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,10 @@ subprojects {
 	apply from: "${rootDir}/gradle/java-compiler-settings.gradle"
 	apply from: "${rootDir}/gradle/xtend-compiler-settings.gradle"
 	apply from: "${rootDir}/gradle/maven-deployment.gradle"
-	apply from: "${rootDir}/gradle/eclipse-project-layout.gradle"
+	// The bootstrap project uses only the mwe2 source set
+	if (!name.endsWith('bootstrap')) {
+		apply from: "${rootDir}/gradle/eclipse-project-layout.gradle"
+	}
 	apply from: "${rootDir}/gradle/manifest-gen.gradle"
 	apply from: "${rootDir}/gradle/validation.gradle"
 }

--- a/gradle/eclipse-project-layout.gradle
+++ b/gradle/eclipse-project-layout.gradle
@@ -60,7 +60,6 @@ if (isTestProject || name.contains('testlanguage')) {
 eclipse {
 	classpath {
 		plusConfigurations += [configurations.optional]
-		plusConfigurations += [configurations.mwe2Runtime]
 		file.whenMerged {
 			entries.each { source ->
 				if (source.kind == 'src' && source.path.endsWith('-gen') && !source.path.equals('xtend-gen') ) {

--- a/gradle/java-compiler-settings.gradle
+++ b/gradle/java-compiler-settings.gradle
@@ -32,17 +32,11 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 	from javadoc.destinationDir
 }
 
-sourceSets {
-	mwe2 {}
-}
-
 configurations {
 	optional {
 		description 'Dependencies required at build time, but not exported into meta data'
 		extendsFrom compile
 	}
-	mwe2Compile.extendsFrom mainCompile
-	mwe2Runtime.extendsFrom mainRuntime
 	
 	// Put any unwanted transitive dependencies here, they will be excluded from all projects.
 	all {

--- a/gradle/mwe2-workflows.gradle
+++ b/gradle/mwe2-workflows.gradle
@@ -1,0 +1,37 @@
+/*
+ * Configuration of source sets, dependencies, and tasks for running MWE2 workflows.
+ */
+
+sourceSets {
+	mwe2 {}
+}
+
+eclipse.classpath.plusConfigurations += [configurations.mwe2Runtime]
+
+dependencies {
+	if (!name.endsWith('bootstrap')) {
+		mwe2Compile project(':org.eclipse.xtext.xtext.generator')
+	}
+	mwe2Runtime "org.eclipse.emf:org.eclipse.emf.mwe2.launch:$versions.emfMwe2"
+	mwe2Runtime "org.eclipse.xtext:org.eclipse.xtext.common.types:$versions.xtext_bootstrap"
+	mwe2Runtime "org.eclipse.xtext:org.eclipse.xtext.ecore:$versions.xtext_bootstrap"
+}
+
+if (findProperty('compileXtend') == 'true') {
+	generateMwe2Xtext.xtextClasspath = rootProject.configurations.getByName('xtendCompiler')
+}
+
+class XtextGeneratorTask extends JavaExec {
+	XtextGeneratorTask() {
+		group = 'Build'
+		main = 'org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher'
+		classpath = project.sourceSets.mwe2.runtimeClasspath
+	}
+	def setWorkflow(File workflowFile) {
+		args = [workflowFile.path, "-p", "rootPath=${project.rootDir}"]
+		inputs.file workflowFile
+		description "Execute the MWE2 workflow ${workflowFile.name}"
+	}
+}
+
+ext.XtextGeneratorTask = XtextGeneratorTask

--- a/org.eclipse.xtext.ide.tests/build.gradle
+++ b/org.eclipse.xtext.ide.tests/build.gradle
@@ -1,3 +1,5 @@
+apply from: "${rootDir}/gradle/mwe2-workflows.gradle"
+
 dependencies {
 	compile project(':org.eclipse.xtext.ide')
 	compile project(':org.eclipse.xtext.testing')
@@ -5,20 +7,6 @@ dependencies {
 	compile project(':org.eclipse.xtext.testlanguages.ide')
 	compile "junit:junit:$versions.junit"
 	compile "org.eclipse.lsp4j:org.eclipse.lsp4j:$versions.lsp4j"
-	mwe2Compile project(':org.eclipse.xtext.xtext.generator')
-	mwe2Compile "org.eclipse.xtext:org.eclipse.xtext.common.types:$versions.xtext_bootstrap"
-	mwe2Runtime "org.eclipse.emf:org.eclipse.emf.mwe2.launch:$versions.emfMwe2"
-}
-
-task generateXtextLanguage(type: JavaExec) {
-	main = 'org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher'
-	classpath = configurations.mwe2Runtime
-	inputs.file "testlang-src/org/eclipse/xtext/ide/tests/testlanguage/GenerateTestLanguage.mwe2"
-	inputs.file "testlang-src/org/eclipse/xtext/ide/tests/testlanguage/TestLanguage.xtext"
-	outputs.dir "testlang-src-gen"
-	args += "testlang-src/org/eclipse/xtext/ide/tests/testlanguage/GenerateTestLanguage.mwe2"
-	args += "-p"
-	args += "rootPath=/${projectDir}/.."
 }
 
 sourceSets.test.java {
@@ -28,4 +16,10 @@ sourceSets.test.java {
 sourceSets.test.resources {
 	srcDir 'testlang-src'
 	srcDir 'testlang-src-gen'
+}
+
+task generateTestLanguages(type: XtextGeneratorTask) {
+	workflow = file('testlang-src/org/eclipse/xtext/ide/tests/testlanguage/GenerateTestLanguage.mwe2')
+	inputs.file 'testlang-src/org/eclipse/xtext/ide/tests/testlanguage/TestLanguage.xtext'
+	outputs.dir 'testlang-src-gen'
 }

--- a/org.eclipse.xtext.ide.tests/model/generated/PartialContentAssistTestLanguage.genmodel
+++ b/org.eclipse.xtext.ide.tests/model/generated/PartialContentAssistTestLanguage.genmodel
@@ -4,7 +4,7 @@
     modelDirectory="/org.eclipse.xtext.ide.tests/testlang-src-gen" modelPluginID="org.eclipse.xtext.ide.tests"
     forceOverwrite="true" modelName="PartialContentAssistTestLanguage" updateClasspath="false"
     rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container" complianceLevel="6.0"
-    copyrightFields="false" runtimeVersion="2.11">
+    copyrightFields="false" runtimeVersion="2.12">
   <genPackages prefix="PartialContentAssistTestLanguage" basePackage="org.eclipse.xtext.ide.tests.testlanguage"
       disposableProviderFactory="true" fileExtensions="partialcontentassisttestlang"
       ecorePackage="PartialContentAssistTestLanguage.ecore#/">

--- a/org.eclipse.xtext.ide.tests/model/generated/TestLanguage.genmodel
+++ b/org.eclipse.xtext.ide.tests/model/generated/TestLanguage.genmodel
@@ -3,7 +3,7 @@
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" copyrightText="Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.&#xA;All rights reserved. This program and the accompanying materials&#xA;are made available under the terms of the Eclipse Public License v1.0&#xA;which accompanies this distribution, and is available at&#xA;http://www.eclipse.org/legal/epl-v10.html"
     modelDirectory="/org.eclipse.xtext.ide.tests/testlang-src-gen" modelPluginID="org.eclipse.xtext.ide.tests"
     forceOverwrite="true" modelName="TestLanguage" updateClasspath="false" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
-    complianceLevel="6.0" copyrightFields="false" runtimeVersion="2.11">
+    complianceLevel="6.0" copyrightFields="false" runtimeVersion="2.12">
   <genPackages prefix="TestLanguage" basePackage="org.eclipse.xtext.ide.tests.testlanguage"
       disposableProviderFactory="true" fileExtensions="testlang" ecorePackage="TestLanguage.ecore#/">
     <genClasses ecoreClass="TestLanguage.ecore#//Model">

--- a/org.eclipse.xtext.testlanguages/build.gradle
+++ b/org.eclipse.xtext.testlanguages/build.gradle
@@ -1,10 +1,15 @@
+apply from: "${rootDir}/gradle/mwe2-workflows.gradle"
+
 dependencies {
 	compile project(':org.eclipse.xtext')
 	compile project(':org.eclipse.xtext.testing')
 	compile "org.eclipse.platform:org.eclipse.core.runtime:$versions.eclipseCore"
-	mwe2Compile project(':org.eclipse.xtext.xtext.generator')
-	mwe2Runtime "org.eclipse.xtext:org.eclipse.xtext.common.types:$versions.xtext_bootstrap"
-	mwe2Runtime "org.eclipse.emf:org.eclipse.emf.mwe2.launch:$versions.emfMwe2"
 }
 
-uploadArchives.enabled = false
+// Include the mwe2 and xtext files from the main source set when executing the workflow
+sourceSets.mwe2.runtimeClasspath += processResources.outputs.files
+
+task generateTestLanguages(type: XtextGeneratorTask) {
+	workflow = file('src/org/eclipse/xtext/testlanguages/GenerateTestLanguages.mwe2')
+	outputs.dir 'src-gen'
+}

--- a/org.eclipse.xtext.tests/build.gradle
+++ b/org.eclipse.xtext.tests/build.gradle
@@ -1,8 +1,4 @@
-repositories {
-	flatDir {
-		dirs 'lib'
-	}
-}
+apply from: "${rootDir}/gradle/mwe2-workflows.gradle"
 
 dependencies {
 	compile project(':org.eclipse.xtext.testing')
@@ -12,19 +8,33 @@ dependencies {
 	compile "junit:junit:$versions.junit"
 	compile "org.eclipse.emf:org.eclipse.emf.common:$versions.emfCommon"
 	compile "org.eclipse.emf:org.eclipse.emf.ecore.xmi:$versions.emfEcore"
-	// From the 'lib' folder
-	optional name: 'simple'
-	mwe2Runtime "org.eclipse.xtext:org.eclipse.xtext.common.types:$versions.xtext_bootstrap"
-	mwe2Runtime "org.eclipse.emf:org.eclipse.emf.mwe2.launch:$versions.emfMwe2"
+	optional files('lib/simple.jar')
+	// The MWE2 workflow depends on emf-gen, so we have to include it in the test dependencies
+	testCompile sourceSets.mwe2.output
 }
 
-sourceSets.test.java {
-	srcDir 'suites'
+sourceSets.test {
+	java.srcDirs = ['src', 'src-gen', 'suites']
+	if (findProperty('compileXtend') != 'true') {
+		java.srcDir 'xtend-gen'
+	}
 }
 
-sourceSets.mwe2.java {
-	srcDir 'generator/src'
-	srcDir 'generator/xtend-gen'
+sourceSets.mwe2 {
+	java.srcDirs = ['generator/src', 'emf-gen']
+	if (findProperty('compileXtend') == 'true') {
+		xtendOutputDir = 'generator/xtend-gen'
+	} else {
+		java.srcDir 'generator/xtend-gen'
+	}
+	runtimeClasspath += processTestResources.outputs.files
+}
+jar.from sourceSets.mwe2.output
+sourcesJar.from sourceSets.mwe2.allSource
+
+task generateTestLanguages(type: XtextGeneratorTask) {
+	workflow = file('src/org/eclipse/xtext/GenerateAllTestLanguages.mwe2')
+	outputs.dir 'src-gen'
 }
 
 test {

--- a/org.eclipse.xtext.tests/emf-gen/org/eclipse/xtext/metamodelreferencing/tests/ecorePerNsURI/impl/EcorePerNsURIPackageImpl.java
+++ b/org.eclipse.xtext.tests/emf-gen/org/eclipse/xtext/metamodelreferencing/tests/ecorePerNsURI/impl/EcorePerNsURIPackageImpl.java
@@ -11,24 +11,14 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EcorePackage;
-
 import org.eclipse.emf.ecore.impl.EPackageImpl;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerNsURI.EcorePerNsURIFactory;
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerNsURI.EcorePerNsURIPackage;
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerNsURI.ExtendsNsURIEObject;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformPlugin.EcorePerPlatformPluginPackage;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformPlugin.impl.EcorePerPlatformPluginPackageImpl;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformResource.EcorePerPlatformResourcePackage;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformResource.impl.EcorePerPlatformResourcePackageImpl;
-
-import org.eclipse.xtext.metamodelreferencing.tests.ecoreReference.EcoreReferencePackage;
-
-import org.eclipse.xtext.metamodelreferencing.tests.ecoreReference.impl.EcoreReferencePackageImpl;
 
 /**
  * <!-- begin-user-doc -->

--- a/org.eclipse.xtext.tests/emf-gen/org/eclipse/xtext/metamodelreferencing/tests/ecorePerPlatformPlugin/impl/EcorePerPlatformPluginPackageImpl.java
+++ b/org.eclipse.xtext.tests/emf-gen/org/eclipse/xtext/metamodelreferencing/tests/ecorePerPlatformPlugin/impl/EcorePerPlatformPluginPackageImpl.java
@@ -11,25 +11,15 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EcorePackage;
-
 import org.eclipse.emf.ecore.impl.EPackageImpl;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerNsURI.EcorePerNsURIPackage;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerNsURI.impl.EcorePerNsURIPackageImpl;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformPlugin.EcorePerPlatformPluginFactory;
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformPlugin.EcorePerPlatformPluginPackage;
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformPlugin.ExtendsEAttribute;
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformPlugin.ExtendsPluginEObject;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformResource.EcorePerPlatformResourcePackage;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformResource.impl.EcorePerPlatformResourcePackageImpl;
-
-import org.eclipse.xtext.metamodelreferencing.tests.ecoreReference.EcoreReferencePackage;
-
-import org.eclipse.xtext.metamodelreferencing.tests.ecoreReference.impl.EcoreReferencePackageImpl;
 
 /**
  * <!-- begin-user-doc -->

--- a/org.eclipse.xtext.tests/emf-gen/org/eclipse/xtext/metamodelreferencing/tests/ecorePerPlatformResource/impl/EcorePerPlatformResourcePackageImpl.java
+++ b/org.eclipse.xtext.tests/emf-gen/org/eclipse/xtext/metamodelreferencing/tests/ecorePerPlatformResource/impl/EcorePerPlatformResourcePackageImpl.java
@@ -11,24 +11,14 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EcorePackage;
-
 import org.eclipse.emf.ecore.impl.EPackageImpl;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerNsURI.EcorePerNsURIPackage;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerNsURI.impl.EcorePerNsURIPackageImpl;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformPlugin.EcorePerPlatformPluginPackage;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformPlugin.impl.EcorePerPlatformPluginPackageImpl;
-
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformResource.EcorePerPlatformResourceFactory;
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformResource.EcorePerPlatformResourcePackage;
 import org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformResource.ExtendsResourceEObject;
-
-import org.eclipse.xtext.metamodelreferencing.tests.ecoreReference.EcoreReferencePackage;
-
-import org.eclipse.xtext.metamodelreferencing.tests.ecoreReference.impl.EcoreReferencePackageImpl;
 
 /**
  * <!-- begin-user-doc -->

--- a/org.eclipse.xtext.tests/plugin.xml
+++ b/org.eclipse.xtext.tests/plugin.xml
@@ -886,4 +886,27 @@
             class="org.eclipse.xtext.generator.ecore.genmodelaccess.noLiterals.NoLiteralsPackage"
             genModel="src/org/eclipse/xtext/generator/ecore/GenModelAccessTest.genmodel"/>
    </extension>
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated EcoreReferences -->
+      <package
+            uri="http://www.eclipse.org/2011/tmf/xtext/ecorePerNsURI"
+            class="org.eclipse.xtext.metamodelreferencing.tests.ecorePerNsURI.EcorePerNsURIPackage"
+            genModel="src/org/eclipse/xtext/metamodelreferencing/tests/EcoreReferences.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated EcoreReferences -->
+      <package
+            uri="http://www.eclipse.org/2011/tmf/xtext/ecorePerPlatformPlugin"
+            class="org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformPlugin.EcorePerPlatformPluginPackage"
+            genModel="src/org/eclipse/xtext/metamodelreferencing/tests/EcoreReferences.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated EcoreReferences -->
+      <package
+            uri="http://www.eclipse.org/2011/tmf/xtext/ecorePerPlatformResource"
+            class="org.eclipse.xtext.metamodelreferencing.tests.ecorePerPlatformResource.EcorePerPlatformResourcePackage"
+            genModel="src/org/eclipse/xtext/metamodelreferencing/tests/EcoreReferences.genmodel"/>
+   </extension>
 </plugin>

--- a/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/serializer/ExUnorderedGroupsTestLanguageSyntacticSequencer.java
+++ b/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/serializer/ExUnorderedGroupsTestLanguageSyntacticSequencer.java
@@ -62,14 +62,14 @@ public class ExUnorderedGroupsTestLanguageSyntacticSequencer extends AbstractSyn
 	/**
 	 * Ambiguous syntax:
 	 *     (
-	  *         '5' | 
-	  *         '6' | 
 	  *         '3' | 
-	  *         '11' | 
-	  *         '7' | 
-	  *         '4' | 
 	  *         '10' | 
-	  *         'bug302585'
+	  *         'bug302585' | 
+	  *         '4' | 
+	  *         '6' | 
+	  *         '5' | 
+	  *         '11' | 
+	  *         '7'
 	  *     )
 	 *
 	 * This ambiguous syntax occurs at:

--- a/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/serializer/SimpleUnorderedGroupsTestLanguageSyntacticSequencer.java
+++ b/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/serializer/SimpleUnorderedGroupsTestLanguageSyntacticSequencer.java
@@ -63,13 +63,13 @@ public class SimpleUnorderedGroupsTestLanguageSyntacticSequencer extends Abstrac
 	 * Ambiguous syntax:
 	 *     (
 	  *         '3' | 
-	  *         '5' | 
-	  *         '11' | 
-	  *         '4' | 
-	  *         '10' | 
-	  *         'bug302585' | 
 	  *         '6' | 
-	  *         '7'
+	  *         '10' | 
+	  *         '7' | 
+	  *         '4' | 
+	  *         '5' | 
+	  *         'bug302585' | 
+	  *         '11'
 	  *     )
 	 *
 	 * This ambiguous syntax occurs at:

--- a/org.eclipse.xtext.xtext.bootstrap/.gitignore
+++ b/org.eclipse.xtext.xtext.bootstrap/.gitignore
@@ -1,0 +1,1 @@
+.antlr-generator-*.jar

--- a/org.eclipse.xtext.xtext.bootstrap/build.gradle
+++ b/org.eclipse.xtext.xtext.bootstrap/build.gradle
@@ -1,26 +1,27 @@
+apply from: "${rootDir}/gradle/mwe2-workflows.gradle"
+
 dependencies {
 	// We cannot use the projects within the workspace, as we would have
 	// to compile them before generating the code, so we need to stick to the bootstrapping version.
-	// Buildship, however, links the workspace projects anyway (as yet).
+	// Buildship, however, links the workspace projects anyway if a composite build is used.
 	compile "org.eclipse.xtext:org.eclipse.xtext:$versions.xtext_bootstrap"
 	compile "org.eclipse.xtext:org.eclipse.xtext.xtext.generator:$versions.xtext_bootstrap"
-	
-	// Dependencies required for successfully executing the Xtext generation workflow
-	mwe2Runtime "org.eclipse.emf:org.eclipse.emf.mwe2.launch:$versions.emfMwe2"
-	mwe2Runtime "org.eclipse.xtext:org.eclipse.xtext.common.types:$versions.xtext_bootstrap"
-	mwe2Runtime "org.eclipse.xtext:org.eclipse.xtext.ecore:$versions.xtext_bootstrap"
 }
 
-// Call this task for generating the 'Xtext' language implementation.
-// The employed version of the Xtext generator is determined by '$versions.xtext_bootstrap', see above.
-task generateXtextLanguage(type: JavaExec) {
-	main = 'org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher'
-	classpath = sourceSets.mwe2.runtimeClasspath
-	args += "src/org/eclipse/xtext/xtext/bootstrap/GenerateXtext.mwe2"
-	args += "-p"
-	args += "rootPath=/${projectDir}/.."
-}
+sourceSets.main.java.srcDirs = []
 
-// The following setting would cause 'generateXtextLanguage' to be executed as part of 'build',
-// namely before compiling the classes of the 'main' sourceSet, which however is empty here.
-// classes.dependsOn(generateXtextLanguage)
+sourceSets.mwe2 {
+	java.srcDir 'src'
+	if (findProperty('compileXtend') == 'true') {
+		xtendOutputDir = 'xtend-gen'
+	} else {
+		java.srcDir 'xtend-gen'
+	}
+}
+configurations.mwe2Compile.extendsFrom configurations.compile
+jar.from sourceSets.mwe2.output
+sourcesJar.from sourceSets.mwe2.allSource
+
+task generateXtextLanguage(type: XtextGeneratorTask) {
+	workflow = file('src/org/eclipse/xtext/xtext/bootstrap/GenerateXtext.mwe2')
+}

--- a/org.eclipse.xtext.xtext.bootstrap/build.gradle
+++ b/org.eclipse.xtext.xtext.bootstrap/build.gradle
@@ -1,3 +1,11 @@
+/*
+ * Bootstrap project for the Xtext language. It contains an MWE2 generator workflow with
+ * dedicated configuration code. The workflow generates into the core and generic ide projects
+ * as well as the Eclipse and IDEA integration projects, which are defined in different
+ * source repositories. The path to these other repositories is assumed to be ../xtext-eclipse
+ * and ../xtext-idea, respectively.
+ */
+
 apply from: "${rootDir}/gradle/mwe2-workflows.gradle"
 
 dependencies {
@@ -9,6 +17,9 @@ dependencies {
 }
 
 sourceSets.main.java.srcDirs = []
+sourceSets.main.resources.srcDirs = []
+sourceSets.test.java.srcDirs = []
+sourceSets.test.resources.srcDirs = []
 
 sourceSets.mwe2 {
 	java.srcDir 'src'
@@ -24,4 +35,11 @@ sourcesJar.from sourceSets.mwe2.allSource
 
 task generateXtextLanguage(type: XtextGeneratorTask) {
 	workflow = file('src/org/eclipse/xtext/xtext/bootstrap/GenerateXtext.mwe2')
+}
+
+eclipse {
+	project {
+		natures 'org.eclipse.xtext.ui.shared.xtextNature'
+		buildCommands.add(0,new org.gradle.plugins.ide.eclipse.model.BuildCommand('org.eclipse.xtext.ui.shared.xtextBuilder'))
+	}
 }


### PR DESCRIPTION
Now you can generate *all* test languages (`org.eclipse.xtext.testlanguages`, `org.eclipse.xtext.tests`, `org.eclipse.xtext.ide.tests`) by calling
```
./gradlew generateTestLanguages
```