### PR TITLE
Lb task 244 junit4 fragment2

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin.ui.tests/META-INF/MANIFEST.MF
@@ -8,5 +8,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.xtext.example.eclipsePlugin.ui,
  org.junit;bundle-version="4.12.0",
  org.eclipse.xtext.testing,
- org.eclipse.xtext.xbase.testing
+ org.eclipse.xtext.xbase.testing,
+ org.eclipse.xtext.junit4,
+ org.eclipse.xtext.xbase.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2.ui.tests/META-INF/MANIFEST.MF
@@ -8,5 +8,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.xtext.example.eclipsePluginP2.ui,
  org.junit;bundle-version="4.12.0",
  org.eclipse.xtext.testing,
- org.eclipse.xtext.xbase.testing
+ org.eclipse.xtext.xbase.testing,
+ org.eclipse.xtext.junit4,
+ org.eclipse.xtext.xbase.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ui.tests/META-INF/MANIFEST.MF
@@ -8,5 +8,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.xtext.example.full.ui,
  org.junit;bundle-version="4.12.0",
  org.eclipse.xtext.testing,
- org.eclipse.xtext.xbase.testing
+ org.eclipse.xtext.xbase.testing,
+ org.eclipse.xtext.junit4,
+ org.eclipse.xtext.xbase.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ui.tests/META-INF/MANIFEST.MF
@@ -8,5 +8,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.xtext.example.mavenTycho.ui,
  org.junit;bundle-version="4.12.0",
  org.eclipse.xtext.testing,
- org.eclipse.xtext.xbase.testing
+ org.eclipse.xtext.xbase.testing,
+ org.eclipse.xtext.junit4,
+ org.eclipse.xtext.xbase.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ui.tests/META-INF/MANIFEST.MF
@@ -8,5 +8,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.xtext.example.mavenTychoP2.ui,
  org.junit;bundle-version="4.12.0",
  org.eclipse.xtext.testing,
- org.eclipse.xtext.xbase.testing
+ org.eclipse.xtext.xbase.testing,
+ org.eclipse.xtext.junit4,
+ org.eclipse.xtext.xbase.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.xtend
@@ -25,18 +25,28 @@ class Junit4Fragment2 extends AbstractStubGeneratingFragment {
 	
 	def protected getTestingPackage() {
 		if (useDeprecatedClasses)
-			"org.eclipse.xtext.junit4"
+			getUiTestingPackage()
 		else
 			"org.eclipse.xtext.testing"
+	}
+	
+	protected def String getUiTestingPackage() {
+		"org.eclipse.xtext.junit4"
 	}
 	
 	def protected getXbaseTestingPackage() {
 		if (skipXbaseTestingPackage)
 			return ""
 		if (useDeprecatedClasses)
-			"org.eclipse.xtext.xbase.junit"
+			getXbaseUiTestingPackage()
 		else
 			"org.eclipse.xtext.xbase.testing"
+	}
+	
+	protected def String getXbaseUiTestingPackage() {
+		if (skipXbaseTestingPackage)
+			return ""
+		"org.eclipse.xtext.xbase.junit"
 	}
 	
 	override generate() {
@@ -55,6 +65,8 @@ class Junit4Fragment2 extends AbstractStubGeneratingFragment {
 				requiredBundles.addAll(
 					testingPackage,
 					xbaseTestingPackage,
+					uiTestingPackage,
+					xbaseUiTestingPackage,
 					"org.eclipse.core.runtime",
 					"org.eclipse.ui.workbench;resolution:=optional"
 				)

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.java
@@ -42,11 +42,15 @@ public class Junit4Fragment2 extends AbstractStubGeneratingFragment {
   protected String getTestingPackage() {
     String _xifexpression = null;
     if (this.useDeprecatedClasses) {
-      _xifexpression = "org.eclipse.xtext.junit4";
+      _xifexpression = this.getUiTestingPackage();
     } else {
       _xifexpression = "org.eclipse.xtext.testing";
     }
     return _xifexpression;
+  }
+  
+  protected String getUiTestingPackage() {
+    return "org.eclipse.xtext.junit4";
   }
   
   protected String getXbaseTestingPackage() {
@@ -57,11 +61,22 @@ public class Junit4Fragment2 extends AbstractStubGeneratingFragment {
       }
       String _xifexpression = null;
       if (this.useDeprecatedClasses) {
-        _xifexpression = "org.eclipse.xtext.xbase.junit";
+        _xifexpression = this.getXbaseUiTestingPackage();
       } else {
         _xifexpression = "org.eclipse.xtext.xbase.testing";
       }
       _xblockexpression = _xifexpression;
+    }
+    return _xblockexpression;
+  }
+  
+  protected String getXbaseUiTestingPackage() {
+    String _xblockexpression = null;
+    {
+      if (this.skipXbaseTestingPackage) {
+        return "";
+      }
+      _xblockexpression = "org.eclipse.xtext.xbase.junit";
     }
     return _xblockexpression;
   }
@@ -91,6 +106,8 @@ public class Junit4Fragment2 extends AbstractStubGeneratingFragment {
         CollectionExtensions.<String>addAll(it.getRequiredBundles(), 
           this.getTestingPackage(), 
           this.getXbaseTestingPackage(), 
+          this.getUiTestingPackage(), 
+          this.getXbaseUiTestingPackage(), 
           "org.eclipse.core.runtime", 
           "org.eclipse.ui.workbench;resolution:=optional");
         String _eclipsePluginTestBasePackage = this._xtextGeneratorNaming.getEclipsePluginTestBasePackage(this.getGrammar());

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/UiTestProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/UiTestProjectDescriptor.xtend
@@ -19,6 +19,8 @@ class UiTestProjectDescriptor extends TestProjectDescriptor {
 		deps += super.externalDependencies
 		deps += createXtextDependency("org.eclipse.xtext.testing") => [maven.scope = Scope.TESTCOMPILE]
 		deps += createXtextDependency("org.eclipse.xtext.xbase.testing") => [maven.scope = Scope.TESTCOMPILE]
+		deps += createXtextDependency("org.eclipse.xtext.junit4") => [maven.scope = Scope.TESTCOMPILE]
+		deps += createXtextDependency("org.eclipse.xtext.xbase.junit") => [maven.scope = Scope.TESTCOMPILE]
 		deps
 	}
 	

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/UiTestProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/UiTestProjectDescriptor.java
@@ -43,6 +43,20 @@ public class UiTestProjectDescriptor extends TestProjectDescriptor {
       };
       ExternalDependency _doubleArrow_1 = ObjectExtensions.<ExternalDependency>operator_doubleArrow(_createXtextDependency_1, _function_1);
       deps.add(_doubleArrow_1);
+      ExternalDependency _createXtextDependency_2 = ExternalDependency.createXtextDependency("org.eclipse.xtext.junit4");
+      final Procedure1<ExternalDependency> _function_2 = (ExternalDependency it) -> {
+        ExternalDependency.MavenCoordinates _maven = it.getMaven();
+        _maven.setScope(Scope.TESTCOMPILE);
+      };
+      ExternalDependency _doubleArrow_2 = ObjectExtensions.<ExternalDependency>operator_doubleArrow(_createXtextDependency_2, _function_2);
+      deps.add(_doubleArrow_2);
+      ExternalDependency _createXtextDependency_3 = ExternalDependency.createXtextDependency("org.eclipse.xtext.xbase.junit");
+      final Procedure1<ExternalDependency> _function_3 = (ExternalDependency it) -> {
+        ExternalDependency.MavenCoordinates _maven = it.getMaven();
+        _maven.setScope(Scope.TESTCOMPILE);
+      };
+      ExternalDependency _doubleArrow_3 = ObjectExtensions.<ExternalDependency>operator_doubleArrow(_createXtextDependency_3, _function_3);
+      deps.add(_doubleArrow_3);
       _xblockexpression = deps;
     }
     return _xblockexpression;


### PR DESCRIPTION
The project wizard now adds .xtext.junit4 and .xbase.junit as deps in the .ui.tests project since these bundles still contain the UI testing classes. Accordingly, the mwe2 does the same (but still respecting skipXbaseTestingPackage).

Note that the additional extracted methods in the Junit4Fragment2.xtend: if useDeprecatedClasses is used in the mwe2, then .xtext.junit4 and .xbase.junit will be added twice in the collection of the required bundles for the .ui.tests project. However, when the MANIFEST is updated, possible duplicates are automatically dealt with, thus it is safe to do so.

Closes #244 