### PR TITLE
fixed #292 Improve performance of FilterUriContainer#isEmpty()

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/FilterUriContainer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/FilterUriContainer.java
@@ -36,7 +36,12 @@ public class FilterUriContainer extends AbstractContainer {
 	
 	@Override
 	public boolean isEmpty() {
-		return getResourceDescriptionCount() == 0;
+		int delegateCount = delegate.getResourceDescriptionCount();
+		if (delegateCount == 0)
+			return true;
+		if (delegateCount > 1)
+			return false;
+		return delegate.hasResourceDescription(filterMe);
 	}
 	
 	@Override


### PR DESCRIPTION
it's called often from e.g. SelectableBasedScope.createScope(...)



Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>