### PR TITLE
refactor: improve performance of StateBasedContainer

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainer.java
@@ -83,7 +83,7 @@ public class StateBasedContainer extends ResourceDescriptionsBasedContainer {
 
 	@Override
 	public Iterable<IResourceDescription> getResourceDescriptions() {
-		if (state.getContents().isEmpty())
+		if (isEmpty())
 			return Collections.emptyList();
 		return getUriToDescription().values();
 	}
@@ -101,28 +101,28 @@ public class StateBasedContainer extends ResourceDescriptionsBasedContainer {
 	
 	@Override
 	public Iterable<IEObjectDescription> getExportedObjects() {
-		if (state.getContents().isEmpty())
+		if (isEmpty())
 			return emptyList();
 		return super.getExportedObjects();
 	}
 	
 	@Override
 	public Iterable<IEObjectDescription> getExportedObjectsByType(EClass type) {
-		if (state.getContents().isEmpty())
+		if (isEmpty())
 			return emptyList();
 		return super.getExportedObjectsByType(type);
 	}
 	
 	@Override
 	public Iterable<IEObjectDescription> getExportedObjectsByObject(EObject object) {
-		if (state.getContents().isEmpty())
+		if (isEmpty())
 			return emptyList();
 		return super.getExportedObjectsByObject(object);
 	}
 	
 	@Override
 	public Iterable<IEObjectDescription> getExportedObjects(EClass type, QualifiedName qualifiedName, boolean ignoreCase) {
-		if (state.getContents().isEmpty())
+		if (isEmpty())
 			return emptyList();
 		return super.getExportedObjects(type, qualifiedName, ignoreCase);
 	}


### PR DESCRIPTION
When using huge models, the getContents() call can consume runtime in the order of minutes and more. Shorten runtime by only asking it for much faster isEmpty().

I've not tested the code in our custom xtext installation, since I still fail to compile the complete xtext-core.

Signed-off-by: Michael Keppler <michael.keppler@gmx.de>