### PR TITLE
[508810] Referencing EStringToStringMapEntry results in compile Error in generated Abstract*SemanticSequencer

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/TypeReferenceTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/TypeReferenceTest.xtend
@@ -109,4 +109,11 @@ class TypeReferenceTest {
 		val ref = new TypeReference(EcorePackage.Literals.EOBJECT, rs)
 		assertEquals("org.eclipse.emf.ecore.EObject", ref.name)
 	}
+	
+	@Test
+	def void testBug508810() {
+		val rs = new ResourceSetImpl
+		val ref = new TypeReference(EcorePackage.Literals.ESTRING_TO_STRING_MAP_ENTRY, rs)
+		assertEquals("java.util.Map.Entry", ref.name)
+	}
 }

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/generator/TypeReferenceTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/generator/TypeReferenceTest.java
@@ -109,4 +109,11 @@ public class TypeReferenceTest {
     final TypeReference ref = new TypeReference(EcorePackage.Literals.EOBJECT, rs);
     Assert.assertEquals("org.eclipse.emf.ecore.EObject", ref.getName());
   }
+  
+  @Test
+  public void testBug508810() {
+    final ResourceSetImpl rs = new ResourceSetImpl();
+    final TypeReference ref = new TypeReference(EcorePackage.Literals.ESTRING_TO_STRING_MAP_ENTRY, rs);
+    Assert.assertEquals("java.util.Map.Entry", ref.getName());
+  }
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TypeReference.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TypeReference.xtend
@@ -140,12 +140,13 @@ class TypeReference {
 	}
 	
 	private static def getQualifiedName(EClass clazz, ResourceSet resourceSet) {
-		if (clazz.EPackage.nsURI == 'http://www.eclipse.org/2008/Xtext')
+		if (clazz.EPackage.nsURI == 'http://www.eclipse.org/2008/Xtext') {
 			'org.eclipse.xtext.' + clazz.name
-		else if (clazz.EPackage.nsURI == 'http://www.eclipse.org/emf/2002/Ecore')
-			'org.eclipse.emf.ecore.' + clazz.name	
-		else
+		} else if (clazz.EPackage.nsURI == 'http://www.eclipse.org/emf/2002/Ecore') {
+			if (clazz.instanceTypeName !== null) clazz.instanceTypeName.replace('$', '.') else 'org.eclipse.emf.ecore.' + clazz.name
+		} else {
 			GenModelUtil2.getGenClass(clazz, resourceSet).qualifiedInterfaceName
+		}
 	}
 	
 	private static def getQualifiedName(EPackage epackage, ResourceSet resourceSet) {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/TypeReference.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/TypeReference.java
@@ -213,8 +213,16 @@ public class TypeReference {
       String _nsURI_1 = clazz.getEPackage().getNsURI();
       boolean _equals_1 = Objects.equal(_nsURI_1, "http://www.eclipse.org/emf/2002/Ecore");
       if (_equals_1) {
-        String _name_1 = clazz.getName();
-        _xifexpression_1 = ("org.eclipse.emf.ecore." + _name_1);
+        String _xifexpression_2 = null;
+        String _instanceTypeName = clazz.getInstanceTypeName();
+        boolean _tripleNotEquals = (_instanceTypeName != null);
+        if (_tripleNotEquals) {
+          _xifexpression_2 = clazz.getInstanceTypeName().replace("$", ".");
+        } else {
+          String _name_1 = clazz.getName();
+          _xifexpression_2 = ("org.eclipse.emf.ecore." + _name_1);
+        }
+        _xifexpression_1 = _xifexpression_2;
       } else {
         _xifexpression_1 = GenModelUtil2.getGenClass(clazz, resourceSet).getQualifiedInterfaceName();
       }


### PR DESCRIPTION
[508810] Referencing EStringToStringMapEntry results in compile Error in generated Abstract*SemanticSequencer

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>