### PR TITLE
[LSP] made aquisition of read lock synchronous to ensure right order of read and write requests. Only reads should go parallel and can be executed in any order.

### DIFF
--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/concurrent/RequestManager.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/concurrent/RequestManager.java
@@ -102,39 +102,43 @@ public class RequestManager {
    * </p>
    */
   public <V extends Object> CompletableFuture<V> runRead(final Function1<? super CancelIndicator, ? extends V> readRequest) {
-    final Function<CancelChecker, V> _function = (CancelChecker it) -> {
-      try {
-        final RequestCancelIndicator cancelIndicator = new RequestCancelIndicator(it);
-        this.cancelIndicators.add(cancelIndicator);
-        this.semaphore.acquire(1);
+    try {
+      this.semaphore.acquire(1);
+      final Function<CancelChecker, V> _function = (CancelChecker it) -> {
         try {
-          cancelIndicator.checkCanceled();
-          final CancelIndicator _function_1 = () -> {
+          final RequestCancelIndicator cancelIndicator = new RequestCancelIndicator(it);
+          this.cancelIndicators.add(cancelIndicator);
+          try {
             cancelIndicator.checkCanceled();
-            return false;
-          };
-          return readRequest.apply(_function_1);
-        } catch (final Throwable _t) {
-          if (_t instanceof Throwable) {
-            final Throwable t = (Throwable)_t;
-            boolean _isCancelException = this.isCancelException(t);
-            if (_isCancelException) {
-              RequestManager.LOGGER.info("request cancelled.");
-              throw new CancellationException();
+            final CancelIndicator _function_1 = () -> {
+              cancelIndicator.checkCanceled();
+              return false;
+            };
+            return readRequest.apply(_function_1);
+          } catch (final Throwable _t) {
+            if (_t instanceof Throwable) {
+              final Throwable t = (Throwable)_t;
+              boolean _isCancelException = this.isCancelException(t);
+              if (_isCancelException) {
+                RequestManager.LOGGER.info("request cancelled.");
+                throw new CancellationException();
+              }
+              throw t;
+            } else {
+              throw Exceptions.sneakyThrow(_t);
             }
-            throw t;
-          } else {
-            throw Exceptions.sneakyThrow(_t);
+          } finally {
+            this.cancelIndicators.remove(cancelIndicator);
+            this.semaphore.release(1);
           }
-        } finally {
-          this.cancelIndicators.remove(cancelIndicator);
-          this.semaphore.release(1);
+        } catch (Throwable _e) {
+          throw Exceptions.sneakyThrow(_e);
         }
-      } catch (Throwable _e) {
-        throw Exceptions.sneakyThrow(_e);
-      }
-    };
-    return CompletableFutures.<V>computeAsync(this.executorService, _function);
+      };
+      return CompletableFutures.<V>computeAsync(this.executorService, _function);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
   }
   
   protected boolean isCancelException(final Throwable t) {


### PR DESCRIPTION
Fixes #332 