### PR TITLE
Allow postprocessing on generator result tree

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/CompositeGeneratorNode.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/CompositeGeneratorNode.xtend
@@ -9,11 +9,14 @@ package org.eclipse.xtext.generator.trace.node
 
 import java.util.List
 import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtend.lib.annotations.EqualsHashCode
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
-@Accessors class CompositeGeneratorNode implements IGeneratorNode {
+@Accessors
+@EqualsHashCode
+class CompositeGeneratorNode implements IGeneratorNode {
 	
 	val List<IGeneratorNode> children = newArrayList
 	

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/CompositeGeneratorNode.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/CompositeGeneratorNode.xtend
@@ -9,13 +9,11 @@ package org.eclipse.xtext.generator.trace.node
 
 import java.util.List
 import org.eclipse.xtend.lib.annotations.Accessors
-import org.eclipse.xtend.lib.annotations.EqualsHashCode
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
 @Accessors
-@EqualsHashCode
 class CompositeGeneratorNode implements IGeneratorNode {
 	
 	val List<IGeneratorNode> children = newArrayList

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/IndentNode.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/IndentNode.xtend
@@ -8,12 +8,19 @@
 package org.eclipse.xtext.generator.trace.node
 
 import org.eclipse.xtend.lib.annotations.Accessors
-import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.eclipse.xtend.lib.annotations.EqualsHashCode
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
-@FinalFieldsConstructor class IndentNode extends CompositeGeneratorNode {
+@Accessors
+@EqualsHashCode
+class IndentNode extends CompositeGeneratorNode {
 	
-	@Accessors val String indentationString
+	String indentationString
+	
+	new(String indentationString) {
+		this.indentationString = indentationString
+	}
+	
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/IndentNode.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/IndentNode.xtend
@@ -8,13 +8,11 @@
 package org.eclipse.xtext.generator.trace.node
 
 import org.eclipse.xtend.lib.annotations.Accessors
-import org.eclipse.xtend.lib.annotations.EqualsHashCode
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
 @Accessors
-@EqualsHashCode
 class IndentNode extends CompositeGeneratorNode {
 	
 	String indentationString

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/NewLineNode.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/NewLineNode.xtend
@@ -7,12 +7,32 @@
  *******************************************************************************/
 package org.eclipse.xtext.generator.trace.node
 
-import org.eclipse.xtend.lib.annotations.Data
+import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtend.lib.annotations.EqualsHashCode
+import org.eclipse.xtext.util.Strings
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
-@Data class NewLineNode implements IGeneratorNode {
+@Accessors
+@EqualsHashCode
+class NewLineNode implements IGeneratorNode {
+	
 	String lineDelimiter
+	
 	boolean ifNotEmpty
+	
+	new(String lineDelimiter) {
+		this.lineDelimiter = lineDelimiter
+	}
+	
+	new(String lineDelimiter, boolean ifNotEmpty) {
+		this.lineDelimiter = lineDelimiter
+		this.ifNotEmpty = ifNotEmpty
+	}
+	
+	override toString() {
+		'''«class.simpleName» "«Strings.convertToJavaString(lineDelimiter)»"«IF ifNotEmpty» if not empty«ENDIF»'''
+	}
+	
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/NewLineNode.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/NewLineNode.xtend
@@ -8,14 +8,12 @@
 package org.eclipse.xtext.generator.trace.node
 
 import org.eclipse.xtend.lib.annotations.Accessors
-import org.eclipse.xtend.lib.annotations.EqualsHashCode
 import org.eclipse.xtext.util.Strings
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
 @Accessors
-@EqualsHashCode
 class NewLineNode implements IGeneratorNode {
 	
 	String lineDelimiter

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/TextNode.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/TextNode.xtend
@@ -8,14 +8,12 @@
 package org.eclipse.xtext.generator.trace.node
 
 import org.eclipse.xtend.lib.annotations.Accessors
-import org.eclipse.xtend.lib.annotations.EqualsHashCode
 import org.eclipse.xtext.util.Strings
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
 @Accessors
-@EqualsHashCode
 class TextNode implements IGeneratorNode {
 	
 	CharSequence text

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/TextNode.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/TextNode.xtend
@@ -7,11 +7,25 @@
  *******************************************************************************/
 package org.eclipse.xtext.generator.trace.node
 
-import org.eclipse.xtend.lib.annotations.Data
+import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtend.lib.annotations.EqualsHashCode
+import org.eclipse.xtext.util.Strings
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
-@Data class TextNode implements IGeneratorNode {
+@Accessors
+@EqualsHashCode
+class TextNode implements IGeneratorNode {
+	
 	CharSequence text
+	
+	new(CharSequence text) {
+		this.text = text
+	}
+	
+	override toString() {
+		'''«class.simpleName» "«Strings.convertToJavaString(text.toString)»"'''
+	}
+	
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/TraceNode.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/TraceNode.xtend
@@ -8,14 +8,20 @@
 package org.eclipse.xtext.generator.trace.node
 
 import org.eclipse.xtend.lib.annotations.Accessors
-import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.eclipse.xtend.lib.annotations.EqualsHashCode
 import org.eclipse.xtext.generator.trace.ILocationData
 
 /**
  * @author Sven Efftinge - initial contribution and API
  */
-@FinalFieldsConstructor class TraceNode extends CompositeGeneratorNode {
+@Accessors
+@EqualsHashCode
+class TraceNode extends CompositeGeneratorNode {
 	
-	@Accessors final ILocationData sourceLocation
+	ILocationData sourceLocation
+	
+	new(ILocationData sourceLocation) {
+		this.sourceLocation = sourceLocation
+	}
 	
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/TraceNode.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/TraceNode.xtend
@@ -8,14 +8,12 @@
 package org.eclipse.xtext.generator.trace.node
 
 import org.eclipse.xtend.lib.annotations.Accessors
-import org.eclipse.xtend.lib.annotations.EqualsHashCode
 import org.eclipse.xtext.generator.trace.ILocationData
 
 /**
  * @author Sven Efftinge - initial contribution and API
  */
 @Accessors
-@EqualsHashCode
 class TraceNode extends CompositeGeneratorNode {
 	
 	ILocationData sourceLocation

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/CompositeGeneratorNode.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/CompositeGeneratorNode.java
@@ -9,6 +9,7 @@ package org.eclipse.xtext.generator.trace.node;
 
 import java.util.List;
 import org.eclipse.xtend.lib.annotations.Accessors;
+import org.eclipse.xtend.lib.annotations.EqualsHashCode;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.generator.trace.node.IGeneratorNode;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
@@ -18,6 +19,7 @@ import org.eclipse.xtext.xbase.lib.Pure;
  * @author Sven Efftinge - Initial contribution and API
  */
 @Accessors
+@EqualsHashCode
 @SuppressWarnings("all")
 public class CompositeGeneratorNode implements IGeneratorNode {
   private final List<IGeneratorNode> children = CollectionLiterals.<IGeneratorNode>newArrayList();
@@ -45,5 +47,32 @@ public class CompositeGeneratorNode implements IGeneratorNode {
   @Pure
   public List<IGeneratorNode> getChildren() {
     return this.children;
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CompositeGeneratorNode other = (CompositeGeneratorNode) obj;
+    if (this.children == null) {
+      if (other.children != null)
+        return false;
+    } else if (!this.children.equals(other.children))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.children== null) ? 0 : this.children.hashCode());
+    return result;
   }
 }

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/CompositeGeneratorNode.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/CompositeGeneratorNode.java
@@ -9,7 +9,6 @@ package org.eclipse.xtext.generator.trace.node;
 
 import java.util.List;
 import org.eclipse.xtend.lib.annotations.Accessors;
-import org.eclipse.xtend.lib.annotations.EqualsHashCode;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.generator.trace.node.IGeneratorNode;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
@@ -19,7 +18,6 @@ import org.eclipse.xtext.xbase.lib.Pure;
  * @author Sven Efftinge - Initial contribution and API
  */
 @Accessors
-@EqualsHashCode
 @SuppressWarnings("all")
 public class CompositeGeneratorNode implements IGeneratorNode {
   private final List<IGeneratorNode> children = CollectionLiterals.<IGeneratorNode>newArrayList();
@@ -47,32 +45,5 @@ public class CompositeGeneratorNode implements IGeneratorNode {
   @Pure
   public List<IGeneratorNode> getChildren() {
     return this.children;
-  }
-  
-  @Override
-  @Pure
-  public boolean equals(final Object obj) {
-    if (this == obj)
-      return true;
-    if (obj == null)
-      return false;
-    if (getClass() != obj.getClass())
-      return false;
-    CompositeGeneratorNode other = (CompositeGeneratorNode) obj;
-    if (this.children == null) {
-      if (other.children != null)
-        return false;
-    } else if (!this.children.equals(other.children))
-      return false;
-    return true;
-  }
-  
-  @Override
-  @Pure
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((this.children== null) ? 0 : this.children.hashCode());
-    return result;
   }
 }

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/IndentNode.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/IndentNode.java
@@ -8,26 +8,58 @@
 package org.eclipse.xtext.generator.trace.node;
 
 import org.eclipse.xtend.lib.annotations.Accessors;
-import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
+import org.eclipse.xtend.lib.annotations.EqualsHashCode;
 import org.eclipse.xtext.generator.trace.node.CompositeGeneratorNode;
 import org.eclipse.xtext.xbase.lib.Pure;
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
-@FinalFieldsConstructor
+@Accessors
+@EqualsHashCode
 @SuppressWarnings("all")
 public class IndentNode extends CompositeGeneratorNode {
-  @Accessors
-  private final String indentationString;
+  private String indentationString;
   
   public IndentNode(final String indentationString) {
-    super();
     this.indentationString = indentationString;
   }
   
   @Pure
   public String getIndentationString() {
     return this.indentationString;
+  }
+  
+  public void setIndentationString(final String indentationString) {
+    this.indentationString = indentationString;
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    if (!super.equals(obj))
+      return false;
+    IndentNode other = (IndentNode) obj;
+    if (this.indentationString == null) {
+      if (other.indentationString != null)
+        return false;
+    } else if (!this.indentationString.equals(other.indentationString))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((this.indentationString== null) ? 0 : this.indentationString.hashCode());
+    return result;
   }
 }

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/IndentNode.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/IndentNode.java
@@ -8,7 +8,6 @@
 package org.eclipse.xtext.generator.trace.node;
 
 import org.eclipse.xtend.lib.annotations.Accessors;
-import org.eclipse.xtend.lib.annotations.EqualsHashCode;
 import org.eclipse.xtext.generator.trace.node.CompositeGeneratorNode;
 import org.eclipse.xtext.xbase.lib.Pure;
 
@@ -16,7 +15,6 @@ import org.eclipse.xtext.xbase.lib.Pure;
  * @author Sven Efftinge - Initial contribution and API
  */
 @Accessors
-@EqualsHashCode
 @SuppressWarnings("all")
 public class IndentNode extends CompositeGeneratorNode {
   private String indentationString;
@@ -32,34 +30,5 @@ public class IndentNode extends CompositeGeneratorNode {
   
   public void setIndentationString(final String indentationString) {
     this.indentationString = indentationString;
-  }
-  
-  @Override
-  @Pure
-  public boolean equals(final Object obj) {
-    if (this == obj)
-      return true;
-    if (obj == null)
-      return false;
-    if (getClass() != obj.getClass())
-      return false;
-    if (!super.equals(obj))
-      return false;
-    IndentNode other = (IndentNode) obj;
-    if (this.indentationString == null) {
-      if (other.indentationString != null)
-        return false;
-    } else if (!this.indentationString.equals(other.indentationString))
-      return false;
-    return true;
-  }
-  
-  @Override
-  @Pure
-  public int hashCode() {
-    final int prime = 31;
-    int result = super.hashCode();
-    result = prime * result + ((this.indentationString== null) ? 0 : this.indentationString.hashCode());
-    return result;
   }
 }

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/NewLineNode.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/NewLineNode.java
@@ -7,35 +7,66 @@
  */
 package org.eclipse.xtext.generator.trace.node;
 
-import org.eclipse.xtend.lib.annotations.Data;
+import org.eclipse.xtend.lib.annotations.Accessors;
+import org.eclipse.xtend.lib.annotations.EqualsHashCode;
+import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.generator.trace.node.IGeneratorNode;
+import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.lib.Pure;
-import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
-@Data
+@Accessors
+@EqualsHashCode
 @SuppressWarnings("all")
 public class NewLineNode implements IGeneratorNode {
-  private final String lineDelimiter;
+  private String lineDelimiter;
   
-  private final boolean ifNotEmpty;
+  private boolean ifNotEmpty;
+  
+  public NewLineNode(final String lineDelimiter) {
+    this.lineDelimiter = lineDelimiter;
+  }
   
   public NewLineNode(final String lineDelimiter, final boolean ifNotEmpty) {
-    super();
     this.lineDelimiter = lineDelimiter;
     this.ifNotEmpty = ifNotEmpty;
   }
   
   @Override
+  public String toString() {
+    StringConcatenation _builder = new StringConcatenation();
+    String _simpleName = this.getClass().getSimpleName();
+    _builder.append(_simpleName);
+    _builder.append(" \"");
+    String _convertToJavaString = Strings.convertToJavaString(this.lineDelimiter);
+    _builder.append(_convertToJavaString);
+    _builder.append("\"");
+    {
+      if (this.ifNotEmpty) {
+        _builder.append(" if not empty");
+      }
+    }
+    return _builder.toString();
+  }
+  
   @Pure
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((this.lineDelimiter== null) ? 0 : this.lineDelimiter.hashCode());
-    result = prime * result + (this.ifNotEmpty ? 1231 : 1237);
-    return result;
+  public String getLineDelimiter() {
+    return this.lineDelimiter;
+  }
+  
+  public void setLineDelimiter(final String lineDelimiter) {
+    this.lineDelimiter = lineDelimiter;
+  }
+  
+  @Pure
+  public boolean isIfNotEmpty() {
+    return this.ifNotEmpty;
+  }
+  
+  public void setIfNotEmpty(final boolean ifNotEmpty) {
+    this.ifNotEmpty = ifNotEmpty;
   }
   
   @Override
@@ -60,20 +91,11 @@ public class NewLineNode implements IGeneratorNode {
   
   @Override
   @Pure
-  public String toString() {
-    ToStringBuilder b = new ToStringBuilder(this);
-    b.add("lineDelimiter", this.lineDelimiter);
-    b.add("ifNotEmpty", this.ifNotEmpty);
-    return b.toString();
-  }
-  
-  @Pure
-  public String getLineDelimiter() {
-    return this.lineDelimiter;
-  }
-  
-  @Pure
-  public boolean isIfNotEmpty() {
-    return this.ifNotEmpty;
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.lineDelimiter== null) ? 0 : this.lineDelimiter.hashCode());
+    result = prime * result + (this.ifNotEmpty ? 1231 : 1237);
+    return result;
   }
 }

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/NewLineNode.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/NewLineNode.java
@@ -8,7 +8,6 @@
 package org.eclipse.xtext.generator.trace.node;
 
 import org.eclipse.xtend.lib.annotations.Accessors;
-import org.eclipse.xtend.lib.annotations.EqualsHashCode;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.generator.trace.node.IGeneratorNode;
 import org.eclipse.xtext.util.Strings;
@@ -18,7 +17,6 @@ import org.eclipse.xtext.xbase.lib.Pure;
  * @author Sven Efftinge - Initial contribution and API
  */
 @Accessors
-@EqualsHashCode
 @SuppressWarnings("all")
 public class NewLineNode implements IGeneratorNode {
   private String lineDelimiter;
@@ -67,35 +65,5 @@ public class NewLineNode implements IGeneratorNode {
   
   public void setIfNotEmpty(final boolean ifNotEmpty) {
     this.ifNotEmpty = ifNotEmpty;
-  }
-  
-  @Override
-  @Pure
-  public boolean equals(final Object obj) {
-    if (this == obj)
-      return true;
-    if (obj == null)
-      return false;
-    if (getClass() != obj.getClass())
-      return false;
-    NewLineNode other = (NewLineNode) obj;
-    if (this.lineDelimiter == null) {
-      if (other.lineDelimiter != null)
-        return false;
-    } else if (!this.lineDelimiter.equals(other.lineDelimiter))
-      return false;
-    if (other.ifNotEmpty != this.ifNotEmpty)
-      return false;
-    return true;
-  }
-  
-  @Override
-  @Pure
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((this.lineDelimiter== null) ? 0 : this.lineDelimiter.hashCode());
-    result = prime * result + (this.ifNotEmpty ? 1231 : 1237);
-    return result;
   }
 }

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/TextNode.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/TextNode.java
@@ -7,31 +7,45 @@
  */
 package org.eclipse.xtext.generator.trace.node;
 
-import org.eclipse.xtend.lib.annotations.Data;
+import org.eclipse.xtend.lib.annotations.Accessors;
+import org.eclipse.xtend.lib.annotations.EqualsHashCode;
+import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.generator.trace.node.IGeneratorNode;
+import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.lib.Pure;
-import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
-@Data
+@Accessors
+@EqualsHashCode
 @SuppressWarnings("all")
 public class TextNode implements IGeneratorNode {
-  private final CharSequence text;
+  private CharSequence text;
   
   public TextNode(final CharSequence text) {
-    super();
     this.text = text;
   }
   
   @Override
+  public String toString() {
+    StringConcatenation _builder = new StringConcatenation();
+    String _simpleName = this.getClass().getSimpleName();
+    _builder.append(_simpleName);
+    _builder.append(" \"");
+    String _convertToJavaString = Strings.convertToJavaString(this.text.toString());
+    _builder.append(_convertToJavaString);
+    _builder.append("\"");
+    return _builder.toString();
+  }
+  
   @Pure
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((this.text== null) ? 0 : this.text.hashCode());
-    return result;
+  public CharSequence getText() {
+    return this.text;
+  }
+  
+  public void setText(final CharSequence text) {
+    this.text = text;
   }
   
   @Override
@@ -54,14 +68,10 @@ public class TextNode implements IGeneratorNode {
   
   @Override
   @Pure
-  public String toString() {
-    ToStringBuilder b = new ToStringBuilder(this);
-    b.add("text", this.text);
-    return b.toString();
-  }
-  
-  @Pure
-  public CharSequence getText() {
-    return this.text;
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.text== null) ? 0 : this.text.hashCode());
+    return result;
   }
 }

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/TextNode.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/TextNode.java
@@ -8,7 +8,6 @@
 package org.eclipse.xtext.generator.trace.node;
 
 import org.eclipse.xtend.lib.annotations.Accessors;
-import org.eclipse.xtend.lib.annotations.EqualsHashCode;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.generator.trace.node.IGeneratorNode;
 import org.eclipse.xtext.util.Strings;
@@ -18,7 +17,6 @@ import org.eclipse.xtext.xbase.lib.Pure;
  * @author Sven Efftinge - Initial contribution and API
  */
 @Accessors
-@EqualsHashCode
 @SuppressWarnings("all")
 public class TextNode implements IGeneratorNode {
   private CharSequence text;
@@ -46,32 +44,5 @@ public class TextNode implements IGeneratorNode {
   
   public void setText(final CharSequence text) {
     this.text = text;
-  }
-  
-  @Override
-  @Pure
-  public boolean equals(final Object obj) {
-    if (this == obj)
-      return true;
-    if (obj == null)
-      return false;
-    if (getClass() != obj.getClass())
-      return false;
-    TextNode other = (TextNode) obj;
-    if (this.text == null) {
-      if (other.text != null)
-        return false;
-    } else if (!this.text.equals(other.text))
-      return false;
-    return true;
-  }
-  
-  @Override
-  @Pure
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((this.text== null) ? 0 : this.text.hashCode());
-    return result;
   }
 }

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/TraceNode.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/TraceNode.java
@@ -8,7 +8,6 @@
 package org.eclipse.xtext.generator.trace.node;
 
 import org.eclipse.xtend.lib.annotations.Accessors;
-import org.eclipse.xtend.lib.annotations.EqualsHashCode;
 import org.eclipse.xtext.generator.trace.ILocationData;
 import org.eclipse.xtext.generator.trace.node.CompositeGeneratorNode;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -17,7 +16,6 @@ import org.eclipse.xtext.xbase.lib.Pure;
  * @author Sven Efftinge - initial contribution and API
  */
 @Accessors
-@EqualsHashCode
 @SuppressWarnings("all")
 public class TraceNode extends CompositeGeneratorNode {
   private ILocationData sourceLocation;
@@ -33,34 +31,5 @@ public class TraceNode extends CompositeGeneratorNode {
   
   public void setSourceLocation(final ILocationData sourceLocation) {
     this.sourceLocation = sourceLocation;
-  }
-  
-  @Override
-  @Pure
-  public boolean equals(final Object obj) {
-    if (this == obj)
-      return true;
-    if (obj == null)
-      return false;
-    if (getClass() != obj.getClass())
-      return false;
-    if (!super.equals(obj))
-      return false;
-    TraceNode other = (TraceNode) obj;
-    if (this.sourceLocation == null) {
-      if (other.sourceLocation != null)
-        return false;
-    } else if (!this.sourceLocation.equals(other.sourceLocation))
-      return false;
-    return true;
-  }
-  
-  @Override
-  @Pure
-  public int hashCode() {
-    final int prime = 31;
-    int result = super.hashCode();
-    result = prime * result + ((this.sourceLocation== null) ? 0 : this.sourceLocation.hashCode());
-    return result;
   }
 }

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/TraceNode.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/TraceNode.java
@@ -8,7 +8,7 @@
 package org.eclipse.xtext.generator.trace.node;
 
 import org.eclipse.xtend.lib.annotations.Accessors;
-import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
+import org.eclipse.xtend.lib.annotations.EqualsHashCode;
 import org.eclipse.xtext.generator.trace.ILocationData;
 import org.eclipse.xtext.generator.trace.node.CompositeGeneratorNode;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -16,19 +16,51 @@ import org.eclipse.xtext.xbase.lib.Pure;
 /**
  * @author Sven Efftinge - initial contribution and API
  */
-@FinalFieldsConstructor
+@Accessors
+@EqualsHashCode
 @SuppressWarnings("all")
 public class TraceNode extends CompositeGeneratorNode {
-  @Accessors
-  private final ILocationData sourceLocation;
+  private ILocationData sourceLocation;
   
   public TraceNode(final ILocationData sourceLocation) {
-    super();
     this.sourceLocation = sourceLocation;
   }
   
   @Pure
   public ILocationData getSourceLocation() {
     return this.sourceLocation;
+  }
+  
+  public void setSourceLocation(final ILocationData sourceLocation) {
+    this.sourceLocation = sourceLocation;
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    if (!super.equals(obj))
+      return false;
+    TraceNode other = (TraceNode) obj;
+    if (this.sourceLocation == null) {
+      if (other.sourceLocation != null)
+        return false;
+    } else if (!this.sourceLocation.equals(other.sourceLocation))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((this.sourceLocation== null) ? 0 : this.sourceLocation.hashCode());
+    return result;
   }
 }


### PR DESCRIPTION
It can be very useful to post-process the resulting tree of the generator. This change makes all generator node types mutable.

Also changed `equals()`, `hashCode()`, and `toString()` to be consistent for all node types.