### PR TITLE
Change import of AssumptionViolatedException

### DIFF
--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/smoketest/internal/AbstractParallelScenarioRunner.java
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/smoketest/internal/AbstractParallelScenarioRunner.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.xtext.testing.IInjectorProvider;
 import org.eclipse.xtext.testing.IRegistryConfigurator;
 import org.eclipse.xtext.testing.smoketest.ScenarioProcessor;
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/smoketest/internal/AbstractScenarioRunner.java
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/smoketest/internal/AbstractScenarioRunner.java
@@ -15,7 +15,7 @@ import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.testing.smoketest.IgnoredBySmokeTest;
 import org.eclipse.xtext.testing.smoketest.ScenarioProcessor;
 import org.junit.Ignore;
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.FrameworkMethod;


### PR DESCRIPTION
With JUnit 4.12 the class was made public API, the old class is
deprecated.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>