### PR TITLE
Deprecated XtextGeneratorLanguage.generateXtendStubs

### DIFF
--- a/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.xtext,
  org.antlr.runtime,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,
- org.eclipse.xtext.testing;bundle-version="2.10.2"
+ org.eclipse.xtext.testing
 Import-Package: org.apache.log4j;version="1.2.15",
  org.hamcrest.core,
  org.junit;version="4.5.0",

--- a/org.eclipse.xtext.tests/META-INF/MANIFEST.MF_gen
+++ b/org.eclipse.xtext.tests/META-INF/MANIFEST.MF_gen
@@ -496,7 +496,8 @@ Require-Bundle: org.antlr.runtime,
  org.eclipse.xtext,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.util,
- org.eclipse.xtext.xbase.lib
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtext.xbase.testing
 Import-Package: org.apache.log4j,
  org.hamcrest.core,
  org.junit.runner.manipulation;version="4.5.0",

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/IXtextGeneratorLanguage.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/IXtextGeneratorLanguage.xtend
@@ -36,6 +36,10 @@ interface IXtextGeneratorLanguage {
 	
 	def ResourceSet getResourceSet()
 	
+	/**
+	 * @deprecated Use {@link CodeConfig#isPreferXtendStubs(boolean)} instead
+	 */
+	@Deprecated
 	def boolean isGenerateXtendStubs() 
 	
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.xtend
@@ -49,7 +49,6 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 	
 	String name
 	
-	@Accessors(PUBLIC_SETTER)	
 	Boolean generateXtendStubs
 	
 	@Accessors(PUBLIC_GETTER)
@@ -124,6 +123,18 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 		return fileExtensions
 	}
 	
+	/**
+	 * @deprecated Use {@link CodeConfig#setPreferXtendStubs(boolean)} instead
+	 */
+	@Deprecated
+	def void setGenerateXtendStubs(Boolean generateXtendStubs) {
+		this.generateXtendStubs = generateXtendStubs
+	}
+	
+	/**
+	 * @deprecated Use {@link CodeConfig#isPreferXtendStubs(boolean)} instead
+	 */
+	@Deprecated
 	override isGenerateXtendStubs() {
 		if (generateXtendStubs !== null) generateXtendStubs.booleanValue else codeConfig.preferXtendStubs
 	}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
@@ -42,6 +42,8 @@ import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
  */
 @Singleton
 class XtextGeneratorTemplates {
+	
+	@Inject CodeConfig codeConfig
 
 	@Inject FileAccessFactory fileAccessFactory
 	
@@ -49,7 +51,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createRuntimeSetup(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (langConfig.generateXtendStubs) {
+		if (codeConfig.preferXtendStubs) {
 			return fileAccessFactory.createXtendFile(runtimeSetup,'''
 				/**
 				 * Initialization support for running Xtext languages without Equinox extension registry.
@@ -168,7 +170,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createRuntimeModule(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (langConfig.generateXtendStubs) {
+		if (codeConfig.preferXtendStubs) {
 			return fileAccessFactory.createXtendFile(runtimeModule,'''
 				/**
 				 * Use this class to register components to be used at runtime / without the Equinox extension registry.
@@ -232,7 +234,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createIdeModule(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (langConfig.generateXtendStubs) {
+		if (codeConfig.preferXtendStubs) {
 			return fileAccessFactory.createXtendFile(genericIdeModule,'''
 				/**
 				 * Use this class to register ide components.
@@ -278,7 +280,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createIdeSetup(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (langConfig.generateXtendStubs) {
+		if (codeConfig.preferXtendStubs) {
 			return fileAccessFactory.createXtendFile(genericIdeSetup,'''
 				/**
 				 * Initialization support for running Xtext languages as language servers.
@@ -311,7 +313,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createEclipsePluginModule(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (langConfig.generateXtendStubs) {
+		if (codeConfig.preferXtendStubs) {
 			return fileAccessFactory.createXtendFile(eclipsePluginModule,'''
 				/**
 				 * Use this class to register components to be used within the Eclipse IDE.
@@ -366,7 +368,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createIdeaModule(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (langConfig.generateXtendStubs) {
+		if (codeConfig.preferXtendStubs) {
 			return fileAccessFactory.createXtendFile(ideaModule,'''
 				/**
 				 * Use this class to register components to be used within IntelliJ IDEA.
@@ -411,7 +413,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createWebModule(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (langConfig.generateXtendStubs) {
+		if (codeConfig.preferXtendStubs) {
 			return fileAccessFactory.createXtendFile(webModule,'''
 				/**
 				 * Use this class to register additional components to be used within the web application.
@@ -456,7 +458,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createWebSetup(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (langConfig.generateXtendStubs) {
+		if (codeConfig.preferXtendStubs) {
 			return fileAccessFactory.createXtendFile(webSetup, '''
 				/**
 				 * Initialization support for running Xtext languages in web applications.

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/IXtextGeneratorLanguage.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/IXtextGeneratorLanguage.java
@@ -36,5 +36,9 @@ public interface IXtextGeneratorLanguage {
   
   public abstract ResourceSet getResourceSet();
   
+  /**
+   * @deprecated Use {@link CodeConfig#isPreferXtendStubs(boolean)} instead
+   */
+  @Deprecated
   public abstract boolean isGenerateXtendStubs();
 }

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.java
@@ -69,7 +69,6 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
   
   private String name;
   
-  @Accessors(AccessorType.PUBLIC_SETTER)
   private Boolean generateXtendStubs;
   
   @Accessors(AccessorType.PUBLIC_GETTER)
@@ -160,6 +159,18 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
     return this.fileExtensions;
   }
   
+  /**
+   * @deprecated Use {@link CodeConfig#setPreferXtendStubs(boolean)} instead
+   */
+  @Deprecated
+  public void setGenerateXtendStubs(final Boolean generateXtendStubs) {
+    this.generateXtendStubs = generateXtendStubs;
+  }
+  
+  /**
+   * @deprecated Use {@link CodeConfig#isPreferXtendStubs(boolean)} instead
+   */
+  @Deprecated
   @Override
   public boolean isGenerateXtendStubs() {
     boolean _xifexpression = false;
@@ -356,10 +367,6 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
   }
   
   private final static Logger LOG = Logger.getLogger(XtextGeneratorLanguage.class);
-  
-  public void setGenerateXtendStubs(final Boolean generateXtendStubs) {
-    this.generateXtendStubs = generateXtendStubs;
-  }
   
   @Pure
   public Grammar getGrammar() {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
@@ -36,6 +36,7 @@ import org.eclipse.xtext.util.Modules2;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory;
@@ -53,6 +54,9 @@ import org.eclipse.xtext.xtext.generator.model.annotations.SuppressWarningsAnnot
 @SuppressWarnings("all")
 public class XtextGeneratorTemplates {
   @Inject
+  private CodeConfig codeConfig;
+  
+  @Inject
   private FileAccessFactory fileAccessFactory;
   
   @Inject
@@ -61,8 +65,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createRuntimeSetup(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
-    if (_isGenerateXtendStubs) {
+    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
+    if (_isPreferXtendStubs) {
       TypeReference _runtimeSetup = this.naming.getRuntimeSetup(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
@@ -522,8 +526,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createRuntimeModule(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
-    if (_isGenerateXtendStubs) {
+    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
+    if (_isPreferXtendStubs) {
       TypeReference _runtimeModule = this.naming.getRuntimeModule(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
@@ -715,8 +719,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createIdeModule(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
-    if (_isGenerateXtendStubs) {
+    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
+    if (_isPreferXtendStubs) {
       TypeReference _genericIdeModule = this.naming.getGenericIdeModule(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
@@ -837,8 +841,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createIdeSetup(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
-    if (_isGenerateXtendStubs) {
+    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
+    if (_isPreferXtendStubs) {
       TypeReference _genericIdeSetup = this.naming.getGenericIdeSetup(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
@@ -943,8 +947,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createEclipsePluginModule(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
-    if (_isGenerateXtendStubs) {
+    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
+    if (_isPreferXtendStubs) {
       TypeReference _eclipsePluginModule = this.naming.getEclipsePluginModule(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
@@ -1101,8 +1105,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createIdeaModule(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
-    if (_isGenerateXtendStubs) {
+    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
+    if (_isPreferXtendStubs) {
       TypeReference _ideaModule = this.naming.getIdeaModule(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
@@ -1223,8 +1227,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createWebModule(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
-    if (_isGenerateXtendStubs) {
+    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
+    if (_isPreferXtendStubs) {
       TypeReference _webModule = this.naming.getWebModule(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
@@ -1345,8 +1349,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createWebSetup(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
-    if (_isGenerateXtendStubs) {
+    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
+    if (_isPreferXtendStubs) {
       TypeReference _webSetup = this.naming.getWebSetup(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override


### PR DESCRIPTION
First step for #223. We should consider removing this property, which is possible since XtextGeneratorLanguage is marked with `@noextend`.