### PR TITLE
Removed some @noreference, @noextend tags; added Javadoc

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/AbstractInheritingFragment.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/AbstractInheritingFragment.xtend
@@ -10,6 +10,12 @@ package org.eclipse.xtext.xtext.generator
 import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment
 import org.eclipse.xtend.lib.annotations.Accessors
 
+/**
+ * A fragment that generates a class that inherits from the generated class of the super-grammar.
+ * This inheritance can be disabled with the {@code inheritImplementation} property.
+ */
 abstract class AbstractInheritingFragment extends AbstractStubGeneratingFragment {
+	
 	@Accessors boolean inheritImplementation = true
+	
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/AbstractStubGeneratingFragment.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/AbstractStubGeneratingFragment.xtend
@@ -11,6 +11,14 @@ import com.google.inject.Inject
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption
 
+/**
+ * A fragment that generates a <em>stub</em>, that is a class where the user can add
+ * custom behavior, e.g. validation or formatting rules. The stub is generated into
+ * the source folder that is not overwritten when the generator is executed again
+ * ({@code src} for plain project layout, {@code src/main/java} for Maven/Gradle
+ * project layout). If you want the stub to be generated again, delete the already
+ * existing file.
+ */
 abstract class AbstractStubGeneratingFragment extends AbstractXtextGeneratorFragment {
 
 	@Inject

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/AbstractXtextGeneratorFragment.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/AbstractXtextGeneratorFragment.xtend
@@ -13,6 +13,10 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.Grammar
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig
 
+/**
+ * Convenience class for implementing generator fragments. Provides access to the
+ * {@link IXtextProjectConfig project configuration} and the {@link IXtextGeneratorLanguage language configuration}.
+ */
 abstract class AbstractXtextGeneratorFragment implements IXtextGeneratorFragment {
 	
 	@Accessors(PROTECTED_GETTER)

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/CodeConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/CodeConfig.xtend
@@ -19,7 +19,6 @@ import java.nio.charset.Charset
 
 /**
  * Configuration object for generated code.
- * @noextend
  */
 class CodeConfig implements IGuiceAwareGeneratorComponent {
 
@@ -56,7 +55,7 @@ class CodeConfig implements IGuiceAwareGeneratorComponent {
 	 *   <li><code>${date}</code> - the current date (month day, year)</li>
 	 *   <li><code>${year}</code> - the current year</li>
 	 *   <li><code>${user}</code> - the content of the 'user.name' system property</li>
-	 *   <li><code>${version}</code> - the generator plug-in version</li>
+	 *   <li><code>${version}</code> - the generator bundle version</li>
 	 * </ul>
 	 */
 	def void setFileHeader(String fileHeaderTemplate) {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/CompositeGeneratorFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/CompositeGeneratorFragment2.xtend
@@ -12,7 +12,9 @@ import java.util.List
 import org.eclipse.xtend.lib.annotations.Accessors
 
 /**
- * @noreference
+ * A generator fragment that delegates to a list of contained fragments. This can be
+ * useful for extracting parts of a language configuration to a separate mwe2 file,
+ * for example.
  */
 class CompositeGeneratorFragment2 implements IXtextGeneratorFragment {
 

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/DefaultGeneratorModule.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/DefaultGeneratorModule.xtend
@@ -19,7 +19,19 @@ import org.eclipse.xtext.xtext.generator.model.project.StandardProjectConfig
 import org.eclipse.xtext.xtext.generator.model.project.XtextProjectConfig
 
 /**
- * @noextend
+ * An instance of this module is assigned to the {@code configuration} property of
+ * {@link XtextGenerator}. It contains the {@link XtextProjectConfig project configuration}
+ * and the {@link CodeConfig code configuration}. If you need to configure more aspects of
+ * the generator, create a subclass and bind your custom configuration classes. For example,
+ * in order to adapt the {@link XtextGeneratorNaming naming} of the generated code, use
+ * the following:
+ * <pre>
+ * class MyGeneratorModule extends DefaultGeneratorModule {
+ *     def Class&lt;? extends XtextGeneratorNaming&gt; bindXtextGeneratorNaming() {
+ *         MyGeneratorNaming
+ *     }
+ * }
+ * </pre>
  */
 class DefaultGeneratorModule extends AbstractGenericModule {
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/IGuiceAwareGeneratorComponent.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/IGuiceAwareGeneratorComponent.xtend
@@ -10,7 +10,9 @@ package org.eclipse.xtext.xtext.generator
 import com.google.inject.Injector
 
 /**
- * @noreference
+ * The Xtext generator uses dependency injection with <a href="https://github.com/google/guice">Guice</a>
+ * for distributing the configuration to all its components. Instances of this interface can initialize
+ * themselves with a Guice injector, e.g. by calling {@code injector.injectMembers(this)}.
  */
 interface IGuiceAwareGeneratorComponent {
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/IXtextGeneratorFragment.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/IXtextGeneratorFragment.xtend
@@ -8,8 +8,8 @@
 package org.eclipse.xtext.xtext.generator
 
 /**
- * A fragment that contributes to the {@link XtextGenerator}.
- * @noimplement
+ * A fragment that contributes to the {@link XtextGenerator}. Use {@link AbstractXtextGeneratorFragment}
+ * for implementing new fragments.
  */
 interface IXtextGeneratorFragment extends IGuiceAwareGeneratorComponent {
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/IXtextGeneratorLanguage.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/IXtextGeneratorLanguage.xtend
@@ -14,7 +14,9 @@ import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
 import org.eclipse.xtext.xtext.generator.model.StandaloneSetupAccess
 
 /**
- * @noimplement
+ * Configuration for an Xtext language. Implemented by {@link XtextGeneratorLanguage}.
+ * 
+ * @noimplement This interface should not be implemented by clients.
  */
 interface IXtextGeneratorLanguage {
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ImplicitFragment.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ImplicitFragment.xtend
@@ -17,6 +17,9 @@ import org.eclipse.xtext.xtext.generator.xbase.XbaseUsageDetector
 import static extension org.eclipse.xtext.GrammarUtil.*
 import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
 
+/**
+ * The ImplicitFragment is added in the first slot to all language configurations.
+ */
 package class ImplicitFragment extends AbstractStubGeneratingFragment {
 	
 	@Inject extension XbaseUsageDetector

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/Issues.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/Issues.xtend
@@ -8,11 +8,16 @@
 package org.eclipse.xtext.xtext.generator
 
 /**
- * @noreference
+ * Use this to report configuration problems during the {@link IXtextGeneratorFragment#checkConfiguration(Issues)} phase.
  */
 interface Issues {
+	
 	def void addError(String message)
+	
 	def void addError(String message, Object source)
+	
 	def void addWarning(String message)
+	
 	def void addWarning(String message, Object source)
+	
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/LanguageModule.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/LanguageModule.xtend
@@ -13,6 +13,10 @@ import org.eclipse.xtext.Grammar
 import org.eclipse.xtext.service.AbstractGenericModule
 import org.eclipse.xtext.xtext.RuleNames
 
+/**
+ * Language-specific Guice module that is used in a child injector of the global injector
+ * derived from {@link DefaultGeneratorModule}.
+ */
 @FinalFieldsConstructor
 package class LanguageModule extends AbstractGenericModule {
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/MweIssues.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/MweIssues.xtend
@@ -11,7 +11,7 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 
 /**
- * @noreference
+ * {@link Issues} implementation for MWE2 workflows.
  */
 @FinalFieldsConstructor
 class MweIssues implements Issues {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/StandardLanguage.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/StandardLanguage.xtend
@@ -40,8 +40,24 @@ import org.eclipse.xtext.xtext.generator.xbase.XbaseGeneratorFragment2
 import org.eclipse.xtext.xtext.generator.xbase.XtypeGeneratorFragment2
 
 /**
+ * This specialization of the {@link XtextGeneratorLanguage} adds all the standard generator fragments
+ * that are commonly used for Xtext languages. This eliminates the need to list all these fragments
+ * explicitly in the workflow file. More fragments can be added as required, but the standard fragments
+ * cannot be removed. However, most of these fragments disable themselves automatically if they are
+ * not applicable, e.g. the {@link WebIntegrationFragment} does not generate anything if the web project
+ * is disabled in the project configuration.
+ * 
+ * <p>The configuration for individual fragments can be made with the corresponding properties.
+ * For example, write
+ * <pre>
+ * formatter = formatting.Formatter2Fragment2 {
+ *     generateStub = true
+ * }
+ * </pre>
+ * to enable stub generation for the formatter.</p>
+ * 
  * @author Sven Efftinge - Initial contribution and API
- * @noextend
+ * @noextend This class should not be extended by clients.
  */
 @Accessors(PUBLIC_SETTER, PROTECTED_GETTER)
 @Log class StandardLanguage extends XtextGeneratorLanguage {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextDirectoryCleaner.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextDirectoryCleaner.xtend
@@ -16,13 +16,18 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig
 
 /**
- * @noextend
+ * This component cleans all directories for generated code according to the project configuration
+ * (usually 'src-gen' for plain layout and 'src/main/xtext-gen' for Maven/Gradle layout).
+ * 
+ * @noextend This class should not be extended by clients.
  */
 class XtextDirectoryCleaner implements IGuiceAwareGeneratorComponent {
+	
 	@Inject IXtextProjectConfig config
 
 	@Accessors(PUBLIC_SETTER)
 	boolean enabled = true
+	
 	@Accessors(PUBLIC_SETTER)
 	boolean useDefaultExcludes = true
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.xtend
@@ -40,10 +40,28 @@ import org.eclipse.xtext.xtext.generator.model.project.BundleProjectConfig
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig
 
 /**
- * The Xtext language infrastructure generator. Can be configured with {@link IXtextGeneratorFragment}
- * instances as well as with some properties declared via setter or adder methods.
+ * The Xtext language infrastructure generator. Use the {@code configuration} block to add general
+ * configuration for your Xtext project and the generated code, e.g.
+ * <pre>
+ * configuration = {
+ *     project = model.project.StandardProjectConfig {
+ *         baseName = "org.example.language"
+ *         rootPath = ".."
+ *     }
+ *     code = {
+ *         encoding = 'ISO-8859-1'
+ *     }
+ * }
+ * </pre>
+ * You can generate code for one or more Xtext languages within the same project. For each language,
+ * add a {@code language} block, e.g.
+ * <pre>
+ * language = StandardLanguage {
+ *     name = "org.example.language.MyExampleLanguage"
+ * }
+ * </pre>
  * 
- * @noextend
+ * @noextend This class should not be extended by clients.
  */
 @Log
 class XtextGenerator extends AbstractWorkflowComponent2 {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.xtend
@@ -40,7 +40,19 @@ import org.eclipse.xtext.xtext.generator.model.StandaloneSetupAccess
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig
 
 /**
- * @noextend
+ * Configuration for an Xtext language. Use this class if you need to specify exactly which generator
+ * fragments you want to include, or alternatively {@link StandardLanguage} to work with the standard
+ * fragments.
+ * 
+ * <p>The most important property is {@code name}, which should be set to the language name exactly
+ * as specified in the grammar file. If the default grammar resolution based on the name does not
+ * work in your particular scenario, set the {@code grammarUri} property instead. Furthermore,
+ * use {@code fileExtensions} to specify the file extensions for your language.</p>
+ * 
+ * <p>Generator fragments can be added with the {@code fragment} property. See {@link StandardLanguage}
+ * for a list of useful fragments.</p>
+ * 
+ * @noextend This class should not be extended by clients.
  */
 @Log
 class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXtextGeneratorLanguage {
@@ -95,6 +107,10 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 	
 	@Inject XtextGeneratorResourceSetInitializer resourceSetInitializer
 	
+	/**
+	 * The URI of the grammar file. Use this property if the automatic grammar resolution based on {@link #setName(String)}
+	 * does not work in your particular scenario.
+	 */
 	def void setGrammarUri(String uri) {
 		this.grammarUri = uri
 	}
@@ -103,14 +119,25 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 		grammarUri ?: new File(projectConfig.runtime.src.path, name.replace('.', '/') + ".xtext").toURI.toString
 	}
 	
+	/**
+	 * The language name exactly as specified in the grammar.
+	 */
 	def void setName(String name) {
 		this.name = name
 	}
 	
+	/**
+	 * Either a single file extension or a comma-separated list of extensions for which the language
+	 * shall be registered.
+	 */
 	def void setFileExtensions(String fileExtensions) {
 		this.fileExtensions = fileExtensions.trim.split('\\s*,\\s*').toList
 	}
 	
+	/**
+	 * Add a resource to be included in the resource set that will be used to load the grammar file.
+	 * This is often necessary if additional Ecore models are referenced by the grammar.
+	 */
 	def void addReferencedResource(String referencedResource) {
 		this.referencedResources += referencedResource
 	}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorNaming.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorNaming.xtend
@@ -15,7 +15,8 @@ import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig
 import static org.eclipse.xtext.GrammarUtil.*
 
 /**
- * @noreference
+ * Configuration of the names of the generated classes. Create a subclass and register it with a specialized
+ * {@link DefaultGeneratorModule} in order to customize some class or package names.
  */
 class XtextGeneratorNaming {
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorResourceSetInitializer.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorResourceSetInitializer.xtend
@@ -21,8 +21,8 @@ import org.eclipse.xtext.util.internal.Log
 import org.eclipse.emf.ecore.EcorePackage
 
 /**
- * @noextend
- * @noreference
+ * Initializes a resource set in order to load the grammar of a language. The resources to include are specified
+ * via {@link XtextGeneratorLanguage#addReferencedResource(String)}.
  */
 @Log
 class XtextGeneratorResourceSetInitializer {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorStandaloneSetup.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorStandaloneSetup.xtend
@@ -16,17 +16,19 @@ import org.eclipse.xtext.util.internal.Log
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig
 
 /**
- * @noextend
+ * Standalone setup for resolving EMF URIs in the context of the {@link XtextGenerator}. The actual
+ * setup is done by {@link StandaloneSetup}.
  */
 @Log
 class XtextGeneratorStandaloneSetup implements IGuiceAwareGeneratorComponent {
+	
 	@Inject IXtextProjectConfig projectConfig
 
 	@Accessors boolean scanClasspath = true
 
 	override initialize(Injector injector) {
 		injector.injectMembers(this)
-		setup
+		setup()
 	}
 
 	private def void setup() {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
@@ -38,7 +38,7 @@ import org.eclipse.xtext.xtext.generator.model.annotations.SuppressWarningsAnnot
 import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
 
 /**
- * @noreference
+ * Templates for generating the common language infrastructure.
  */
 @Singleton
 class XtextGeneratorTemplates {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/FileAccessFactory.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/FileAccessFactory.xtend
@@ -11,6 +11,9 @@ import com.google.inject.Inject
 import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtend2.lib.StringConcatenationClient
 
+/**
+ * Factory for creating text files, Java files, and Xtend files.
+ */
 class FileAccessFactory {
 	
 	@Inject CodeConfig codeConfig

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/GeneratedJavaFileAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/GeneratedJavaFileAccess.xtend
@@ -7,6 +7,9 @@ import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtext.xtext.generator.model.JavaFileAccess.JavaTypeAwareStringConcatenation
 import org.eclipse.xtext.xtext.generator.model.annotations.IClassAnnotation
 
+/**
+ * A specialized Java file generator used for classes in the 'src-gen' folder.
+ */
 class GeneratedJavaFileAccess extends JavaFileAccess {
 	
 	CharSequence typeComment

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/GuiceModuleAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/GuiceModuleAccess.xtend
@@ -15,6 +15,9 @@ import org.eclipse.xtend.lib.annotations.Data
 import org.eclipse.xtend2.lib.StringConcatenationClient
 import org.eclipse.xtext.util.internal.Log
 
+/**
+ * Configuration object for Guice modules based on {@link org.eclipse.xtext.service.AbstractGenericModule}.
+ */
 @Log
 class GuiceModuleAccess {
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/IXtextGeneratorFileSystemAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/IXtextGeneratorFileSystemAccess.xtend
@@ -7,9 +7,14 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext.generator.model
 
+import com.google.inject.ImplementedBy
 import org.eclipse.xtext.generator.IFileSystemAccess2
 import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent
 
+/**
+ * File system access for the Xtext generator.
+ */
+@ImplementedBy(XtextGeneratorFileSystemAccess)
 interface IXtextGeneratorFileSystemAccess extends IFileSystemAccess2, IGuiceAwareGeneratorComponent {
 	
 	def String getPath()

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/JavaFileAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/JavaFileAccess.xtend
@@ -17,6 +17,9 @@ import org.eclipse.xtend2.lib.StringConcatenationClient
 import org.eclipse.xtext.util.internal.CodeGenUtil2
 import org.eclipse.xtext.xtext.generator.CodeConfig
 
+/**
+ * A utility class for generating Java files.
+ */
 class JavaFileAccess extends TextFileAccess {
 	
 	/**

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/ManifestAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/ManifestAccess.xtend
@@ -19,6 +19,9 @@ import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent
 import com.google.inject.Injector
 import org.eclipse.xtext.util.Strings
 
+/**
+ * Configuration object for MANIFEST.MF files for use in Eclipse.
+ */
 @Log
 @Accessors
 class ManifestAccess extends TextFileAccess implements IGuiceAwareGeneratorComponent {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/PluginXmlAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/PluginXmlAccess.xtend
@@ -17,6 +17,9 @@ import com.google.inject.Inject
 import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent
 import com.google.inject.Injector
 
+/**
+ * Configuration object for plugin.xml files for use in Eclipse.
+ */
 @Log
 @Accessors
 class PluginXmlAccess extends TextFileAccess implements IGuiceAwareGeneratorComponent {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/StandaloneSetupAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/StandaloneSetupAccess.xtend
@@ -12,6 +12,10 @@ import java.util.Set
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend2.lib.StringConcatenationClient
 
+/**
+ * Configuration object for the generated standalone setup class. This class is responsible for adding
+ * required EMF packages to the global registries.
+ */
 @Accessors
 class StandaloneSetupAccess {
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TextFileAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TextFileAccess.xtend
@@ -12,6 +12,9 @@ import org.eclipse.xtext.generator.IFileSystemAccess2
 import org.eclipse.xtend2.lib.StringConcatenationClient
 import org.eclipse.xtend2.lib.StringConcatenation
 
+/**
+ * A utility class for generating plain text files.
+ */
 class TextFileAccess {
 
 	@Accessors

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TypeReference.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TypeReference.xtend
@@ -18,6 +18,10 @@ import org.eclipse.xtend.lib.annotations.EqualsHashCode
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage
 import org.eclipse.xtext.xtext.generator.util.GenModelUtil2
 
+/**
+ * Reference to a Java type. Use this for automatic import of types in {@link JavaFileAccess}
+ * and {@link XtendFileAccess}.
+ */
 @Accessors
 @EqualsHashCode
 class TypeReference {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/XtendFileAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/XtendFileAccess.xtend
@@ -9,6 +9,9 @@ package org.eclipse.xtext.xtext.generator.model
 
 import org.eclipse.xtext.xtext.generator.CodeConfig
 
+/**
+ * A utility class for generating Xtend files.
+ */
 class XtendFileAccess extends JavaFileAccess {
 	
 	/**

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/BundleProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/BundleProjectConfig.xtend
@@ -14,10 +14,13 @@ import org.eclipse.xtext.xtext.generator.model.ManifestAccess
 import org.eclipse.xtext.xtext.generator.model.PluginXmlAccess
 
 /**
- * @noextend
+ * Configuration of subprojects that can be used as Eclipse bundles.
+ * 
+ * @noextend This class should not be extended by clients.
  */
 @Accessors
-class BundleProjectConfig extends SubProjectConfig implements IBundleProjectConfig{
+class BundleProjectConfig extends SubProjectConfig implements IBundleProjectConfig {
+	
 	ManifestAccess manifest
 	PluginXmlAccess pluginXml
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/IBundleProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/IBundleProjectConfig.xtend
@@ -11,9 +11,14 @@ import org.eclipse.xtext.xtext.generator.model.ManifestAccess
 import org.eclipse.xtext.xtext.generator.model.PluginXmlAccess
 
 /**
- * @noimplement
+ * Configuration of subprojects that can be used as Eclipse bundles.
+ * 
+ * @noimplement This interface should not be implemented by clients.
  */
 interface IBundleProjectConfig extends ISubProjectConfig {
+	
 	def ManifestAccess getManifest()
+	
 	def PluginXmlAccess getPluginXml()
+	
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/IRuntimeProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/IRuntimeProjectConfig.xtend
@@ -10,9 +10,14 @@ package org.eclipse.xtext.xtext.generator.model.project
 import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess
 
 /**
- * @noimplement
+ * Configuration of the runtime project, i.e. the main subproject containing the language definition.
+ * 
+ * @noimplement This interface should not be implemented by clients.
  */
 interface IRuntimeProjectConfig extends IBundleProjectConfig {
+	
 	def IXtextGeneratorFileSystemAccess getEcoreModel()
+	
 	def String getEcoreModelFolder()
+	
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/ISubProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/ISubProjectConfig.xtend
@@ -11,13 +11,22 @@ import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent
 import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess
 
 /**
- * @noimplement
+ * Configuration of subprojects.
+ * 
+ * @noimplement This interface should not be implemented by clients.
  */
 interface ISubProjectConfig extends IGuiceAwareGeneratorComponent {
+	
 	def boolean isEnabled()
+	
 	def String getName()
+	
 	def IXtextGeneratorFileSystemAccess getRoot()
+	
 	def IXtextGeneratorFileSystemAccess getMetaInf()
+	
 	def IXtextGeneratorFileSystemAccess getSrc()
+	
 	def IXtextGeneratorFileSystemAccess getSrcGen()
+	
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/IWebProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/IWebProjectConfig.xtend
@@ -10,8 +10,12 @@ package org.eclipse.xtext.xtext.generator.model.project
 import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess
 
 /**
- * @noimplement
+ * Configuration of the web project.
+ * 
+ * @noimplement This interface should not be implemented by clients.
  */
 interface IWebProjectConfig extends ISubProjectConfig {
+	
 	def IXtextGeneratorFileSystemAccess getAssets()
+	
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/IXtextProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/IXtextProjectConfig.xtend
@@ -11,16 +11,28 @@ import java.util.List
 import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent
 
 /**
- * @noimplement
+ * Configuration of the subprojects for one or more Xtext languages. Implemented by {@link XtextProjectConfig}.
+ * 
+ * @noimplement This interface should not be implemented by clients.
  */
 interface IXtextProjectConfig extends IGuiceAwareGeneratorComponent {
+	
 	def IRuntimeProjectConfig getRuntime()
+	
 	def IBundleProjectConfig getRuntimeTest()
+	
 	def IBundleProjectConfig getGenericIde()
+	
 	def IBundleProjectConfig getEclipsePlugin()
+	
 	def IBundleProjectConfig getEclipsePluginTest()
+	
 	def ISubProjectConfig getIdeaPlugin()
+	
 	def IWebProjectConfig getWeb()
+	
 	def List<? extends ISubProjectConfig> getEnabledProjects()
+	
 	def List<? extends ISubProjectConfig> getTestProjects()
+	
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/RuntimeProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/RuntimeProjectConfig.xtend
@@ -13,7 +13,9 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess
 
 /**
- * @noextend
+ * Configuration of the runtime project, i.e. the main subproject containing the language definition.
+ * 
+ * @noextend This class should not be extended by clients.
  */
 class RuntimeProjectConfig extends BundleProjectConfig implements IRuntimeProjectConfig {
 	@Accessors(PUBLIC_GETTER)

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/StandardProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/StandardProjectConfig.xtend
@@ -12,7 +12,10 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.xtext.generator.Issues
 
 /**
- * @noextend
+ * Specialized project configuration that uses standard names and paths. Usually it is sufficient to
+ * set the {@code baseName} and {@code rootPath} properties and to enable the required subprojects.
+ * 
+ * @noextend This class should not be extended by clients.
  */
 @Accessors
 class StandardProjectConfig extends XtextProjectConfig {
@@ -23,11 +26,17 @@ class StandardProjectConfig extends XtextProjectConfig {
 	String rootPath
 	String baseName
 
+	/**
+	 * The base name of the project, which is usually equal to the runtime subproject.
+	 */
 	@Mandatory
 	def setBaseName(String baseName) {
 		this.baseName = baseName
 	}
 
+	/**
+	 * The root path, usually {@code ".."}.
+	 */
 	@Mandatory
 	def setRootPath(String rootPath) {
 		this.rootPath = rootPath

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/SubProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/SubProjectConfig.xtend
@@ -14,9 +14,12 @@ import org.eclipse.xtext.xtext.generator.Issues
 import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess
 
 /**
- * @noextend
+ * Configuration of subprojects.
+ * 
+ * @noextend This class should not be extended by clients.
  */
 class SubProjectConfig implements ISubProjectConfig {
+	
 	@Inject
 	@Accessors(PUBLIC_GETTER)
 	XtextProjectConfig owner

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/WebProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/WebProjectConfig.xtend
@@ -12,11 +12,15 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess
 
 /**
- * @noextend
+ * Configuration of the web project.
+ * 
+ * @noextend This class should not be extended by clients.
  */
 class WebProjectConfig extends SubProjectConfig implements IWebProjectConfig {
+	
 	@Accessors(PUBLIC_GETTER)
 	String assetsPath
+	
 	@Accessors(PUBLIC_GETTER)
 	IXtextGeneratorFileSystemAccess assets
 	

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/XtextProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/XtextProjectConfig.xtend
@@ -18,16 +18,26 @@ import org.eclipse.xtext.xtext.generator.model.PluginXmlAccess
 import org.eclipse.xtext.xtext.generator.model.XtextGeneratorFileSystemAccess
 
 /**
- * @noextend
+ * Configuration of the subprojects for one or more Xtext languages. If the standard project names
+ * and layout is sufficient, use {@link StandardProjectConfig}.
+ * 
+ * @noextend This class should not be extended by clients.
  */
 @Accessors
 class XtextProjectConfig implements IXtextProjectConfig {
+	
 	RuntimeProjectConfig runtime = new RuntimeProjectConfig
+	
 	BundleProjectConfig runtimeTest = new BundleProjectConfig
+	
 	BundleProjectConfig genericIde = new BundleProjectConfig
+	
 	BundleProjectConfig eclipsePlugin = new BundleProjectConfig
+	
 	BundleProjectConfig eclipsePluginTest = new BundleProjectConfig
+	
 	SubProjectConfig ideaPlugin = new SubProjectConfig
+	
 	WebProjectConfig web = new WebProjectConfig
 	
 	@Inject CodeConfig codeConfig

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractInheritingFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractInheritingFragment.java
@@ -11,6 +11,10 @@ import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment;
 
+/**
+ * A fragment that generates a class that inherits from the generated class of the super-grammar.
+ * This inheritance can be disabled with the {@code inheritImplementation} property.
+ */
 @SuppressWarnings("all")
 public abstract class AbstractInheritingFragment extends AbstractStubGeneratingFragment {
   @Accessors

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractStubGeneratingFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractStubGeneratingFragment.java
@@ -16,6 +16,14 @@ import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment;
 import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption;
 
+/**
+ * A fragment that generates a <em>stub</em>, that is a class where the user can add
+ * custom behavior, e.g. validation or formatting rules. The stub is generated into
+ * the source folder that is not overwritten when the generator is executed again
+ * ({@code src} for plain project layout, {@code src/main/java} for Maven/Gradle
+ * project layout). If you want the stub to be generated again, delete the already
+ * existing file.
+ */
 @SuppressWarnings("all")
 public abstract class AbstractStubGeneratingFragment extends AbstractXtextGeneratorFragment {
   @Inject

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractXtextGeneratorFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractXtextGeneratorFragment.java
@@ -18,6 +18,10 @@ import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.Issues;
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
 
+/**
+ * Convenience class for implementing generator fragments. Provides access to the
+ * {@link IXtextProjectConfig project configuration} and the {@link IXtextGeneratorLanguage language configuration}.
+ */
 @SuppressWarnings("all")
 public abstract class AbstractXtextGeneratorFragment implements IXtextGeneratorFragment {
   @Accessors(AccessorType.PROTECTED_GETTER)

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/CodeConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/CodeConfig.java
@@ -24,7 +24,6 @@ import org.eclipse.xtext.xtext.generator.model.annotations.IClassAnnotation;
 
 /**
  * Configuration object for generated code.
- * @noextend
  */
 @SuppressWarnings("all")
 public class CodeConfig implements IGuiceAwareGeneratorComponent {
@@ -65,7 +64,7 @@ public class CodeConfig implements IGuiceAwareGeneratorComponent {
    *   <li><code>${date}</code> - the current date (month day, year)</li>
    *   <li><code>${year}</code> - the current year</li>
    *   <li><code>${user}</code> - the content of the 'user.name' system property</li>
-   *   <li><code>${version}</code> - the generator plug-in version</li>
+   *   <li><code>${version}</code> - the generator bundle version</li>
    * </ul>
    */
   public void setFileHeader(final String fileHeaderTemplate) {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/CompositeGeneratorFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/CompositeGeneratorFragment2.java
@@ -19,7 +19,9 @@ import org.eclipse.xtext.xtext.generator.IXtextGeneratorFragment;
 import org.eclipse.xtext.xtext.generator.Issues;
 
 /**
- * @noreference
+ * A generator fragment that delegates to a list of contained fragments. This can be
+ * useful for extracting parts of a language configuration to a separate mwe2 file,
+ * for example.
  */
 @SuppressWarnings("all")
 public class CompositeGeneratorFragment2 implements IXtextGeneratorFragment {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/DefaultGeneratorModule.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/DefaultGeneratorModule.java
@@ -25,7 +25,19 @@ import org.eclipse.xtext.xtext.generator.model.project.StandardProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.XtextProjectConfig;
 
 /**
- * @noextend
+ * An instance of this module is assigned to the {@code configuration} property of
+ * {@link XtextGenerator}. It contains the {@link XtextProjectConfig project configuration}
+ * and the {@link CodeConfig code configuration}. If you need to configure more aspects of
+ * the generator, create a subclass and bind your custom configuration classes. For example,
+ * in order to adapt the {@link XtextGeneratorNaming naming} of the generated code, use
+ * the following:
+ * <pre>
+ * class MyGeneratorModule extends DefaultGeneratorModule {
+ *     def Class&lt;? extends XtextGeneratorNaming&gt; bindXtextGeneratorNaming() {
+ *         MyGeneratorNaming
+ *     }
+ * }
+ * </pre>
  */
 @SuppressWarnings("all")
 public class DefaultGeneratorModule extends AbstractGenericModule {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/IGuiceAwareGeneratorComponent.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/IGuiceAwareGeneratorComponent.java
@@ -10,7 +10,9 @@ package org.eclipse.xtext.xtext.generator;
 import com.google.inject.Injector;
 
 /**
- * @noreference
+ * The Xtext generator uses dependency injection with <a href="https://github.com/google/guice">Guice</a>
+ * for distributing the configuration to all its components. Instances of this interface can initialize
+ * themselves with a Guice injector, e.g. by calling {@code injector.injectMembers(this)}.
  */
 @SuppressWarnings("all")
 public interface IGuiceAwareGeneratorComponent {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/IXtextGeneratorFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/IXtextGeneratorFragment.java
@@ -11,8 +11,8 @@ import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent;
 import org.eclipse.xtext.xtext.generator.Issues;
 
 /**
- * A fragment that contributes to the {@link XtextGenerator}.
- * @noimplement
+ * A fragment that contributes to the {@link XtextGenerator}. Use {@link AbstractXtextGeneratorFragment}
+ * for implementing new fragments.
  */
 @SuppressWarnings("all")
 public interface IXtextGeneratorFragment extends IGuiceAwareGeneratorComponent {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/IXtextGeneratorLanguage.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/IXtextGeneratorLanguage.java
@@ -14,7 +14,9 @@ import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess;
 import org.eclipse.xtext.xtext.generator.model.StandaloneSetupAccess;
 
 /**
- * @noimplement
+ * Configuration for an Xtext language. Implemented by {@link XtextGeneratorLanguage}.
+ * 
+ * @noimplement This interface should not be implemented by clients.
  */
 @SuppressWarnings("all")
 public interface IXtextGeneratorLanguage {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ImplicitFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ImplicitFragment.java
@@ -27,6 +27,9 @@ import org.eclipse.xtext.xtext.generator.model.PluginXmlAccess;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
 import org.eclipse.xtext.xtext.generator.xbase.XbaseUsageDetector;
 
+/**
+ * The ImplicitFragment is added in the first slot to all language configurations.
+ */
 @SuppressWarnings("all")
 class ImplicitFragment extends AbstractStubGeneratingFragment {
   @Inject

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/Issues.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/Issues.java
@@ -8,7 +8,7 @@
 package org.eclipse.xtext.xtext.generator;
 
 /**
- * @noreference
+ * Use this to report configuration problems during the {@link IXtextGeneratorFragment#checkConfiguration(Issues)} phase.
  */
 @SuppressWarnings("all")
 public interface Issues {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/LanguageModule.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/LanguageModule.java
@@ -16,6 +16,10 @@ import org.eclipse.xtext.xtext.RuleNames;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorLanguage;
 
+/**
+ * Language-specific Guice module that is used in a child injector of the global injector
+ * derived from {@link DefaultGeneratorModule}.
+ */
 @FinalFieldsConstructor
 @SuppressWarnings("all")
 class LanguageModule extends AbstractGenericModule {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/MweIssues.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/MweIssues.java
@@ -14,7 +14,7 @@ import org.eclipse.xtext.xtext.generator.Issues;
 import org.eclipse.xtext.xtext.generator.XtextGenerator;
 
 /**
- * @noreference
+ * {@link Issues} implementation for MWE2 workflows.
  */
 @FinalFieldsConstructor
 @SuppressWarnings("all")

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/StandardLanguage.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/StandardLanguage.java
@@ -49,8 +49,24 @@ import org.eclipse.xtext.xtext.generator.xbase.XbaseGeneratorFragment2;
 import org.eclipse.xtext.xtext.generator.xbase.XtypeGeneratorFragment2;
 
 /**
+ * This specialization of the {@link XtextGeneratorLanguage} adds all the standard generator fragments
+ * that are commonly used for Xtext languages. This eliminates the need to list all these fragments
+ * explicitly in the workflow file. More fragments can be added as required, but the standard fragments
+ * cannot be removed. However, most of these fragments disable themselves automatically if they are
+ * not applicable, e.g. the {@link WebIntegrationFragment} does not generate anything if the web project
+ * is disabled in the project configuration.
+ * 
+ * <p>The configuration for individual fragments can be made with the corresponding properties.
+ * For example, write
+ * <pre>
+ * formatter = formatting.Formatter2Fragment2 {
+ *     generateStub = true
+ * }
+ * </pre>
+ * to enable stub generation for the formatter.</p>
+ * 
  * @author Sven Efftinge - Initial contribution and API
- * @noextend
+ * @noextend This class should not be extended by clients.
  */
 @Accessors({ AccessorType.PUBLIC_SETTER, AccessorType.PROTECTED_GETTER })
 @Log

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextDirectoryCleaner.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextDirectoryCleaner.java
@@ -29,7 +29,10 @@ import org.eclipse.xtext.xtext.generator.model.project.ISubProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
 
 /**
- * @noextend
+ * This component cleans all directories for generated code according to the project configuration
+ * (usually 'src-gen' for plain layout and 'src/main/xtext-gen' for Maven/Gradle layout).
+ * 
+ * @noextend This class should not be extended by clients.
  */
 @SuppressWarnings("all")
 public class XtextDirectoryCleaner implements IGuiceAwareGeneratorComponent {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGenerator.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGenerator.java
@@ -68,10 +68,28 @@ import org.eclipse.xtext.xtext.generator.model.project.BundleProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
 
 /**
- * The Xtext language infrastructure generator. Can be configured with {@link IXtextGeneratorFragment}
- * instances as well as with some properties declared via setter or adder methods.
+ * The Xtext language infrastructure generator. Use the {@code configuration} block to add general
+ * configuration for your Xtext project and the generated code, e.g.
+ * <pre>
+ * configuration = {
+ *     project = model.project.StandardProjectConfig {
+ *         baseName = "org.example.language"
+ *         rootPath = ".."
+ *     }
+ *     code = {
+ *         encoding = 'ISO-8859-1'
+ *     }
+ * }
+ * </pre>
+ * You can generate code for one or more Xtext languages within the same project. For each language,
+ * add a {@code language} block, e.g.
+ * <pre>
+ * language = StandardLanguage {
+ *     name = "org.example.language.MyExampleLanguage"
+ * }
+ * </pre>
  * 
- * @noextend
+ * @noextend This class should not be extended by clients.
  */
 @Log
 @SuppressWarnings("all")

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.java
@@ -60,7 +60,19 @@ import org.eclipse.xtext.xtext.generator.model.StandaloneSetupAccess;
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
 
 /**
- * @noextend
+ * Configuration for an Xtext language. Use this class if you need to specify exactly which generator
+ * fragments you want to include, or alternatively {@link StandardLanguage} to work with the standard
+ * fragments.
+ * 
+ * <p>The most important property is {@code name}, which should be set to the language name exactly
+ * as specified in the grammar file. If the default grammar resolution based on the name does not
+ * work in your particular scenario, set the {@code grammarUri} property instead. Furthermore,
+ * use {@code fileExtensions} to specify the file extensions for your language.</p>
+ * 
+ * <p>Generator fragments can be added with the {@code fragment} property. See {@link StandardLanguage}
+ * for a list of useful fragments.</p>
+ * 
+ * @noextend This class should not be extended by clients.
  */
 @Log
 @SuppressWarnings("all")
@@ -120,6 +132,10 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
   @Inject
   private XtextGeneratorResourceSetInitializer resourceSetInitializer;
   
+  /**
+   * The URI of the grammar file. Use this property if the automatic grammar resolution based on {@link #setName(String)}
+   * does not work in your particular scenario.
+   */
   public void setGrammarUri(final String uri) {
     this.grammarUri = uri;
   }
@@ -138,14 +154,25 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
     return _elvis;
   }
   
+  /**
+   * The language name exactly as specified in the grammar.
+   */
   public void setName(final String name) {
     this.name = name;
   }
   
+  /**
+   * Either a single file extension or a comma-separated list of extensions for which the language
+   * shall be registered.
+   */
   public void setFileExtensions(final String fileExtensions) {
     this.fileExtensions = IterableExtensions.<String>toList(((Iterable<String>)Conversions.doWrapArray(fileExtensions.trim().split("\\s*,\\s*"))));
   }
   
+  /**
+   * Add a resource to be included in the resource set that will be used to load the grammar file.
+   * This is often necessary if additional Ecore models are referenced by the grammar.
+   */
   public void addReferencedResource(final String referencedResource) {
     this.referencedResources.add(referencedResource);
   }

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorNaming.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorNaming.java
@@ -15,7 +15,8 @@ import org.eclipse.xtext.xtext.generator.model.TypeReference;
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
 
 /**
- * @noreference
+ * Configuration of the names of the generated classes. Create a subclass and register it with a specialized
+ * {@link DefaultGeneratorModule} in order to customize some class or package names.
  */
 @SuppressWarnings("all")
 public class XtextGeneratorNaming {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorResourceSetInitializer.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorResourceSetInitializer.java
@@ -27,8 +27,8 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
- * @noextend
- * @noreference
+ * Initializes a resource set in order to load the grammar of a language. The resources to include are specified
+ * via {@link XtextGeneratorLanguage#addReferencedResource(String)}.
  */
 @Log
 @SuppressWarnings("all")

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorStandaloneSetup.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorStandaloneSetup.java
@@ -26,7 +26,8 @@ import org.eclipse.xtext.xtext.generator.model.project.ISubProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
 
 /**
- * @noextend
+ * Standalone setup for resolving EMF URIs in the context of the {@link XtextGenerator}. The actual
+ * setup is done by {@link StandaloneSetup}.
  */
 @Log
 @SuppressWarnings("all")

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
@@ -48,7 +48,7 @@ import org.eclipse.xtext.xtext.generator.model.annotations.IClassAnnotation;
 import org.eclipse.xtext.xtext.generator.model.annotations.SuppressWarningsAnnotation;
 
 /**
- * @noreference
+ * Templates for generating the common language infrastructure.
  */
 @Singleton
 @SuppressWarnings("all")

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/FileAccessFactory.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/FileAccessFactory.java
@@ -16,6 +16,9 @@ import org.eclipse.xtext.xtext.generator.model.TextFileAccess;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
 import org.eclipse.xtext.xtext.generator.model.XtendFileAccess;
 
+/**
+ * Factory for creating text files, Java files, and Xtend files.
+ */
 @SuppressWarnings("all")
 public class FileAccessFactory {
   @Inject

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/GeneratedJavaFileAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/GeneratedJavaFileAccess.java
@@ -15,6 +15,9 @@ import org.eclipse.xtext.xtext.generator.model.JavaFileAccess;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
 import org.eclipse.xtext.xtext.generator.model.annotations.IClassAnnotation;
 
+/**
+ * A specialized Java file generator used for classes in the 'src-gen' folder.
+ */
 @SuppressWarnings("all")
 public class GeneratedJavaFileAccess extends JavaFileAccess {
   private CharSequence typeComment;

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/GuiceModuleAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/GuiceModuleAccess.java
@@ -23,6 +23,9 @@ import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
 
+/**
+ * Configuration object for Guice modules based on {@link org.eclipse.xtext.service.AbstractGenericModule}.
+ */
 @Log
 @SuppressWarnings("all")
 public class GuiceModuleAccess {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/IXtextGeneratorFileSystemAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/IXtextGeneratorFileSystemAccess.java
@@ -7,9 +7,15 @@
  */
 package org.eclipse.xtext.xtext.generator.model;
 
+import com.google.inject.ImplementedBy;
 import org.eclipse.xtext.generator.IFileSystemAccess2;
 import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent;
+import org.eclipse.xtext.xtext.generator.model.XtextGeneratorFileSystemAccess;
 
+/**
+ * File system access for the Xtext generator.
+ */
+@ImplementedBy(XtextGeneratorFileSystemAccess.class)
 @SuppressWarnings("all")
 public interface IXtextGeneratorFileSystemAccess extends IFileSystemAccess2, IGuiceAwareGeneratorComponent {
   public abstract String getPath();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/JavaFileAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/JavaFileAccess.java
@@ -29,6 +29,9 @@ import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.model.TextFileAccess;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
 
+/**
+ * A utility class for generating Java files.
+ */
 @SuppressWarnings("all")
 public class JavaFileAccess extends TextFileAccess {
   protected static class JavaTypeAwareStringConcatenation extends StringConcatenation {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/ManifestAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/ManifestAccess.java
@@ -31,6 +31,9 @@ import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent;
 import org.eclipse.xtext.xtext.generator.model.TextFileAccess;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
 
+/**
+ * Configuration object for MANIFEST.MF files for use in Eclipse.
+ */
 @Log
 @Accessors
 @SuppressWarnings("all")

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/PluginXmlAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/PluginXmlAccess.java
@@ -23,6 +23,9 @@ import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent;
 import org.eclipse.xtext.xtext.generator.model.TextFileAccess;
 
+/**
+ * Configuration object for plugin.xml files for use in Eclipse.
+ */
 @Log
 @Accessors
 @SuppressWarnings("all")

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/StandaloneSetupAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/StandaloneSetupAccess.java
@@ -15,6 +15,10 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
 
+/**
+ * Configuration object for the generated standalone setup class. This class is responsible for adding
+ * required EMF packages to the global registries.
+ */
 @Accessors
 @SuppressWarnings("all")
 public class StandaloneSetupAccess {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/TextFileAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/TextFileAccess.java
@@ -15,6 +15,9 @@ import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 
+/**
+ * A utility class for generating plain text files.
+ */
 @SuppressWarnings("all")
 public class TextFileAccess {
   @Accessors

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/TypeReference.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/TypeReference.java
@@ -24,6 +24,10 @@ import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.util.GenModelUtil2;
 
+/**
+ * Reference to a Java type. Use this for automatic import of types in {@link JavaFileAccess}
+ * and {@link XtendFileAccess}.
+ */
 @Accessors
 @EqualsHashCode
 @SuppressWarnings("all")

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/XtendFileAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/XtendFileAccess.java
@@ -14,6 +14,9 @@ import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.model.JavaFileAccess;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
 
+/**
+ * A utility class for generating Xtend files.
+ */
 @SuppressWarnings("all")
 public class XtendFileAccess extends JavaFileAccess {
   /**

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/BundleProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/BundleProjectConfig.java
@@ -17,7 +17,9 @@ import org.eclipse.xtext.xtext.generator.model.project.IBundleProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.SubProjectConfig;
 
 /**
- * @noextend
+ * Configuration of subprojects that can be used as Eclipse bundles.
+ * 
+ * @noextend This class should not be extended by clients.
  */
 @Accessors
 @SuppressWarnings("all")

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/IBundleProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/IBundleProjectConfig.java
@@ -12,7 +12,9 @@ import org.eclipse.xtext.xtext.generator.model.PluginXmlAccess;
 import org.eclipse.xtext.xtext.generator.model.project.ISubProjectConfig;
 
 /**
- * @noimplement
+ * Configuration of subprojects that can be used as Eclipse bundles.
+ * 
+ * @noimplement This interface should not be implemented by clients.
  */
 @SuppressWarnings("all")
 public interface IBundleProjectConfig extends ISubProjectConfig {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/IRuntimeProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/IRuntimeProjectConfig.java
@@ -11,7 +11,9 @@ import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess;
 import org.eclipse.xtext.xtext.generator.model.project.IBundleProjectConfig;
 
 /**
- * @noimplement
+ * Configuration of the runtime project, i.e. the main subproject containing the language definition.
+ * 
+ * @noimplement This interface should not be implemented by clients.
  */
 @SuppressWarnings("all")
 public interface IRuntimeProjectConfig extends IBundleProjectConfig {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/ISubProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/ISubProjectConfig.java
@@ -11,7 +11,9 @@ import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent;
 import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess;
 
 /**
- * @noimplement
+ * Configuration of subprojects.
+ * 
+ * @noimplement This interface should not be implemented by clients.
  */
 @SuppressWarnings("all")
 public interface ISubProjectConfig extends IGuiceAwareGeneratorComponent {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/IWebProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/IWebProjectConfig.java
@@ -11,7 +11,9 @@ import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess;
 import org.eclipse.xtext.xtext.generator.model.project.ISubProjectConfig;
 
 /**
- * @noimplement
+ * Configuration of the web project.
+ * 
+ * @noimplement This interface should not be implemented by clients.
  */
 @SuppressWarnings("all")
 public interface IWebProjectConfig extends ISubProjectConfig {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/IXtextProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/IXtextProjectConfig.java
@@ -15,7 +15,9 @@ import org.eclipse.xtext.xtext.generator.model.project.ISubProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.IWebProjectConfig;
 
 /**
- * @noimplement
+ * Configuration of the subprojects for one or more Xtext languages. Implemented by {@link XtextProjectConfig}.
+ * 
+ * @noimplement This interface should not be implemented by clients.
  */
 @SuppressWarnings("all")
 public interface IXtextProjectConfig extends IGuiceAwareGeneratorComponent {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/RuntimeProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/RuntimeProjectConfig.java
@@ -18,7 +18,9 @@ import org.eclipse.xtext.xtext.generator.model.project.BundleProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.IRuntimeProjectConfig;
 
 /**
- * @noextend
+ * Configuration of the runtime project, i.e. the main subproject containing the language definition.
+ * 
+ * @noextend This class should not be extended by clients.
  */
 @SuppressWarnings("all")
 public class RuntimeProjectConfig extends BundleProjectConfig implements IRuntimeProjectConfig {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/StandardProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/StandardProjectConfig.java
@@ -22,7 +22,10 @@ import org.eclipse.xtext.xtext.generator.model.project.WebProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.XtextProjectConfig;
 
 /**
- * @noextend
+ * Specialized project configuration that uses standard names and paths. Usually it is sufficient to
+ * set the {@code baseName} and {@code rootPath} properties and to enable the required subprojects.
+ * 
+ * @noextend This class should not be extended by clients.
  */
 @Accessors
 @SuppressWarnings("all")
@@ -38,11 +41,17 @@ public class StandardProjectConfig extends XtextProjectConfig {
   
   private String baseName;
   
+  /**
+   * The base name of the project, which is usually equal to the runtime subproject.
+   */
   @Mandatory
   public String setBaseName(final String baseName) {
     return this.baseName = baseName;
   }
   
+  /**
+   * The root path, usually {@code ".."}.
+   */
   @Mandatory
   public String setRootPath(final String rootPath) {
     return this.rootPath = rootPath;

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/SubProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/SubProjectConfig.java
@@ -19,7 +19,9 @@ import org.eclipse.xtext.xtext.generator.model.project.ISubProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.XtextProjectConfig;
 
 /**
- * @noextend
+ * Configuration of subprojects.
+ * 
+ * @noextend This class should not be extended by clients.
  */
 @SuppressWarnings("all")
 public class SubProjectConfig implements ISubProjectConfig {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/WebProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/WebProjectConfig.java
@@ -16,7 +16,9 @@ import org.eclipse.xtext.xtext.generator.model.project.IWebProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.SubProjectConfig;
 
 /**
- * @noextend
+ * Configuration of the web project.
+ * 
+ * @noextend This class should not be extended by clients.
  */
 @SuppressWarnings("all")
 public class WebProjectConfig extends SubProjectConfig implements IWebProjectConfig {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/XtextProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/XtextProjectConfig.java
@@ -33,7 +33,10 @@ import org.eclipse.xtext.xtext.generator.model.project.SubProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.WebProjectConfig;
 
 /**
- * @noextend
+ * Configuration of the subprojects for one or more Xtext languages. If the standard project names
+ * and layout is sufficient, use {@link StandardProjectConfig}.
+ * 
+ * @noextend This class should not be extended by clients.
  */
 @Accessors
 @SuppressWarnings("all")


### PR DESCRIPTION
See #58. I left `@noextend ` for some classes: XtextGenerator, XtextGeneratorLanguage, StandardLanguage, XtextDirectoryCleaner, and all classes in generator.model.project. We could consider opening these for extension by clients later on.