### PR TITLE
Fixed #238:PolymorphicDispatcher#compare violates contr. of Comparators

### DIFF
--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/PolymorphicDispatcher.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/PolymorphicDispatcher.java
@@ -353,7 +353,23 @@ public class PolymorphicDispatcher<RT> {
 		Collections.sort(cachedDescriptors, new Comparator<MethodDesc>() {
 			@Override
 			public int compare(MethodDesc o1, MethodDesc o2) {
-				return PolymorphicDispatcher.this.compare(o1, o2);
+				int compare = PolymorphicDispatcher.this.compare(o1, o2);
+				if (compare != 0) {
+					return compare;
+				}
+				Class<?>[] p1 = o1.getParameterTypes();
+				Class<?>[] p2 = o2.getParameterTypes();
+				int to = Math.min(p1.length, p2.length);
+
+				for (int i = 0; i < to; i++) {
+					final String n1 = p1[i].getName();
+					final String n2 = p2[i].getName();
+					compare = n1.compareTo(n2);
+					if (compare != 0) {
+						return compare;
+					}
+				}
+				return compare;
 			}
 		});
 		return cachedDescriptors;


### PR DESCRIPTION
based on @LorenzoBettini suggestions in
https://github.com/eclipse/xtext-core/pull/248#issuecomment-272873308

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>