### PR TITLE
Create an in-memory workspace configuration when no root URI is given

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/InMemoryWorkspaceTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/InMemoryWorkspaceTest.xtend
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.server
+
+import org.eclipse.lsp4j.DidOpenTextDocumentParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextDocumentItem
+import org.eclipse.lsp4j.TextDocumentPositionParams
+import org.junit.Test
+
+class InMemoryWorkspaceTest extends AbstractTestLangLanguageServerTest {
+	
+	@Test
+	def void testCompletion() {
+		initialize[rootUri = null]
+		val inmemoryUri = 'inmemory:/mydoc.testlang'
+		languageServer.didOpen(new DidOpenTextDocumentParams => [
+			textDocument = new TextDocumentItem => [
+				uri = inmemoryUri
+				text = '''
+					type Foo {}
+				'''
+			]
+		])
+		
+		val completionItems = languageServer.completion(new TextDocumentPositionParams => [
+			textDocument = new TextDocumentIdentifier(inmemoryUri)
+			position = new Position(0, 10)
+		])
+		val result = completionItems.get
+		val items = if (result.isLeft) result.getLeft else result.getRight.items 
+		val actualCompletionItems = items.toExpectation
+		val expectedCompletionItems = '''
+			Foo (TypeDeclaration) -> Foo [[0, 10] .. [0, 10]]
+			boolean -> boolean [[0, 10] .. [0, 10]]
+			int -> int [[0, 10] .. [0, 10]]
+			op -> op [[0, 10] .. [0, 10]]
+			string -> string [[0, 10] .. [0, 10]]
+			void -> void [[0, 10] .. [0, 10]]
+			} -> } [[0, 10] .. [0, 10]]
+			{ -> { [[0, 9] .. [0, 10]]
+		'''
+		assertEquals(expectedCompletionItems, actualCompletionItems)
+	}
+	
+}

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/InMemoryWorkspaceTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/InMemoryWorkspaceTest.xtend
@@ -17,7 +17,7 @@ import org.junit.Test
 class InMemoryWorkspaceTest extends AbstractTestLangLanguageServerTest {
 	
 	@Test
-	def void testCompletion() {
+	def void testCompletionWithInmemoryScheme() {
 		initialize[rootUri = null]
 		val inmemoryUri = 'inmemory:/mydoc.testlang'
 		languageServer.didOpen(new DidOpenTextDocumentParams => [
@@ -28,9 +28,27 @@ class InMemoryWorkspaceTest extends AbstractTestLangLanguageServerTest {
 				'''
 			]
 		])
-		
+		checkCompletion(inmemoryUri)
+	}
+	
+	@Test
+	def void testCompletionWithFileScheme() {
+		initialize[rootUri = null]
+		val fileUri = 'file:/home/test/workspace/mydoc.testlang'
+		languageServer.didOpen(new DidOpenTextDocumentParams => [
+			textDocument = new TextDocumentItem => [
+				uri = fileUri
+				text = '''
+					type Foo {}
+				'''
+			]
+		])
+		checkCompletion(fileUri)
+	}
+	
+	protected def checkCompletion(String uri) {
 		val completionItems = languageServer.completion(new TextDocumentPositionParams => [
-			textDocument = new TextDocumentIdentifier(inmemoryUri)
+			textDocument = new TextDocumentIdentifier(uri)
 			position = new Position(0, 10)
 		])
 		val result = completionItems.get

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/generator/TestLanguageGenerator.xtend
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/generator/TestLanguageGenerator.xtend
@@ -24,6 +24,10 @@ import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.Property
 class TestLanguageGenerator extends AbstractGenerator {
 
 	override void doGenerate(Resource resource, IFileSystemAccess2 fsa, IGeneratorContext context) {
+		if (resource.URI.scheme == 'inmemory') {
+			// Suppress the generator when building in memory, see InMemoryWorkspaceTest
+			return
+		}
 		for (type : resource.allContents.filter(TypeDeclaration).toList) {
 			fsa.generateFile(type.name+".java", '''
 			public class «type.name» {

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/generator/TestLanguageGenerator.xtend
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/generator/TestLanguageGenerator.xtend
@@ -24,7 +24,7 @@ import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.Property
 class TestLanguageGenerator extends AbstractGenerator {
 
 	override void doGenerate(Resource resource, IFileSystemAccess2 fsa, IGeneratorContext context) {
-		if (resource.URI.scheme == 'inmemory') {
+		if (fsa.getURI('').scheme == 'inmemory') {
 			// Suppress the generator when building in memory, see InMemoryWorkspaceTest
 			return
 		}

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/InMemoryWorkspaceTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/InMemoryWorkspaceTest.java
@@ -28,37 +28,66 @@ import org.junit.Test;
 @SuppressWarnings("all")
 public class InMemoryWorkspaceTest extends AbstractTestLangLanguageServerTest {
   @Test
-  public void testCompletion() {
+  public void testCompletionWithInmemoryScheme() {
+    final Procedure1<InitializeParams> _function = (InitializeParams it) -> {
+      it.setRootUri(null);
+    };
+    this.initialize(_function);
+    final String inmemoryUri = "inmemory:/mydoc.testlang";
+    DidOpenTextDocumentParams _didOpenTextDocumentParams = new DidOpenTextDocumentParams();
+    final Procedure1<DidOpenTextDocumentParams> _function_1 = (DidOpenTextDocumentParams it) -> {
+      TextDocumentItem _textDocumentItem = new TextDocumentItem();
+      final Procedure1<TextDocumentItem> _function_2 = (TextDocumentItem it_1) -> {
+        it_1.setUri(inmemoryUri);
+        StringConcatenation _builder = new StringConcatenation();
+        _builder.append("type Foo {}");
+        _builder.newLine();
+        it_1.setText(_builder.toString());
+      };
+      TextDocumentItem _doubleArrow = ObjectExtensions.<TextDocumentItem>operator_doubleArrow(_textDocumentItem, _function_2);
+      it.setTextDocument(_doubleArrow);
+    };
+    DidOpenTextDocumentParams _doubleArrow = ObjectExtensions.<DidOpenTextDocumentParams>operator_doubleArrow(_didOpenTextDocumentParams, _function_1);
+    this.languageServer.didOpen(_doubleArrow);
+    this.checkCompletion(inmemoryUri);
+  }
+  
+  @Test
+  public void testCompletionWithFileScheme() {
+    final Procedure1<InitializeParams> _function = (InitializeParams it) -> {
+      it.setRootUri(null);
+    };
+    this.initialize(_function);
+    final String fileUri = "file:/home/test/workspace/mydoc.testlang";
+    DidOpenTextDocumentParams _didOpenTextDocumentParams = new DidOpenTextDocumentParams();
+    final Procedure1<DidOpenTextDocumentParams> _function_1 = (DidOpenTextDocumentParams it) -> {
+      TextDocumentItem _textDocumentItem = new TextDocumentItem();
+      final Procedure1<TextDocumentItem> _function_2 = (TextDocumentItem it_1) -> {
+        it_1.setUri(fileUri);
+        StringConcatenation _builder = new StringConcatenation();
+        _builder.append("type Foo {}");
+        _builder.newLine();
+        it_1.setText(_builder.toString());
+      };
+      TextDocumentItem _doubleArrow = ObjectExtensions.<TextDocumentItem>operator_doubleArrow(_textDocumentItem, _function_2);
+      it.setTextDocument(_doubleArrow);
+    };
+    DidOpenTextDocumentParams _doubleArrow = ObjectExtensions.<DidOpenTextDocumentParams>operator_doubleArrow(_didOpenTextDocumentParams, _function_1);
+    this.languageServer.didOpen(_doubleArrow);
+    this.checkCompletion(fileUri);
+  }
+  
+  protected void checkCompletion(final String uri) {
     try {
-      final Procedure1<InitializeParams> _function = (InitializeParams it) -> {
-        it.setRootUri(null);
-      };
-      this.initialize(_function);
-      final String inmemoryUri = "inmemory:/mydoc.testlang";
-      DidOpenTextDocumentParams _didOpenTextDocumentParams = new DidOpenTextDocumentParams();
-      final Procedure1<DidOpenTextDocumentParams> _function_1 = (DidOpenTextDocumentParams it) -> {
-        TextDocumentItem _textDocumentItem = new TextDocumentItem();
-        final Procedure1<TextDocumentItem> _function_2 = (TextDocumentItem it_1) -> {
-          it_1.setUri(inmemoryUri);
-          StringConcatenation _builder = new StringConcatenation();
-          _builder.append("type Foo {}");
-          _builder.newLine();
-          it_1.setText(_builder.toString());
-        };
-        TextDocumentItem _doubleArrow = ObjectExtensions.<TextDocumentItem>operator_doubleArrow(_textDocumentItem, _function_2);
-        it.setTextDocument(_doubleArrow);
-      };
-      DidOpenTextDocumentParams _doubleArrow = ObjectExtensions.<DidOpenTextDocumentParams>operator_doubleArrow(_didOpenTextDocumentParams, _function_1);
-      this.languageServer.didOpen(_doubleArrow);
       TextDocumentPositionParams _textDocumentPositionParams = new TextDocumentPositionParams();
-      final Procedure1<TextDocumentPositionParams> _function_2 = (TextDocumentPositionParams it) -> {
-        TextDocumentIdentifier _textDocumentIdentifier = new TextDocumentIdentifier(inmemoryUri);
+      final Procedure1<TextDocumentPositionParams> _function = (TextDocumentPositionParams it) -> {
+        TextDocumentIdentifier _textDocumentIdentifier = new TextDocumentIdentifier(uri);
         it.setTextDocument(_textDocumentIdentifier);
         Position _position = new Position(0, 10);
         it.setPosition(_position);
       };
-      TextDocumentPositionParams _doubleArrow_1 = ObjectExtensions.<TextDocumentPositionParams>operator_doubleArrow(_textDocumentPositionParams, _function_2);
-      final CompletableFuture<Either<List<CompletionItem>, CompletionList>> completionItems = this.languageServer.completion(_doubleArrow_1);
+      TextDocumentPositionParams _doubleArrow = ObjectExtensions.<TextDocumentPositionParams>operator_doubleArrow(_textDocumentPositionParams, _function);
+      final CompletableFuture<Either<List<CompletionItem>, CompletionList>> completionItems = this.languageServer.completion(_doubleArrow);
       final Either<List<CompletionItem>, CompletionList> result = completionItems.get();
       List<CompletionItem> _xifexpression = null;
       boolean _isLeft = result.isLeft();

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/InMemoryWorkspaceTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/InMemoryWorkspaceTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.tests.server;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Test;
+
+@SuppressWarnings("all")
+public class InMemoryWorkspaceTest extends AbstractTestLangLanguageServerTest {
+  @Test
+  public void testCompletion() {
+    try {
+      final Procedure1<InitializeParams> _function = (InitializeParams it) -> {
+        it.setRootUri(null);
+      };
+      this.initialize(_function);
+      final String inmemoryUri = "inmemory:/mydoc.testlang";
+      DidOpenTextDocumentParams _didOpenTextDocumentParams = new DidOpenTextDocumentParams();
+      final Procedure1<DidOpenTextDocumentParams> _function_1 = (DidOpenTextDocumentParams it) -> {
+        TextDocumentItem _textDocumentItem = new TextDocumentItem();
+        final Procedure1<TextDocumentItem> _function_2 = (TextDocumentItem it_1) -> {
+          it_1.setUri(inmemoryUri);
+          StringConcatenation _builder = new StringConcatenation();
+          _builder.append("type Foo {}");
+          _builder.newLine();
+          it_1.setText(_builder.toString());
+        };
+        TextDocumentItem _doubleArrow = ObjectExtensions.<TextDocumentItem>operator_doubleArrow(_textDocumentItem, _function_2);
+        it.setTextDocument(_doubleArrow);
+      };
+      DidOpenTextDocumentParams _doubleArrow = ObjectExtensions.<DidOpenTextDocumentParams>operator_doubleArrow(_didOpenTextDocumentParams, _function_1);
+      this.languageServer.didOpen(_doubleArrow);
+      TextDocumentPositionParams _textDocumentPositionParams = new TextDocumentPositionParams();
+      final Procedure1<TextDocumentPositionParams> _function_2 = (TextDocumentPositionParams it) -> {
+        TextDocumentIdentifier _textDocumentIdentifier = new TextDocumentIdentifier(inmemoryUri);
+        it.setTextDocument(_textDocumentIdentifier);
+        Position _position = new Position(0, 10);
+        it.setPosition(_position);
+      };
+      TextDocumentPositionParams _doubleArrow_1 = ObjectExtensions.<TextDocumentPositionParams>operator_doubleArrow(_textDocumentPositionParams, _function_2);
+      final CompletableFuture<Either<List<CompletionItem>, CompletionList>> completionItems = this.languageServer.completion(_doubleArrow_1);
+      final Either<List<CompletionItem>, CompletionList> result = completionItems.get();
+      List<CompletionItem> _xifexpression = null;
+      boolean _isLeft = result.isLeft();
+      if (_isLeft) {
+        _xifexpression = result.getLeft();
+      } else {
+        _xifexpression = result.getRight().getItems();
+      }
+      final List<CompletionItem> items = _xifexpression;
+      final String actualCompletionItems = this.toExpectation(items);
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("Foo (TypeDeclaration) -> Foo [[0, 10] .. [0, 10]]");
+      _builder.newLine();
+      _builder.append("boolean -> boolean [[0, 10] .. [0, 10]]");
+      _builder.newLine();
+      _builder.append("int -> int [[0, 10] .. [0, 10]]");
+      _builder.newLine();
+      _builder.append("op -> op [[0, 10] .. [0, 10]]");
+      _builder.newLine();
+      _builder.append("string -> string [[0, 10] .. [0, 10]]");
+      _builder.newLine();
+      _builder.append("void -> void [[0, 10] .. [0, 10]]");
+      _builder.newLine();
+      _builder.append("} -> } [[0, 10] .. [0, 10]]");
+      _builder.newLine();
+      _builder.append("{ -> { [[0, 9] .. [0, 10]]");
+      _builder.newLine();
+      final String expectedCompletionItems = _builder.toString();
+      this.assertEquals(expectedCompletionItems, actualCompletionItems);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+}

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/generator/TestLanguageGenerator.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/generator/TestLanguageGenerator.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.xtext.ide.tests.testlanguage.generator;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import java.util.Arrays;
@@ -36,6 +37,11 @@ import org.eclipse.xtext.xbase.lib.StringExtensions;
 public class TestLanguageGenerator extends AbstractGenerator {
   @Override
   public void doGenerate(final Resource resource, final IFileSystemAccess2 fsa, final IGeneratorContext context) {
+    String _scheme = resource.getURI().scheme();
+    boolean _equals = Objects.equal(_scheme, "inmemory");
+    if (_equals) {
+      return;
+    }
     List<TypeDeclaration> _list = IteratorExtensions.<TypeDeclaration>toList(Iterators.<TypeDeclaration>filter(resource.getAllContents(), TypeDeclaration.class));
     for (final TypeDeclaration type : _list) {
       String _name = type.getName();

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/generator/TestLanguageGenerator.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/generator/TestLanguageGenerator.java
@@ -37,7 +37,7 @@ import org.eclipse.xtext.xbase.lib.StringExtensions;
 public class TestLanguageGenerator extends AbstractGenerator {
   @Override
   public void doGenerate(final Resource resource, final IFileSystemAccess2 fsa, final IGeneratorContext context) {
-    String _scheme = resource.getURI().scheme();
+    String _scheme = fsa.getURI("").scheme();
     boolean _equals = Objects.equal(_scheme, "inmemory");
     if (_equals) {
       return;

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/IWorkspaceConfigFactory.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/IWorkspaceConfigFactory.xtend
@@ -11,6 +11,7 @@ import org.eclipse.emf.common.util.URI
 import org.eclipse.xtext.workspace.FileProjectConfig
 import org.eclipse.xtext.workspace.FileSourceFolder
 import org.eclipse.xtext.workspace.IWorkspaceConfig
+import org.eclipse.xtext.workspace.InMemoryProjectConfig
 
 /**
  * @author Jan Koehnlein - Initial contribution and API
@@ -30,11 +31,15 @@ interface IWorkspaceConfigFactory {
  */
 class ProjectWorkspaceConfigFactory implements IWorkspaceConfigFactory {
     
-    
     override getWorkspaceConfig(URI workspaceBaseURI) {
-        val projectConfig = new FileProjectConfig(workspaceBaseURI)
-        projectConfig.sourceFolders += new FileSourceFolder(projectConfig, '.')
-        return projectConfig.workspaceConfig
+    	if (workspaceBaseURI === null) {
+			val projectConfig = new InMemoryProjectConfig
+			return projectConfig.workspaceConfig
+    	} else {
+	        val projectConfig = new FileProjectConfig(workspaceBaseURI)
+	        projectConfig.sourceFolders += new FileSourceFolder(projectConfig, '.')
+	        return projectConfig.workspaceConfig
+        }
     }
+    
 }
-

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.xtend
@@ -106,9 +106,6 @@ import org.eclipse.xtext.validation.Issue
 			throw new IllegalStateException("This language server has already been initialized.")
 		}
 		val baseDir = params.baseDir
-		if (baseDir === null) {
-			throw new IllegalArgumentException("Bad initialization request: rootUri must not be null.")
-		}
 		if (languagesRegistry.extensionToFactoryMap.isEmpty) {
 			throw new IllegalStateException("No Xtext languages have been registered. Please make sure you have added the languages's setup class in '/META-INF/services/org.eclipse.xtext.ISetup'")
 		}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/MultiProjectWorkspaceConfigFactory.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/MultiProjectWorkspaceConfigFactory.xtend
@@ -71,6 +71,8 @@ class MultiProjectWorkspaceConfig implements IWorkspaceConfig {
         ]
         if (!candidates.empty)
         	return candidates.maxBy[path.segmentCount]
+        else
+        	return null
     }
 }
 

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/LanguageServerImpl.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/LanguageServerImpl.java
@@ -173,9 +173,6 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
       throw new IllegalStateException("This language server has already been initialized.");
     }
     final URI baseDir = this.getBaseDir(params);
-    if ((baseDir == null)) {
-      throw new IllegalArgumentException("Bad initialization request: rootUri must not be null.");
-    }
     boolean _isEmpty = this.languagesRegistry.getExtensionToFactoryMap().isEmpty();
     if (_isEmpty) {
       throw new IllegalStateException("No Xtext languages have been registered. Please make sure you have added the languages\'s setup class in \'/META-INF/services/org.eclipse.xtext.ISetup\'");

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/MultiProjectWorkspaceConfig.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/MultiProjectWorkspaceConfig.java
@@ -49,8 +49,9 @@ public class MultiProjectWorkspaceConfig implements IWorkspaceConfig {
         return Integer.valueOf(it.getPath().segmentCount());
       };
       return IterableExtensions.<IProjectConfig, Integer>maxBy(candidates, _function_1);
+    } else {
+      return null;
     }
-    return null;
   }
   
   public MultiProjectWorkspaceConfig(final Map<String, IProjectConfig> name2config) {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/MultiProjectWorkspaceConfig.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/MultiProjectWorkspaceConfig.java
@@ -41,10 +41,16 @@ public class MultiProjectWorkspaceConfig implements IWorkspaceConfig {
       ISourceFolder _findSourceFolderContaining = it.findSourceFolderContaining(member);
       return Boolean.valueOf((_findSourceFolderContaining != null));
     };
-    final Function1<IProjectConfig, Integer> _function_1 = (IProjectConfig it) -> {
-      return Integer.valueOf(it.getPath().segmentCount());
-    };
-    return IterableExtensions.<IProjectConfig, Integer>maxBy(IterableExtensions.<IProjectConfig>filter(this.name2config.values(), _function), _function_1);
+    final Iterable<IProjectConfig> candidates = IterableExtensions.<IProjectConfig>filter(this.name2config.values(), _function);
+    boolean _isEmpty = IterableExtensions.isEmpty(candidates);
+    boolean _not = (!_isEmpty);
+    if (_not) {
+      final Function1<IProjectConfig, Integer> _function_1 = (IProjectConfig it) -> {
+        return Integer.valueOf(it.getPath().segmentCount());
+      };
+      return IterableExtensions.<IProjectConfig, Integer>maxBy(candidates, _function_1);
+    }
+    return null;
   }
   
   public MultiProjectWorkspaceConfig(final Map<String, IProjectConfig> name2config) {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/MultiProjectWorkspaceConfigFactory.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/MultiProjectWorkspaceConfigFactory.java
@@ -17,6 +17,7 @@ import org.eclipse.xtext.ide.server.RootSourceFolderProjectConfig;
 import org.eclipse.xtext.util.IAcceptor;
 import org.eclipse.xtext.workspace.IProjectConfig;
 import org.eclipse.xtext.workspace.IWorkspaceConfig;
+import org.eclipse.xtext.workspace.InMemoryProjectConfig;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
@@ -30,24 +31,29 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 public class MultiProjectWorkspaceConfigFactory implements IWorkspaceConfigFactory {
   @Override
   public IWorkspaceConfig getWorkspaceConfig(final URI workspaceBaseURI) {
-    String _fileString = workspaceBaseURI.toFileString();
-    final File baseFile = new File(_fileString);
-    boolean _isDirectory = baseFile.isDirectory();
-    if (_isDirectory) {
-      final HashMap<String, IProjectConfig> name2config = CollectionLiterals.<String, IProjectConfig>newHashMap();
-      final MultiProjectWorkspaceConfig result = new MultiProjectWorkspaceConfig(name2config);
-      final IAcceptor<IProjectConfig> _function = (IProjectConfig it) -> {
-        name2config.put(it.getName(), it);
-      };
-      final IAcceptor<IProjectConfig> acceptor = _function;
-      final Function1<File, Boolean> _function_1 = (File it) -> {
-        return Boolean.valueOf(it.isDirectory());
-      };
-      final Consumer<File> _function_2 = (File it) -> {
-        this.addProjectConfigs(URI.createFileURI(it.getAbsolutePath()), result, acceptor);
-      };
-      IterableExtensions.<File>filter(((Iterable<File>)Conversions.doWrapArray(baseFile.listFiles())), _function_1).forEach(_function_2);
-      return result;
+    if ((workspaceBaseURI == null)) {
+      final InMemoryProjectConfig projectConfig = new InMemoryProjectConfig();
+      return projectConfig.getWorkspaceConfig();
+    } else {
+      String _fileString = workspaceBaseURI.toFileString();
+      final File baseFile = new File(_fileString);
+      boolean _isDirectory = baseFile.isDirectory();
+      if (_isDirectory) {
+        final HashMap<String, IProjectConfig> name2config = CollectionLiterals.<String, IProjectConfig>newHashMap();
+        final MultiProjectWorkspaceConfig result = new MultiProjectWorkspaceConfig(name2config);
+        final IAcceptor<IProjectConfig> _function = (IProjectConfig it) -> {
+          name2config.put(it.getName(), it);
+        };
+        final IAcceptor<IProjectConfig> acceptor = _function;
+        final Function1<File, Boolean> _function_1 = (File it) -> {
+          return Boolean.valueOf(it.isDirectory());
+        };
+        final Consumer<File> _function_2 = (File it) -> {
+          this.addProjectConfigs(URI.createFileURI(it.getAbsolutePath()), result, acceptor);
+        };
+        IterableExtensions.<File>filter(((Iterable<File>)Conversions.doWrapArray(baseFile.listFiles())), _function_1).forEach(_function_2);
+        return result;
+      }
     }
     return null;
   }

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/ProjectWorkspaceConfigFactory.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/ProjectWorkspaceConfigFactory.java
@@ -13,6 +13,7 @@ import org.eclipse.xtext.ide.server.IWorkspaceConfigFactory;
 import org.eclipse.xtext.workspace.FileProjectConfig;
 import org.eclipse.xtext.workspace.FileSourceFolder;
 import org.eclipse.xtext.workspace.IWorkspaceConfig;
+import org.eclipse.xtext.workspace.InMemoryProjectConfig;
 
 /**
  * The workspace itself is a single project
@@ -24,10 +25,15 @@ import org.eclipse.xtext.workspace.IWorkspaceConfig;
 public class ProjectWorkspaceConfigFactory implements IWorkspaceConfigFactory {
   @Override
   public IWorkspaceConfig getWorkspaceConfig(final URI workspaceBaseURI) {
-    final FileProjectConfig projectConfig = new FileProjectConfig(workspaceBaseURI);
-    Set<FileSourceFolder> _sourceFolders = projectConfig.getSourceFolders();
-    FileSourceFolder _fileSourceFolder = new FileSourceFolder(projectConfig, ".");
-    _sourceFolders.add(_fileSourceFolder);
-    return projectConfig.getWorkspaceConfig();
+    if ((workspaceBaseURI == null)) {
+      final InMemoryProjectConfig projectConfig = new InMemoryProjectConfig();
+      return projectConfig.getWorkspaceConfig();
+    } else {
+      final FileProjectConfig projectConfig_1 = new FileProjectConfig(workspaceBaseURI);
+      Set<FileSourceFolder> _sourceFolders = projectConfig_1.getSourceFolders();
+      FileSourceFolder _fileSourceFolder = new FileSourceFolder(projectConfig_1, ".");
+      _sourceFolders.add(_fileSourceFolder);
+      return projectConfig_1.getWorkspaceConfig();
+    }
   }
 }

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.testing
 
-import com.google.inject.AbstractModule
 import com.google.inject.Guice
 import com.google.inject.Inject
 import java.io.File
@@ -50,6 +49,7 @@ import org.eclipse.lsp4j.TextDocumentPositionParams
 import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.WorkspaceSymbolParams
 import org.eclipse.lsp4j.jsonrpc.Endpoint
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints
 import org.eclipse.lsp4j.services.LanguageClientExtensions
 import org.eclipse.xtend.lib.annotations.Accessors
@@ -67,7 +67,6 @@ import org.eclipse.xtext.util.Files
 import org.eclipse.xtext.util.Modules2
 import org.junit.Assert
 import org.junit.Before
-import org.eclipse.lsp4j.jsonrpc.messages.Either
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -80,23 +79,19 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 
 	@Before
 	def void setup() {
-		val module = Modules2.mixin(new ServerModule, new AbstractModule() {
-
-			override protected configure() {
-				bind(RequestManager).toInstance(new RequestManager() {
-
-					override <V> runWrite((CancelIndicator)=>V writeRequest) {
-						return CompletableFuture.completedFuture(writeRequest.apply [ false ])
-					}
-
-					override <V> runRead((CancelIndicator)=>V readRequest) {
-						return CompletableFuture.completedFuture(readRequest.apply [ false ])
-					}
-
-				})
-			}
-
-		})
+		val module = Modules2.mixin(new ServerModule, [
+			bind(RequestManager).toInstance(new RequestManager() {
+	
+				override <V> runWrite((CancelIndicator)=>V writeRequest) {
+					return CompletableFuture.completedFuture(writeRequest.apply [ false ])
+				}
+	
+				override <V> runRead((CancelIndicator)=>V readRequest) {
+					return CompletableFuture.completedFuture(readRequest.apply [ false ])
+				}
+	
+			})
+		])
 
 		val injector = Guice.createInjector(module)
 		injector.injectMembers(this)

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
@@ -9,7 +9,7 @@ package org.eclipse.xtext.testing;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
-import com.google.inject.AbstractModule;
+import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -115,29 +115,27 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
   public void setup() {
     try {
       ServerModule _serverModule = new ServerModule();
-      final Module module = Modules2.mixin(_serverModule, new AbstractModule() {
-        @Override
-        protected void configure() {
-          AnnotatedBindingBuilder<RequestManager> _bind = this.<RequestManager>bind(RequestManager.class);
-          _bind.toInstance(new RequestManager() {
-            @Override
-            public <V extends Object> CompletableFuture<V> runWrite(final Function1<? super CancelIndicator, ? extends V> writeRequest) {
-              final CancelIndicator _function = () -> {
-                return false;
-              };
-              return CompletableFuture.<V>completedFuture(writeRequest.apply(_function));
-            }
-            
-            @Override
-            public <V extends Object> CompletableFuture<V> runRead(final Function1<? super CancelIndicator, ? extends V> readRequest) {
-              final CancelIndicator _function = () -> {
-                return false;
-              };
-              return CompletableFuture.<V>completedFuture(readRequest.apply(_function));
-            }
-          });
-        }
-      });
+      final Module _function = (Binder it) -> {
+        AnnotatedBindingBuilder<RequestManager> _bind = it.<RequestManager>bind(RequestManager.class);
+        _bind.toInstance(new RequestManager() {
+          @Override
+          public <V extends Object> CompletableFuture<V> runWrite(final Function1<? super CancelIndicator, ? extends V> writeRequest) {
+            final CancelIndicator _function = () -> {
+              return false;
+            };
+            return CompletableFuture.<V>completedFuture(writeRequest.apply(_function));
+          }
+          
+          @Override
+          public <V extends Object> CompletableFuture<V> runRead(final Function1<? super CancelIndicator, ? extends V> readRequest) {
+            final CancelIndicator _function = () -> {
+              return false;
+            };
+            return CompletableFuture.<V>completedFuture(readRequest.apply(_function));
+          }
+        });
+      };
+      final Module module = Modules2.mixin(_serverModule, _function);
       final Injector injector = Guice.createInjector(module);
       injector.injectMembers(this);
       final Object resourceServiceProvider = this.resourceServerProviderRegistry.getExtensionToFactoryMap().get(this.fileExtension);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/workspace/FileWorkspaceConfig.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/workspace/FileWorkspaceConfig.xtend
@@ -124,11 +124,15 @@ class SingleProjectWorkspaceConfig implements IWorkspaceConfig {
 	override findProjectByName(String name) {
 		if (projectConfig.name == name)
 			return projectConfig
+		else
+			return null
 	}
 	
 	override findProjectContaining(URI member) {
 		if (projectConfig.path.isPrefixOf(member))
 			return projectConfig
+		else
+			return null
 	}
 	
 	override getProjects() {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/workspace/InMemoryWorkspaceConfig.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/workspace/InMemoryWorkspaceConfig.xtend
@@ -21,13 +21,15 @@ class InMemoryWorkspaceConfig implements IWorkspaceConfig {
 	override findProjectByName(String name) {
 		if (projectConfig.name == name)
 			return projectConfig
+		else
+			return null
 	}
 	
 	override findProjectContaining(URI member) {
 		if (projectConfig.path.isPrefixOf(member))
 			return projectConfig
 		else
-			new InMemoryProjectConfig(member.trimFragment.trimQuery.trimSegments(1))
+			return new InMemoryProjectConfig(member.trimFragment.trimQuery.trimSegments(1))
 	}
 	
 	override getProjects() {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/workspace/InMemoryWorkspaceConfig.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/workspace/InMemoryWorkspaceConfig.xtend
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.workspace
+
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+
+import static extension org.eclipse.xtext.util.UriUtil.*
+
+@FinalFieldsConstructor
+class InMemoryWorkspaceConfig implements IWorkspaceConfig {
+	
+	val IProjectConfig projectConfig
+	
+	override findProjectByName(String name) {
+		if (projectConfig.name == name)
+			return projectConfig
+	}
+	
+	override findProjectContaining(URI member) {
+		if (projectConfig.path.isPrefixOf(member))
+			return projectConfig
+		else
+			new InMemoryProjectConfig(member.trimFragment.trimQuery.trimSegments(1))
+	}
+	
+	override getProjects() {
+		#{projectConfig}
+	}
+	
+}
+
+@Accessors
+class InMemoryProjectConfig implements IProjectConfig {
+	
+	val URI path
+	
+	val IWorkspaceConfig workspaceConfig
+	
+	String name = 'inmemory'
+	
+	new() {
+		this(URI.createURI('inmemory:/'))
+	}
+	
+	new(URI path) {
+		this.path = path
+		this.workspaceConfig = new InMemoryWorkspaceConfig(this)
+	}
+	
+	override getSourceFolders() {
+		emptySet
+	}
+	
+	override findSourceFolderContaining(URI member) {
+		null
+	}
+	
+}
+

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/workspace/InMemoryProjectConfig.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/workspace/InMemoryProjectConfig.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.workspace;
+
+import java.util.Set;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtend.lib.annotations.Accessors;
+import org.eclipse.xtext.workspace.IProjectConfig;
+import org.eclipse.xtext.workspace.ISourceFolder;
+import org.eclipse.xtext.workspace.IWorkspaceConfig;
+import org.eclipse.xtext.workspace.InMemoryWorkspaceConfig;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Pure;
+
+@Accessors
+@SuppressWarnings("all")
+public class InMemoryProjectConfig implements IProjectConfig {
+  private final URI path;
+  
+  private final IWorkspaceConfig workspaceConfig;
+  
+  private String name = "inmemory";
+  
+  public InMemoryProjectConfig() {
+    this(URI.createURI("inmemory:/"));
+  }
+  
+  public InMemoryProjectConfig(final URI path) {
+    this.path = path;
+    InMemoryWorkspaceConfig _inMemoryWorkspaceConfig = new InMemoryWorkspaceConfig(this);
+    this.workspaceConfig = _inMemoryWorkspaceConfig;
+  }
+  
+  @Override
+  public Set<? extends ISourceFolder> getSourceFolders() {
+    return CollectionLiterals.<ISourceFolder>emptySet();
+  }
+  
+  @Override
+  public ISourceFolder findSourceFolderContaining(final URI member) {
+    return null;
+  }
+  
+  @Pure
+  public URI getPath() {
+    return this.path;
+  }
+  
+  @Pure
+  public IWorkspaceConfig getWorkspaceConfig() {
+    return this.workspaceConfig;
+  }
+  
+  @Pure
+  public String getName() {
+    return this.name;
+  }
+  
+  public void setName(final String name) {
+    this.name = name;
+  }
+}

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/workspace/InMemoryWorkspaceConfig.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/workspace/InMemoryWorkspaceConfig.java
@@ -29,21 +29,20 @@ public class InMemoryWorkspaceConfig implements IWorkspaceConfig {
     boolean _equals = Objects.equal(_name, name);
     if (_equals) {
       return this.projectConfig;
+    } else {
+      return null;
     }
-    return null;
   }
   
   @Override
   public IProjectConfig findProjectContaining(final URI member) {
-    InMemoryProjectConfig _xifexpression = null;
     boolean _isPrefixOf = UriUtil.isPrefixOf(this.projectConfig.getPath(), member);
     if (_isPrefixOf) {
       return this.projectConfig;
     } else {
       URI _trimSegments = member.trimFragment().trimQuery().trimSegments(1);
-      _xifexpression = new InMemoryProjectConfig(_trimSegments);
+      return new InMemoryProjectConfig(_trimSegments);
     }
-    return _xifexpression;
   }
   
   @Override

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/workspace/InMemoryWorkspaceConfig.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/workspace/InMemoryWorkspaceConfig.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.workspace;
+
+import com.google.common.base.Objects;
+import java.util.Collections;
+import java.util.Set;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
+import org.eclipse.xtext.util.UriUtil;
+import org.eclipse.xtext.workspace.IProjectConfig;
+import org.eclipse.xtext.workspace.IWorkspaceConfig;
+import org.eclipse.xtext.workspace.InMemoryProjectConfig;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+
+@FinalFieldsConstructor
+@SuppressWarnings("all")
+public class InMemoryWorkspaceConfig implements IWorkspaceConfig {
+  private final IProjectConfig projectConfig;
+  
+  @Override
+  public IProjectConfig findProjectByName(final String name) {
+    String _name = this.projectConfig.getName();
+    boolean _equals = Objects.equal(_name, name);
+    if (_equals) {
+      return this.projectConfig;
+    }
+    return null;
+  }
+  
+  @Override
+  public IProjectConfig findProjectContaining(final URI member) {
+    InMemoryProjectConfig _xifexpression = null;
+    boolean _isPrefixOf = UriUtil.isPrefixOf(this.projectConfig.getPath(), member);
+    if (_isPrefixOf) {
+      return this.projectConfig;
+    } else {
+      URI _trimSegments = member.trimFragment().trimQuery().trimSegments(1);
+      _xifexpression = new InMemoryProjectConfig(_trimSegments);
+    }
+    return _xifexpression;
+  }
+  
+  @Override
+  public Set<? extends IProjectConfig> getProjects() {
+    return Collections.<IProjectConfig>unmodifiableSet(CollectionLiterals.<IProjectConfig>newHashSet(this.projectConfig));
+  }
+  
+  public InMemoryWorkspaceConfig(final IProjectConfig projectConfig) {
+    super();
+    this.projectConfig = projectConfig;
+  }
+}

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/workspace/SingleProjectWorkspaceConfig.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/workspace/SingleProjectWorkspaceConfig.java
@@ -30,8 +30,9 @@ public class SingleProjectWorkspaceConfig implements IWorkspaceConfig {
     boolean _equals = Objects.equal(_name, name);
     if (_equals) {
       return this.projectConfig;
+    } else {
+      return null;
     }
-    return null;
   }
   
   @Override
@@ -39,8 +40,9 @@ public class SingleProjectWorkspaceConfig implements IWorkspaceConfig {
     boolean _isPrefixOf = UriUtil.isPrefixOf(this.projectConfig.getPath(), member);
     if (_isPrefixOf) {
       return this.projectConfig;
+    } else {
+      return null;
     }
-    return null;
   }
   
   @Override


### PR DESCRIPTION
Fixes eclipse/xtext-core#57. WorkspaceConfigFactory switches to the new InMemoryProjectConfig when the root URI is null. This allows to work with files without a real workspace, e.g. when using the standalone Monaco web editor.