### PR TITLE
[380449] Enhancements to Task Finder

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/tasks/DefaultTaskFinderTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/tasks/DefaultTaskFinderTest.xtend
@@ -47,6 +47,7 @@ class DefaultTaskFinderTest extends AbstractXtextTests {
 				 * Fixme no match
 				 * FOO also no match
 				 */
+				/* TODO Get rid of this */
 				Hello notATODO!
 			''')
 		)
@@ -68,9 +69,17 @@ class DefaultTaskFinderTest extends AbstractXtextTests {
 				description = " bar"
 				offset = 17
 				lineNumber = 3
+			],
+			new Task => [
+				tag = new TaskTag => [
+					name = "TODO"
+					priority = Priority.NORMAL
+				]
+				description = " Get rid of this "
+				offset = 73
+				lineNumber = 7
 			]
 		])
-		
 		
 	}
 

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/tasks/DefaultTaskFinderTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/tasks/DefaultTaskFinderTest.xtend
@@ -7,16 +7,21 @@
  *******************************************************************************/
 package org.eclipse.xtext.tasks
 
+import com.google.inject.Binder
+import com.google.inject.Guice
 import java.util.List
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl
+import org.eclipse.xtext.testlanguages.noJdt.NoJdtTestLanguageRuntimeModule
 import org.eclipse.xtext.testlanguages.noJdt.NoJdtTestLanguageStandaloneSetup
+import org.eclipse.xtext.tests.AbstractXtextTests
+import org.eclipse.xtext.tests.LineDelimiters
 import org.junit.Before
 import org.junit.Test
 
 import static org.eclipse.xtext.tasks.TaskAssert.*
-import org.eclipse.xtext.tests.AbstractXtextTests
-import org.eclipse.xtext.tests.LineDelimiters
+import com.google.inject.name.Names
+import org.eclipse.xtext.documentation.impl.AbstractMultiLineCommentProvider
 
 /**
  * @author Stefan Oehme - Initial contribution and API
@@ -80,6 +85,44 @@ class DefaultTaskFinderTest extends AbstractXtextTests {
 				lineNumber = 7
 			]
 		])
+		
+	}
+	
+	@Test
+	def void testSpecialEndTag() {
+		with(NoJdtTestLanguageStandaloneSetupCustom)
+		finder = get(DefaultTaskFinder)
+		getResourceFromString(
+			LineDelimiters.toUnix(
+			'''
+				/* TODO Get rid of this ***/
+				Hello notATODO!
+			''')
+		)
+		.assertContainsTasks(#[
+			new Task => [
+				tag = new TaskTag => [
+					name = "TODO"
+					priority = Priority.NORMAL
+				]
+				description = " Get rid of this "
+				offset = 3
+				lineNumber = 1
+			]
+		])
+	}
+	
+	static class NoJdtTestLanguageStandaloneSetupCustom extends NoJdtTestLanguageStandaloneSetup {
+		
+		override createInjector() {
+			return Guice.createInjector(new NoJdtTestLanguageRuntimeModule() {
+				def configureEndTag(Binder binder) {
+					binder.bind(String).annotatedWith(
+						Names.named(AbstractMultiLineCommentProvider.END_TAG)
+					).toInstance("\\*\\*\\*/")
+				}
+			});
+		}
 		
 	}
 

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskFinderTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskFinderTest.java
@@ -7,17 +7,23 @@
  */
 package org.eclipse.xtext.tasks;
 
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.name.Names;
 import java.util.Collections;
 import java.util.List;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.documentation.impl.AbstractMultiLineCommentProvider;
 import org.eclipse.xtext.tasks.DefaultTaskFinder;
 import org.eclipse.xtext.tasks.ITaskFinder;
 import org.eclipse.xtext.tasks.Priority;
 import org.eclipse.xtext.tasks.Task;
 import org.eclipse.xtext.tasks.TaskAssert;
 import org.eclipse.xtext.tasks.TaskTag;
+import org.eclipse.xtext.testlanguages.noJdt.NoJdtTestLanguageRuntimeModule;
 import org.eclipse.xtext.testlanguages.noJdt.NoJdtTestLanguageStandaloneSetup;
 import org.eclipse.xtext.tests.AbstractXtextTests;
 import org.eclipse.xtext.tests.LineDelimiters;
@@ -35,6 +41,23 @@ import org.junit.Test;
  */
 @SuppressWarnings("all")
 public class DefaultTaskFinderTest extends AbstractXtextTests {
+  public static class NoJdtTestLanguageStandaloneSetupCustom extends NoJdtTestLanguageStandaloneSetup {
+    @Override
+    public Injector createInjector() {
+      abstract class __NoJdtTestLanguageStandaloneSetupCustom_1 extends NoJdtTestLanguageRuntimeModule {
+        public abstract void configureEndTag(final Binder binder);
+      }
+      
+      __NoJdtTestLanguageStandaloneSetupCustom_1 ___NoJdtTestLanguageStandaloneSetupCustom_1 = new __NoJdtTestLanguageStandaloneSetupCustom_1() {
+        public void configureEndTag(final Binder binder) {
+          binder.<String>bind(String.class).annotatedWith(
+            Names.named(AbstractMultiLineCommentProvider.END_TAG)).toInstance("\\*\\*\\*/");
+        }
+      };
+      return Guice.createInjector(___NoJdtTestLanguageStandaloneSetupCustom_1);
+    }
+  }
+  
   private ITaskFinder finder;
   
   @Before
@@ -121,6 +144,38 @@ public class DefaultTaskFinderTest extends AbstractXtextTests {
       this.assertContainsTasks(this.getResourceFromString(
         LineDelimiters.toUnix(_builder.toString())), 
         Collections.<Task>unmodifiableList(CollectionLiterals.<Task>newArrayList(_doubleArrow, _doubleArrow_1, _doubleArrow_2)));
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testSpecialEndTag() {
+    try {
+      this.with(DefaultTaskFinderTest.NoJdtTestLanguageStandaloneSetupCustom.class);
+      this.finder = this.<DefaultTaskFinder>get(DefaultTaskFinder.class);
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("/* TODO Get rid of this ***/");
+      _builder.newLine();
+      _builder.append("Hello notATODO!");
+      _builder.newLine();
+      Task _task = new Task();
+      final Procedure1<Task> _function = (Task it) -> {
+        TaskTag _taskTag = new TaskTag();
+        final Procedure1<TaskTag> _function_1 = (TaskTag it_1) -> {
+          it_1.setName("TODO");
+          it_1.setPriority(Priority.NORMAL);
+        };
+        TaskTag _doubleArrow = ObjectExtensions.<TaskTag>operator_doubleArrow(_taskTag, _function_1);
+        it.setTag(_doubleArrow);
+        it.setDescription(" Get rid of this ");
+        it.setOffset(3);
+        it.setLineNumber(1);
+      };
+      Task _doubleArrow = ObjectExtensions.<Task>operator_doubleArrow(_task, _function);
+      this.assertContainsTasks(this.getResourceFromString(
+        LineDelimiters.toUnix(_builder.toString())), 
+        Collections.<Task>unmodifiableList(CollectionLiterals.<Task>newArrayList(_doubleArrow)));
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskFinderTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskFinderTest.java
@@ -72,6 +72,8 @@ public class DefaultTaskFinderTest extends AbstractXtextTests {
       _builder.append(" ");
       _builder.append("*/");
       _builder.newLine();
+      _builder.append("/* TODO Get rid of this */");
+      _builder.newLine();
       _builder.append("Hello notATODO!");
       _builder.newLine();
       Task _task = new Task();
@@ -102,9 +104,23 @@ public class DefaultTaskFinderTest extends AbstractXtextTests {
         it.setLineNumber(3);
       };
       Task _doubleArrow_1 = ObjectExtensions.<Task>operator_doubleArrow(_task_1, _function_1);
+      Task _task_2 = new Task();
+      final Procedure1<Task> _function_2 = (Task it) -> {
+        TaskTag _taskTag = new TaskTag();
+        final Procedure1<TaskTag> _function_3 = (TaskTag it_1) -> {
+          it_1.setName("TODO");
+          it_1.setPriority(Priority.NORMAL);
+        };
+        TaskTag _doubleArrow_2 = ObjectExtensions.<TaskTag>operator_doubleArrow(_taskTag, _function_3);
+        it.setTag(_doubleArrow_2);
+        it.setDescription(" Get rid of this ");
+        it.setOffset(73);
+        it.setLineNumber(7);
+      };
+      Task _doubleArrow_2 = ObjectExtensions.<Task>operator_doubleArrow(_task_2, _function_2);
       this.assertContainsTasks(this.getResourceFromString(
         LineDelimiters.toUnix(_builder.toString())), 
-        Collections.<Task>unmodifiableList(CollectionLiterals.<Task>newArrayList(_doubleArrow, _doubleArrow_1)));
+        Collections.<Task>unmodifiableList(CollectionLiterals.<Task>newArrayList(_doubleArrow, _doubleArrow_1, _doubleArrow_2)));
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/tasks/DefaultTaskFinder.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/tasks/DefaultTaskFinder.xtend
@@ -8,9 +8,12 @@
 package org.eclipse.xtext.tasks
 
 import com.google.inject.Inject
+import com.google.inject.name.Named
 import java.util.List
+import java.util.regex.Pattern
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.xtext.AbstractRule
+import org.eclipse.xtext.documentation.impl.AbstractMultiLineCommentProvider
 import org.eclipse.xtext.nodemodel.ICompositeNode
 import org.eclipse.xtext.nodemodel.ILeafNode
 import org.eclipse.xtext.parsetree.reconstr.IHiddenTokenHelper
@@ -27,6 +30,16 @@ class DefaultTaskFinder implements ITaskFinder {
 	ITaskTagProvider taskTagProvider
 	@Inject
 	IHiddenTokenHelper hiddenTokenHelper
+	Pattern endTagPattern = Pattern.compile("\\*/\\z")
+
+	/**
+	 * this method is not intended to be called by clients
+	 * @since 2.12
+	 */
+	@Inject(optional=true)
+	protected def setEndTag(@Named(AbstractMultiLineCommentProvider.END_TAG) String endTag) {
+		endTagPattern = Pattern.compile(endTag+"\\z")
+	}
 
 	override findTasks(Resource resource) {
 		val taskTags = taskTagProvider.getTaskTags(resource)
@@ -59,10 +72,7 @@ class DefaultTaskFinder implements ITaskFinder {
 	 * @since 2.12
 	 */
 	protected def String stripText(ILeafNode node, String text) {
-		if (text.endsWith("*/")) {
-			return text.substring(0, text.length-2)
-		}
-		return text
+		return endTagPattern.matcher(text).replaceAll("")
 	}
 
 	protected def boolean canContainTaskTags(ILeafNode node) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/tasks/DefaultTaskFinder.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/tasks/DefaultTaskFinder.xtend
@@ -10,11 +10,11 @@ package org.eclipse.xtext.tasks
 import com.google.inject.Inject
 import java.util.List
 import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.xtext.AbstractRule
 import org.eclipse.xtext.nodemodel.ICompositeNode
 import org.eclipse.xtext.nodemodel.ILeafNode
-import org.eclipse.xtext.resource.XtextResource
-import org.eclipse.xtext.AbstractRule
 import org.eclipse.xtext.parsetree.reconstr.IHiddenTokenHelper
+import org.eclipse.xtext.resource.XtextResource
 
 /**
  * @author Stefan Oehme - Initial contribution and API
@@ -45,7 +45,7 @@ class DefaultTaskFinder implements ITaskFinder {
 	protected def List<Task> findTasks(ILeafNode node, TaskTags taskTags) {
 		if (node.canContainTaskTags) {
 			//TODO strip comment characters before parsing, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=380449#c13
-			val tasks = parser.parseTasks(node.text, taskTags)
+			val tasks = parser.parseTasks(stripText(node, node.text), taskTags)
 			tasks.forEach [
 				offset = offset + node.offset
 				lineNumber = lineNumber + node.startLine - 1
@@ -53,6 +53,16 @@ class DefaultTaskFinder implements ITaskFinder {
 			return tasks
 		}
 		return #[]
+	}
+
+	/**
+	 * @since 2.12
+	 */
+	protected def String stripText(ILeafNode node, String text) {
+		if (text.endsWith("*/")) {
+			return text.substring(0, text.length-2)
+		}
+		return text
 	}
 
 	protected def boolean canContainTaskTags(ILeafNode node) {

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskFinder.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskFinder.java
@@ -89,7 +89,7 @@ public class DefaultTaskFinder implements ITaskFinder {
   protected List<Task> findTasks(final ILeafNode node, final TaskTags taskTags) {
     boolean _canContainTaskTags = this.canContainTaskTags(node);
     if (_canContainTaskTags) {
-      final List<Task> tasks = this.parser.parseTasks(node.getText(), taskTags);
+      final List<Task> tasks = this.parser.parseTasks(this.stripText(node, node.getText()), taskTags);
       final Consumer<Task> _function = (Task it) -> {
         int _offset = it.getOffset();
         int _offset_1 = node.getOffset();
@@ -105,6 +105,19 @@ public class DefaultTaskFinder implements ITaskFinder {
       return tasks;
     }
     return Collections.<Task>unmodifiableList(CollectionLiterals.<Task>newArrayList());
+  }
+  
+  /**
+   * @since 2.12
+   */
+  protected String stripText(final ILeafNode node, final String text) {
+    boolean _endsWith = text.endsWith("*/");
+    if (_endsWith) {
+      int _length = text.length();
+      int _minus = (_length - 2);
+      return text.substring(0, _minus);
+    }
+    return text;
   }
   
   protected boolean canContainTaskTags(final ILeafNode node) {

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskFinder.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskFinder.java
@@ -9,12 +9,15 @@ package org.eclipse.xtext.tasks;
 
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.AbstractRule;
+import org.eclipse.xtext.documentation.impl.AbstractMultiLineCommentProvider;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.ILeafNode;
 import org.eclipse.xtext.parser.IParseResult;
@@ -43,6 +46,17 @@ public class DefaultTaskFinder implements ITaskFinder {
   
   @Inject
   private IHiddenTokenHelper hiddenTokenHelper;
+  
+  private Pattern endTagPattern = Pattern.compile("\\*/\\z");
+  
+  /**
+   * this method is not intended to be called by clients
+   * @since 2.12
+   */
+  @Inject(optional = true)
+  protected Pattern setEndTag(@Named(AbstractMultiLineCommentProvider.END_TAG) final String endTag) {
+    return this.endTagPattern = Pattern.compile((endTag + "\\z"));
+  }
   
   @Override
   public List<Task> findTasks(final Resource resource) {
@@ -111,13 +125,7 @@ public class DefaultTaskFinder implements ITaskFinder {
    * @since 2.12
    */
   protected String stripText(final ILeafNode node, final String text) {
-    boolean _endsWith = text.endsWith("*/");
-    if (_endsWith) {
-      int _length = text.length();
-      int _minus = (_length - 2);
-      return text.substring(0, _minus);
-    }
-    return text;
+    return this.endTagPattern.matcher(text).replaceAll("");
   }
   
   protected boolean canContainTaskTags(final ILeafNode node) {


### PR DESCRIPTION
[380449] Enhancements to Task Finder

- Introduced a hook to allow stripping of the node text before calling the task parser
- Stripped trailing comment in tasks

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>