### PR TITLE
Switched to LSP4J 0.1.0 release

### DIFF
--- a/gradle/upstream-repositories.gradle
+++ b/gradle/upstream-repositories.gradle
@@ -12,7 +12,6 @@ def jenkinsPipelineRepo = { jobName -> "http://services.typefox.io/open-source/j
 repositories {
 	jcenter()
 	if (findProperty('useJenkinsSnapshots') == 'true') {
-		maven { url jenkinsPipelineRepo('lsp4j') }
 		maven { url jenkinsPipelineRepo('xtext-lib') }
 	} else {
 		mavenLocal()

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -9,7 +9,7 @@ ext.versions = [
 	'xtext_bootstrap': '2.11.0.beta2',
 	'gradle_plugins': '0.1.0',
 	'xtext_gradle_plugin': '1.0.15',
-	'lsp4j': '0.1.0-SNAPSHOT',
+	'lsp4j': '0.1.0',
 	'log4j': '1.2.16',
 	'equinoxCommon' : '3.8.0',
 	'equinoxRegistry' : '3.6.100',


### PR DESCRIPTION
The Xtext 2.11.0 release needs a fixed LSP4J version to depend on.