### PR TITLE
Use getValuesProvider function in IssueSeveritiesProvider.

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/validation/IssueSeveritiesProvider.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/validation/IssueSeveritiesProvider.java
@@ -15,6 +15,7 @@ import com.google.inject.Inject;
 
 /**
  * @author Sven Efftinge - Initial contribution and API
+ * @author Stephane Galland - add calls to getValuesProvider()
  * @since 2.4
  */
 public class IssueSeveritiesProvider {
@@ -28,7 +29,7 @@ public class IssueSeveritiesProvider {
 	}
 	
 	public IssueSeverities getIssueSeverities(Resource context) {
-		IPreferenceValues preferenceValues = valuesProvider.getPreferenceValues(context);
+		IPreferenceValues preferenceValues = getValuesProvider().getPreferenceValues(context);
 		return new IssueSeverities(preferenceValues, issueCodesProvider.getConfigurableIssueCodes(), severityConverter);
 	}
 }


### PR DESCRIPTION
The function `getValueProvider` is defined in `IssueSeveritiesProvider` for replying the value provider instance. 
This function seems to be defined as protected in order to be overriden. But is it not called from the rest of the code of `IssueSeveritiesProvider`. This PR fixes this issue.