### PR TITLE
Return Object insteadof null in LanguageServer.shutdown.

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.xtend
@@ -152,7 +152,7 @@ import org.eclipse.xtext.validation.Issue
 	}
 
 	override CompletableFuture<Object> shutdown() {
-		return CompletableFuture.completedFuture(null);
+		return CompletableFuture.completedFuture(new Object());
 	}
 
 	override TextDocumentService getTextDocumentService() {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/LanguageServerImpl.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/LanguageServerImpl.java
@@ -229,7 +229,8 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
   
   @Override
   public CompletableFuture<Object> shutdown() {
-    return CompletableFuture.<Object>completedFuture(null);
+    Object _object = new Object();
+    return CompletableFuture.<Object>completedFuture(_object);
   }
   
   @Override


### PR DESCRIPTION
Return Object insteadof null in LanguageServer.shutdown.

Solves #240

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>