### PR TITLE
fixed #294 improve performance of IContainerState#contains(URI)

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/ContainerState.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/ContainerState.java
@@ -27,7 +27,7 @@ class ContainerState implements IContainerState {
 
 	@Override
 	public boolean contains(URI uri) {
-		return getContents().contains(uri);
+		return globalState.containsURI(root, uri);
 	}
 	
 	@Override

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/DelegatingIAllContainerAdapter.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/DelegatingIAllContainerAdapter.java
@@ -39,6 +39,11 @@ public class DelegatingIAllContainerAdapter extends AdapterImpl implements IAllC
 	public Collection<URI> getContainedURIs(String containerHandle) {
 		return delegate.getContainedURIs(containerHandle);
 	}
+	
+	@Override
+	public boolean containsURI(String containerHandle, URI candidateURI) {
+		return delegate.containsURI(containerHandle, candidateURI);
+	}
 
 	@Override
 	public String getContainerHandle(URI uri) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/FlatResourceSetBasedAllContainersState.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/FlatResourceSetBasedAllContainersState.java
@@ -1,6 +1,7 @@
 package org.eclipse.xtext.resource.containers;
 
 import static com.google.common.collect.Lists.*;
+import static org.eclipse.xtext.resource.impl.ResourceDescriptionsData.ResourceSetAdapter.*;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -43,18 +44,44 @@ public class FlatResourceSetBasedAllContainersState extends AdapterImpl implemen
 		if (!HANDLE.equals(containerHandle))
 			return Collections.emptySet();
 		if (resourceSet instanceof XtextResourceSet) {
-			XtextResourceSet xtextResourceSet = (XtextResourceSet) resourceSet;
-			ResourceDescriptionsData descriptionsData = ResourceDescriptionsData.ResourceSetAdapter.findResourceDescriptionsData(resourceSet);
+			ResourceDescriptionsData descriptionsData = findResourceDescriptionsData(resourceSet);
 			if (descriptionsData != null) {
 				return descriptionsData.getAllURIs();
 			}
-			return newArrayList(xtextResourceSet.getNormalizationMap().values());
+			return newArrayList(((XtextResourceSet) resourceSet).getNormalizationMap().values());
 		}
 		List<URI> uris = Lists.newArrayListWithCapacity(resourceSet.getResources().size());
 		URIConverter uriConverter = resourceSet.getURIConverter();
 		for (Resource r : resourceSet.getResources())
 			uris.add(uriConverter.normalize(r.getURI()));
 		return uris;
+	}
+	
+	@Override
+	public boolean containsURI(String containerHandle, URI candidateURI) {
+		if (!HANDLE.equals(containerHandle))
+			return false;
+		if (resourceSet instanceof XtextResourceSet) {
+			ResourceDescriptionsData descriptionsData = findResourceDescriptionsData(resourceSet);
+			if (descriptionsData != null) {
+				return descriptionsData.getResourceDescription(candidateURI) != null;
+			}
+			Collection<URI> allUris = ((XtextResourceSet) resourceSet).getNormalizationMap().values();
+			for (URI uri : allUris) {
+				if (uri.equals(candidateURI)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		URIConverter uriConverter = resourceSet.getURIConverter();
+		for (Resource r : resourceSet.getResources()) {
+			URI normalized = uriConverter.normalize(r.getURI());
+			if (normalized.equals(candidateURI)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/IAllContainersState.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/IAllContainersState.java
@@ -26,6 +26,10 @@ public interface IAllContainersState {
 
 	String getContainerHandle(URI uri);
 	
+	default boolean containsURI(String containerHandle, URI candidateURI) {
+		return getContainedURIs(containerHandle).contains(candidateURI);	
+	}
+
 	interface Provider {
 		IAllContainersState get(IResourceDescriptions context);
 	}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/LiveShadowedAllContainerState.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/LiveShadowedAllContainerState.java
@@ -59,6 +59,14 @@ public class LiveShadowedAllContainerState implements IAllContainersState {
 		result.addAll(globalState.getContainedURIs(containerHandle));
 		return result;
 	}
+	
+	@Override
+	public boolean containsURI(String containerHandle, URI candidateURI) {
+		if(localDescriptions.getResourceDescription(candidateURI) != null) {
+			return true;
+		}
+		return globalState.containsURI(containerHandle, candidateURI);
+	}
 
 	@Override
 	public String getContainerHandle(URI uri) {


### PR DESCRIPTION
This change adds a default method 
boolean containsURI(String containerHandle, URI candidateURI)
to IAllContainersState, so that implementations can introduce 
a faster algorithm that leverages the internals data structures.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>