### PR TITLE
Do not allow identity edits, even for undefined regions

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/TextReplacerContext.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/TextReplacerContext.java
@@ -228,16 +228,10 @@ public class TextReplacerContext implements ITextReplacerContext {
 			request.getExceptionHandler().accept(exception);
 			return;
 		}
-		if (!isInRequestedRange(replacement)) {
+		if (!isInRequestedRange(replacement) ||
+			(!request.allowIdentityEdits() && isIdentityEdit(replacement)) ||
+			(!isInUndefinedRegion(replacement) && request.isFormatUndefinedHiddenRegionsOnly())) {
 			return;
-		}
-		if (!isInUndefinedRegion(replacement)) {
-			if (request.isFormatUndefinedHiddenRegionsOnly()) {
-				return;
-			}
-			if (!request.allowIdentityEdits() && isIdentityEdit(replacement)) {
-				return;
-			}
 		}
 		try {
 			replacements.add(replacement);


### PR DESCRIPTION
Tell me if I'm missing something, but I do not think we're doing any harm by disallowing identity edits (if the option was checked) in the general case, even for undefined regions.

Signed-off-by: Titouan Vervack <titouan.vervack@sigasi.com>