### PR TITLE
dont generate traced accessor for java.lang.Object#getClass

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/TracedAccessors.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/TracedAccessors.xtend
@@ -88,7 +88,9 @@ class TracedAccessorsProcessor extends AbstractClassProcessor {
 			return false
 		if (declaration.static)
 			return false
-		val n = it.declaration.simpleName
+		val n = declaration.simpleName
+		if (declaration.declaringType.qualifiedName == Object.name)
+			return false
 		return n.startsWith('get') || n.startsWith('is')
 	}
 }

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/TracedAccessorsProcessor.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/TracedAccessorsProcessor.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.xtext.generator.trace.node;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import java.util.Collections;
 import java.util.List;
@@ -184,6 +185,12 @@ public class TracedAccessorsProcessor extends AbstractClassProcessor {
       return false;
     }
     final String n = it.getDeclaration().getSimpleName();
+    String _qualifiedName = it.getDeclaration().getDeclaringType().getQualifiedName();
+    String _name = Object.class.getName();
+    boolean _equals = Objects.equal(_qualifiedName, _name);
+    if (_equals) {
+      return false;
+    }
     return (n.startsWith("get") || n.startsWith("is"));
   }
 }


### PR DESCRIPTION
dont generate traced accessor for java.lang.Object#getClass

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>