### PR TITLE
server: file log name has whitespace

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ServerLauncher.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ServerLauncher.xtend
@@ -52,7 +52,7 @@ class ServerLauncher {
 
 	def static redirectStandardStreams() {
 		System.setIn(new ByteArrayInputStream(newByteArrayOfSize(0)))
-		val id = ServerLauncher.name + "-" + new Timestamp(System.currentTimeMillis)
+		val id = (ServerLauncher.name + "-" + new Timestamp(System.currentTimeMillis)).replace(" ", "_")
 		if (IS_DEBUG) {
 			val stdFileOut = new FileOutputStream("out-" + id + ".log")
 			System.setOut(new PrintStream(stdFileOut))


### PR DESCRIPTION
The whitespaces make it not work on Windows. 

I'm not sure if the suggested solution is the best, so take it just as a suggestion.