### PR TITLE
Introduce Nullable Annotation

### DIFF
--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/internal/Nullable.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/internal/Nullable.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.util.internal;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * This annotation is <b>not</b> intended to be used to do <b>null analysis</b>.
+ * The only purpose is to allow Google Guice to inject <code>@Inject(optional=true)</code> places with <code>null</code> instances.
+ * 
+ * @author Christian Dietrich - Initial contribution and API
+ * 
+ * @since 2.12
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Nullable {
+	
+}


### PR DESCRIPTION
Introduce Nullable Annotation to allow Null-Injections with google guice. see https://github.com/eclipse/xtext-eclipse/issues/153 for details

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>