### PR TITLE
safe retrieval of bundle in EEF

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.xtend
@@ -307,7 +307,7 @@ class XtextGenerator extends AbstractWorkflowComponent2 {
 	
 	protected def void generateActivator() {
 		if (projectConfig.eclipsePlugin.srcGen !== null && !languageConfigs.empty)
-			templates.createEclipsePluginActivator(languageConfigs).writeTo(projectConfig.eclipsePlugin.srcGen)
+			templates.createEclipsePluginActivator(projectConfig, languageConfigs).writeTo(projectConfig.eclipsePlugin.srcGen)
 	}
 	
 	protected def void generatePluginXmls() {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGenerator.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGenerator.java
@@ -409,7 +409,7 @@ public class XtextGenerator extends AbstractWorkflowComponent2 {
   
   protected void generateActivator() {
     if (((this.projectConfig.getEclipsePlugin().getSrcGen() != null) && (!this.languageConfigs.isEmpty()))) {
-      this.templates.createEclipsePluginActivator(this.languageConfigs).writeTo(this.projectConfig.getEclipsePlugin().getSrcGen());
+      this.templates.createEclipsePluginActivator(this.projectConfig, this.languageConfigs).writeTo(this.projectConfig.getEclipsePlugin().getSrcGen());
     }
   }
   

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
@@ -46,6 +46,7 @@ import org.eclipse.xtext.xtext.generator.model.JavaFileAccess;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
 import org.eclipse.xtext.xtext.generator.model.annotations.IClassAnnotation;
 import org.eclipse.xtext.xtext.generator.model.annotations.SuppressWarningsAnnotation;
+import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
 
 /**
  * Templates for generating the common language infrastructure.
@@ -1512,9 +1513,12 @@ public class XtextGeneratorTemplates {
         _builder.newLineIfNotEmpty();
         _builder.append("\t\t");
         _builder.append("return ");
+        TypeReference _typeRef_2 = TypeReference.typeRef("org.eclipse.core.runtime.Platform");
+        _builder.append(_typeRef_2, "\t\t");
+        _builder.append(".getBundle(");
         TypeReference _eclipsePluginActivator = XtextGeneratorTemplates.this.naming.getEclipsePluginActivator();
         _builder.append(_eclipsePluginActivator, "\t\t");
-        _builder.append(".getInstance().getBundle();");
+        _builder.append(".PLUGIN_ID);");
         _builder.newLineIfNotEmpty();
         _builder.append("\t");
         _builder.append("}");
@@ -1530,21 +1534,25 @@ public class XtextGeneratorTemplates {
         _builder.append(" getInjector() {");
         _builder.newLineIfNotEmpty();
         _builder.append("\t\t");
-        _builder.append("return ");
         TypeReference _eclipsePluginActivator_1 = XtextGeneratorTemplates.this.naming.getEclipsePluginActivator();
         _builder.append(_eclipsePluginActivator_1, "\t\t");
-        _builder.append(".getInstance().getInjector(");
+        _builder.append(" activator = ");
         TypeReference _eclipsePluginActivator_2 = XtextGeneratorTemplates.this.naming.getEclipsePluginActivator();
         _builder.append(_eclipsePluginActivator_2, "\t\t");
+        _builder.append(".getInstance();");
+        _builder.newLineIfNotEmpty();
+        _builder.append("\t\t");
+        _builder.append("return activator != null ? activator.getInjector(");
+        TypeReference _eclipsePluginActivator_3 = XtextGeneratorTemplates.this.naming.getEclipsePluginActivator();
+        _builder.append(_eclipsePluginActivator_3, "\t\t");
         _builder.append(".");
         String _replaceAll = langConfig.getGrammar().getName().toUpperCase().replaceAll("\\.", "_");
         _builder.append(_replaceAll, "\t\t");
-        _builder.append(");");
+        _builder.append(") : null;");
         _builder.newLineIfNotEmpty();
         _builder.append("\t");
         _builder.append("}");
         _builder.newLine();
-        _builder.append("\t");
         _builder.newLine();
         _builder.append("}");
         _builder.newLine();
@@ -1554,7 +1562,7 @@ public class XtextGeneratorTemplates {
     return file;
   }
   
-  public JavaFileAccess createEclipsePluginActivator(final List<? extends IXtextGeneratorLanguage> langConfigs) {
+  public JavaFileAccess createEclipsePluginActivator(final IXtextProjectConfig projectConfig, final List<? extends IXtextGeneratorLanguage> langConfigs) {
     final TypeReference activator = this.naming.getEclipsePluginActivator();
     final GeneratedJavaFileAccess file = this.fileAccessFactory.createGeneratedJavaFile(activator);
     StringConcatenationClient _client = new StringConcatenationClient() {
@@ -1586,6 +1594,12 @@ public class XtextGeneratorTemplates {
         _builder.append(" {");
         _builder.newLineIfNotEmpty();
         _builder.newLine();
+        _builder.append("\t");
+        _builder.append("public static final String PLUGIN_ID = \"");
+        String _name = projectConfig.getEclipsePlugin().getName();
+        _builder.append(_name, "\t");
+        _builder.append("\";");
+        _builder.newLineIfNotEmpty();
         {
           for(final IXtextGeneratorLanguage lang : langConfigs) {
             _builder.append("\t");
@@ -1593,8 +1607,8 @@ public class XtextGeneratorTemplates {
             String _replaceAll = lang.getGrammar().getName().toUpperCase().replaceAll("\\.", "_");
             _builder.append(_replaceAll, "\t");
             _builder.append(" = \"");
-            String _name = lang.getGrammar().getName();
-            _builder.append(_name, "\t");
+            String _name_1 = lang.getGrammar().getName();
+            _builder.append(_name_1, "\t");
             _builder.append("\";");
             _builder.newLineIfNotEmpty();
           }
@@ -1853,6 +1867,8 @@ public class XtextGeneratorTemplates {
         _builder.newLineIfNotEmpty();
         _builder.append("\t");
         _builder.append("}");
+        _builder.newLine();
+        _builder.append("\t");
         _builder.newLine();
         _builder.append("\t");
         _builder.newLine();


### PR DESCRIPTION
The EEF used to produce the following code:
```
public class MyDslExecutableExtensionFactory extends AbstractGuiceAwareExecutableExtensionFactory {

	@Override
	protected Bundle getBundle() {
		return MydslActivator.getInstance().getBundle();
	}
	
	@Override
	protected Injector getInjector() {
		return MydslActivator.getInstance().getInjector(MydslActivator.ORG_XTEXT_EXAMPLE_MYDSL_MYDSL);
	}
	
}
```

This raises a NPE when the activator was not started and hence getInstance() returns null. This can happen due to configuration issues and happens quite frequently.

This change will produce the following code:
```
	@Override
	protected Bundle getBundle() {
		return Platform.getBundle(MydslActivator.PLUGIN_ID);
	}
	
	@Override
	protected Injector getInjector() {
		MydslActivator activator = MydslActivator.getInstance();
		return activator != null ? activator.getInjector(MydslActivator.ORG_XTEXT_EXAMPLE_MYDSL_MYDSL) : null;
	}
```

Additionally the PLUGIN_ID constant is generated to the Activator class.

The proper handling of the null conditions will be done in a separate PR for AbstractGuiceAwareExecutableExtensionFactory.