### PR TITLE
generated Xtend servlet class should use !== instead of !=

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.xtend
@@ -737,7 +737,7 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 				}
 				
 				override destroy() {
-					if (disposableRegistry != null) {
+					if (disposableRegistry !== null) {
 						disposableRegistry.dispose()
 						disposableRegistry = null
 					}

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.java
@@ -1749,7 +1749,7 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
         _builder.append("override destroy() {");
         _builder.newLine();
         _builder.append("\t\t");
-        _builder.append("if (disposableRegistry != null) {");
+        _builder.append("if (disposableRegistry !== null) {");
         _builder.newLine();
         _builder.append("\t\t\t");
         _builder.append("disposableRegistry.dispose()");


### PR DESCRIPTION
Since now Xtend issues a warning if you use != with null.

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>