### PR TITLE
[ls] cancellable builds

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/WorkspaceManagerTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/WorkspaceManagerTest.xtend
@@ -43,7 +43,7 @@ class WorkspaceManagerTest {
             }
         '''
         
-        workspaceManger.didOpen(path, 1, inMemContents, null)
+        workspaceManger.didOpen(path, 1, inMemContents).build(null)
         
         Assert.assertEquals(inMemContents, workspaceManger.doRead(path, [$0.contents]))
     }

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.xtend
@@ -67,7 +67,7 @@ class RequestManagerTest {
 	@Test(timeout = 1000)
 	def void testRunReadAfterWrite() {
 		requestManager.runWrite [
-    		sharedState.incrementAndGet
+			sharedState.incrementAndGet
 		]
 		val future = requestManager.runRead [
 			sharedState.get
@@ -101,7 +101,8 @@ class RequestManagerTest {
 			sharedState.incrementAndGet
 		]
 		requestManager.runWrite [
-			assertEquals(1, sharedState.get)
+			while (sharedState.get == 0) {
+			}
 			sharedState.incrementAndGet
 		].join
 		assertEquals(2, sharedState.get)

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/WorkspaceManagerTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/WorkspaceManagerTest.java
@@ -62,7 +62,7 @@ public class WorkspaceManagerTest {
     _builder_1.append("}");
     _builder_1.newLine();
     final String inMemContents = _builder_1.toString();
-    this.workspaceManger.didOpen(path, 1, inMemContents, null);
+    this.workspaceManger.didOpen(path, 1, inMemContents).build(null);
     final Function2<Document, XtextResource, String> _function = (Document $0, XtextResource $1) -> {
       return $0.getContents();
     };

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.java
@@ -134,7 +134,8 @@ public class RequestManagerTest {
     final Function1<CancelIndicator, Integer> _function_1 = (CancelIndicator it) -> {
       int _xblockexpression = (int) 0;
       {
-        Assert.assertEquals(1, this.sharedState.get());
+        while ((this.sharedState.get() == 0)) {
+        }
         _xblockexpression = this.sharedState.incrementAndGet();
       }
       return Integer.valueOf(_xblockexpression);

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/BuildManager.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/BuildManager.xtend
@@ -36,11 +36,15 @@ class BuildManager {
 
     val dirtyFiles = <URI>newLinkedHashSet
     val deletedFiles = <URI>newLinkedHashSet
+    
+    def Buildable submit(List<URI> dirtyFiles, List<URI> deletedFiles) {
+    	queue(this.dirtyFiles, deletedFiles, dirtyFiles)
+        queue(this.deletedFiles, dirtyFiles, deletedFiles)
+        return [cancelIndicator|internalBuild(cancelIndicator)]
+    }
 
     def List<IResourceDescription.Delta> doBuild(List<URI> dirtyFiles, List<URI> deletedFiles, CancelIndicator cancelIndicator) {
-        queue(this.dirtyFiles, deletedFiles, dirtyFiles)
-        queue(this.deletedFiles, dirtyFiles, deletedFiles)
-        return internalBuild(cancelIndicator)
+    	return submit(dirtyFiles, deletedFiles).build(cancelIndicator)
     }
     
     protected def void queue(Set<URI> files, Collection<URI> toRemove, Collection<URI> toAdd) {
@@ -99,5 +103,9 @@ class BuildManager {
     protected static class ProjectBuildData {
         List<URI> dirtyFiles
         List<URI> deletedFiles
+    }
+    
+    static interface Buildable {
+    	def List<IResourceDescription.Delta> build(CancelIndicator cancelIndicator)
     }
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.xtend
@@ -132,8 +132,8 @@ import org.eclipse.xtext.validation.Issue
 			documentHighlightProvider = true
 		]
 
-		requestManager.runWrite [ cancelIndicator |
-			workspaceManager.initialize(baseDir, [this.publishDiagnostics($0, $1)], cancelIndicator)
+		requestManager.lockWrite [
+			workspaceManager.initialize(baseDir, [this.publishDiagnostics($0, $1)], CancelIndicator.NullImpl)
 			return null
 		]
 
@@ -179,26 +179,29 @@ import org.eclipse.xtext.validation.Issue
 	// end notification callbacks
 	// file/content change events
 	override didOpen(DidOpenTextDocumentParams params) {
-		requestManager.runWrite [ cancelIndicator |
-			workspaceManager.didOpen(params.textDocument.uri.toUri, params.textDocument.version, params.textDocument.text, cancelIndicator)
-			return null
+		requestManager.cancel
+		val buildable = requestManager.lockWrite [
+			workspaceManager.didOpen(params.textDocument.uri.toUri, params.textDocument.version, params.textDocument.text)
 		]
+		requestManager.runWrite(buildable)
 	}
 
 	override didChange(DidChangeTextDocumentParams params) {
-		requestManager.runWrite [ cancelIndicator |
+		requestManager.cancel
+		val buildable = requestManager.lockWrite [ 
 			workspaceManager.didChange(params.textDocument.uri.toUri, params.textDocument.version, params.contentChanges.map [ event |
 				new TextEdit(event.range, event.text)
-			], cancelIndicator)
-			return null
+			])
 		]
+		requestManager.runWrite(buildable)
 	}
 
 	override didClose(DidCloseTextDocumentParams params) {
-		requestManager.runWrite [ cancelIndicator |
-			workspaceManager.didClose(params.textDocument.uri.toUri, cancelIndicator)
-			return null
+		requestManager.cancel
+		val buildable = requestManager.lockWrite [
+			workspaceManager.didClose(params.textDocument.uri.toUri)
 		]
+		requestManager.runWrite(buildable)
 	}
 
 	override didSave(DidSaveTextDocumentParams params) {
@@ -207,7 +210,8 @@ import org.eclipse.xtext.validation.Issue
 	}
 
 	override didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
-		requestManager.runWrite [ cancelIndicator |
+		requestManager.cancel
+		val buildable = requestManager.lockWrite [
 			val dirtyFiles = newArrayList
 			val deletedFiles = newArrayList
 			for (fileEvent : params.changes) {
@@ -217,14 +221,15 @@ import org.eclipse.xtext.validation.Issue
 					dirtyFiles += toUri(fileEvent.uri)
 				}
 			}
-			workspaceManager.doBuild(dirtyFiles, deletedFiles, cancelIndicator)
-			return null
+			workspaceManager.didChangeFiles(dirtyFiles, deletedFiles)
 		]
+		requestManager.runWrite(buildable)
 	}
 	
 	override didChangeConfiguration(DidChangeConfigurationParams params) {
-        requestManager.runWrite [ cancelIndicator |
-            workspaceManager.refreshWorkspaceConfig(cancelIndicator)
+		requestManager.cancel
+        requestManager.lockWrite [
+            workspaceManager.refreshWorkspaceConfig(CancelIndicator.NullImpl)
             return null
         ]
     }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/concurrent/RequestCancelIndicator.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/concurrent/RequestCancelIndicator.xtend
@@ -8,35 +8,32 @@
 package org.eclipse.xtext.ide.server.concurrent
 
 import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.jsonrpc.CancelChecker
-import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.eclipse.xtext.util.CancelIndicator
 
 /**
  * @author kosyakov - Initial contribution and API
  * @since 2.11
  */
-class RequestCancelIndicator implements CancelChecker, Cancellable {
+@FinalFieldsConstructor
+class RequestCancelIndicator implements CancelIndicator, CancelChecker, Cancellable {
 
-	@Accessors(PUBLIC_GETTER)
-	volatile boolean canceled
-	
-	CancelChecker delegate
-	
-	new () {}
-	new (CancelChecker delegate) {
-		this.delegate = delegate
-	}
+	val CompletableFuture<?> requestFuture
 
 	override cancel() {
-		canceled = true
+		requestFuture.cancel(true)
 	}
 	
-	override checkCanceled() {
-		if (delegate !== null) {
-			delegate.checkCanceled
-		}
-		if (canceled) {
-			throw new CancellationException("process canceled")
+	override isCanceled() {
+		checkCanceled
+		return false
+	}
+
+	override void checkCanceled() {
+		if (requestFuture.cancelled) {
+			throw new CancellationException()
 		}
 	}
 

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/concurrent/RequestManager.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/concurrent/RequestManager.xtend
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.ide.server.concurrent
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.google.inject.Inject
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
@@ -43,7 +44,9 @@ class RequestManager {
 	val final WRITE_PERMITS = MAX_PERMITS
 	val final READ_PERMITS = 1
 
-	val sequential = Executors.newSingleThreadExecutor
+	val sequential = Executors.newSingleThreadExecutor(
+		new ThreadFactoryBuilder().setDaemon(true).setNameFormat("RequestManager-Queue-%d").build
+	)
 	@Inject ExecutorService parallel
 
 	@Inject
@@ -56,6 +59,7 @@ class RequestManager {
 	def void shutdown() {
 		sequential.shutdown()
 		parallel.shutdown()
+		cancel()
 	}
 
 	def <V> V lockRead(()=>V request) {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/BuildManager.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/BuildManager.java
@@ -107,6 +107,10 @@ public class BuildManager {
     }
   }
   
+  public interface Buildable {
+    public abstract List<IResourceDescription.Delta> build(final CancelIndicator cancelIndicator);
+  }
+  
   public final static String CYCLIC_PROJECT_DEPENDENCIES = (BuildManager.class.getCanonicalName() + ".cyclicProjectDependencies");
   
   @Accessors(AccessorType.PUBLIC_SETTER)
@@ -119,10 +123,17 @@ public class BuildManager {
   
   private final LinkedHashSet<URI> deletedFiles = CollectionLiterals.<URI>newLinkedHashSet();
   
-  public List<IResourceDescription.Delta> doBuild(final List<URI> dirtyFiles, final List<URI> deletedFiles, final CancelIndicator cancelIndicator) {
+  public BuildManager.Buildable submit(final List<URI> dirtyFiles, final List<URI> deletedFiles) {
     this.queue(this.dirtyFiles, deletedFiles, dirtyFiles);
     this.queue(this.deletedFiles, dirtyFiles, deletedFiles);
-    return this.internalBuild(cancelIndicator);
+    final BuildManager.Buildable _function = (CancelIndicator cancelIndicator) -> {
+      return this.internalBuild(cancelIndicator);
+    };
+    return _function;
+  }
+  
+  public List<IResourceDescription.Delta> doBuild(final List<URI> dirtyFiles, final List<URI> deletedFiles, final CancelIndicator cancelIndicator) {
+    return this.submit(dirtyFiles, deletedFiles).build(cancelIndicator);
   }
   
   protected void queue(final Set<URI> files, final Collection<URI> toRemove, final Collection<URI> toAdd) {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/concurrent/RequestCancelIndicator.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/concurrent/RequestCancelIndicator.java
@@ -8,47 +8,42 @@
 package org.eclipse.xtext.ide.server.concurrent;
 
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
-import org.eclipse.xtend.lib.annotations.AccessorType;
-import org.eclipse.xtend.lib.annotations.Accessors;
+import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 import org.eclipse.xtext.ide.server.concurrent.Cancellable;
-import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.util.CancelIndicator;
 
 /**
  * @author kosyakov - Initial contribution and API
  * @since 2.11
  */
+@FinalFieldsConstructor
 @SuppressWarnings("all")
-public class RequestCancelIndicator implements CancelChecker, Cancellable {
-  @Accessors(AccessorType.PUBLIC_GETTER)
-  private volatile boolean canceled;
-  
-  private CancelChecker delegate;
-  
-  public RequestCancelIndicator() {
-  }
-  
-  public RequestCancelIndicator(final CancelChecker delegate) {
-    this.delegate = delegate;
-  }
+public class RequestCancelIndicator implements CancelIndicator, CancelChecker, Cancellable {
+  private final CompletableFuture<?> requestFuture;
   
   @Override
   public void cancel() {
-    this.canceled = true;
+    this.requestFuture.cancel(true);
+  }
+  
+  @Override
+  public boolean isCanceled() {
+    this.checkCanceled();
+    return false;
   }
   
   @Override
   public void checkCanceled() {
-    if ((this.delegate != null)) {
-      this.delegate.checkCanceled();
-    }
-    if (this.canceled) {
-      throw new CancellationException("process canceled");
+    boolean _isCancelled = this.requestFuture.isCancelled();
+    if (_isCancelled) {
+      throw new CancellationException();
     }
   }
   
-  @Pure
-  public boolean isCanceled() {
-    return this.canceled;
+  public RequestCancelIndicator(final CompletableFuture<?> requestFuture) {
+    super();
+    this.requestFuture = requestFuture;
   }
 }

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/concurrent/RequestManager.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/concurrent/RequestManager.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.xtext.ide.server.concurrent;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -52,7 +53,8 @@ public class RequestManager {
   
   private final int READ_PERMITS = 1;
   
-  private final ExecutorService sequential = Executors.newSingleThreadExecutor();
+  private final ExecutorService sequential = Executors.newSingleThreadExecutor(
+    new ThreadFactoryBuilder().setDaemon(true).setNameFormat("RequestManager-Queue-%d").build());
   
   @Inject
   private ExecutorService parallel;
@@ -67,6 +69,7 @@ public class RequestManager {
   public void shutdown() {
     this.sequential.shutdown();
     this.parallel.shutdown();
+    this.cancel();
   }
   
   public <V extends Object> V lockRead(final Function0<? extends V> request) {


### PR DESCRIPTION
I've split `didOpen`, `didChange`, `didClose` and `didChangeWatchedFiles` to 2 write requests:
- applying document changes - performed synchronously, cannot be canceled
- building - performed asynchronously, can be canceled

In that way, we preserve the order of document changes and don't lose them, and at the same time are able to cancel builds.

Read requests are handled as before, so they can be canceled only by the client but not by another request. I've tried to cancel them with write requests but it leads to unexpectedly canceled requests on the client side.

