### PR TITLE
added logging to inform the user that calling the formatter with an non resource eobject is a bad idea

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting/impl/AbstractDeclarativeFormatter.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting/impl/AbstractDeclarativeFormatter.java
@@ -13,6 +13,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 
+import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.EcoreUtil2;
@@ -33,6 +34,8 @@ import com.google.inject.Singleton;
  * @author Moritz Eysholdt - Initial contribution and API
  */
 public abstract class AbstractDeclarativeFormatter extends BaseFormatter {
+
+	private static final Logger log = Logger.getLogger(AbstractDeclarativeFormatter.class);
 
 	@Singleton
 	protected static class ConfigStore {
@@ -71,6 +74,8 @@ public abstract class AbstractDeclarativeFormatter extends BaseFormatter {
 	public ITokenStream createFormatterStream(EObject context, String indent, ITokenStream out, boolean preserveWhitespaces) {
 		if(context != null && context.eResource() != null && context.eResource().getURI() != null) {
 			contextResourceURI = EcoreUtil2.getPlatformResourceOrNormalizedURI(context).trimFragment();
+		} else if (context != null && context.eResource() == null) {
+			log.error("Model has no XtextResource. This is likely to cause follow-up errors");
 		}
 		return new FormattingConfigBasedStream(out, indent, getConfig(), createMatcher(), hiddenTokenHelper,
 				preserveWhitespaces);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/TextRegionAccessBuildingSequencer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/TextRegionAccessBuildingSequencer.java
@@ -9,12 +9,14 @@ package org.eclipse.xtext.formatting2.regionaccess.internal;
 
 import java.util.LinkedList;
 
+import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.AbstractElement;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.Action;
 import org.eclipse.xtext.Keyword;
 import org.eclipse.xtext.RuleCall;
+import org.eclipse.xtext.generator.trace.internal.AbstractTraceForURIProvider;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.ILeafNode;
 import org.eclipse.xtext.resource.XtextResource;
@@ -24,6 +26,9 @@ import org.eclipse.xtext.serializer.analysis.SerializationContext;
 import org.eclipse.xtext.util.Strings;
 
 public class TextRegionAccessBuildingSequencer implements ISequenceAcceptor {
+
+	private static final Logger log = Logger.getLogger(TextRegionAccessBuildingSequencer.class);
+
 	private StringHiddenRegion last;
 	private StringBasedRegionAccess regionAccess;
 	private final LinkedList<AbstractEObjectRegion> stack = new LinkedList<AbstractEObjectRegion>();
@@ -201,6 +206,9 @@ public class TextRegionAccessBuildingSequencer implements ISequenceAcceptor {
 	}
 
 	public TextRegionAccessBuildingSequencer withRoot(ISerializationContext ctx, EObject root) {
+		if (root.eResource() == null) {
+			log.error("Root has no XtextResource. This is likely to cause follow-up errors");
+		}
 		this.regionAccess = new StringBasedRegionAccess((XtextResource) root.eResource());
 		this.last = createHiddenRegion();
 		this.regionAccess.setRootEObject(enterEObject(((SerializationContext) ctx).getActionOrRule(), root));


### PR DESCRIPTION
added logging to inform the user that calling the formatter with an non resource eobject is a bad idea

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>