### PR TITLE
Throw a response error when workspace is not initialized

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/ServerTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/ServerTest.xtend
@@ -8,8 +8,13 @@
 package org.eclipse.xtext.ide.tests.server
 
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams
+import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.FileChangeType
 import org.eclipse.lsp4j.FileEvent
+import org.eclipse.lsp4j.TextDocumentItem
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode
+import org.junit.Assert
 import org.junit.Test
 
 import static org.junit.Assert.*
@@ -67,6 +72,19 @@ class ServerTest extends AbstractTestLangLanguageServerTest {
     	assertTrue(diagnostics.values.join(','), diagnostics.values.forall[empty])
     }
     
-    
+    @Test
+    def void testMissingInitialize() {
+    	try {
+	    	languageServer.didOpen(new DidOpenTextDocumentParams => [
+				textDocument = new TextDocumentItem => [
+					uri = 'file:/home/test/workspace/mydoc.testlang'
+					text = 'type Foo {}'
+				]
+			])
+			Assert.fail("Expected a ResponseErrorException")
+		} catch (ResponseErrorException exception) {
+			Assert.assertEquals(ResponseErrorCode.serverNotInitialized.value, exception.responseError.code)
+		}
+    }
     
 }

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/ServerTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/ServerTest.java
@@ -11,14 +11,21 @@ import java.util.Collections;
 import java.util.List;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.FileChangeType;
 import org.eclipse.lsp4j.FileEvent;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.eclipse.lsp4j.services.WorkspaceService;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -94,5 +101,31 @@ public class ServerTest extends AbstractTestLangLanguageServerTest {
       return Boolean.valueOf(it.isEmpty());
     };
     Assert.assertTrue(IterableExtensions.join(this.getDiagnostics().values(), ","), IterableExtensions.<List<Diagnostic>>forall(this.getDiagnostics().values(), _function));
+  }
+  
+  @Test
+  public void testMissingInitialize() {
+    try {
+      DidOpenTextDocumentParams _didOpenTextDocumentParams = new DidOpenTextDocumentParams();
+      final Procedure1<DidOpenTextDocumentParams> _function = (DidOpenTextDocumentParams it) -> {
+        TextDocumentItem _textDocumentItem = new TextDocumentItem();
+        final Procedure1<TextDocumentItem> _function_1 = (TextDocumentItem it_1) -> {
+          it_1.setUri("file:/home/test/workspace/mydoc.testlang");
+          it_1.setText("type Foo {}");
+        };
+        TextDocumentItem _doubleArrow = ObjectExtensions.<TextDocumentItem>operator_doubleArrow(_textDocumentItem, _function_1);
+        it.setTextDocument(_doubleArrow);
+      };
+      DidOpenTextDocumentParams _doubleArrow = ObjectExtensions.<DidOpenTextDocumentParams>operator_doubleArrow(_didOpenTextDocumentParams, _function);
+      this.languageServer.didOpen(_doubleArrow);
+      Assert.fail("Expected a ResponseErrorException");
+    } catch (final Throwable _t) {
+      if (_t instanceof ResponseErrorException) {
+        final ResponseErrorException exception = (ResponseErrorException)_t;
+        Assert.assertEquals(ResponseErrorCode.serverNotInitialized.getValue(), exception.getResponseError().getCode());
+      } else {
+        throw Exceptions.sneakyThrow(_t);
+      }
+    }
   }
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/WorkspaceManager.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/WorkspaceManager.xtend
@@ -48,7 +48,7 @@ import org.eclipse.xtext.workspace.IWorkspaceConfig
 
     URI baseDir
     (URI, Iterable<Issue>)=>void issueAcceptor
-    IWorkspaceConfig workspaceConfig
+    IWorkspaceConfig _workspaceConfig
     
     List<IBuildListener> buildListeners = newArrayList
     
@@ -111,11 +111,15 @@ import org.eclipse.xtext.workspace.IWorkspaceConfig
     }
     
     protected def IWorkspaceConfig getWorkspaceConfig() {
-    	if (workspaceConfig === null) {
+    	if (_workspaceConfig === null) {
     		val error = new ResponseError(ResponseErrorCode.serverNotInitialized, "Workspace has not been initialized yet.", null)
     		throw new ResponseErrorException(error)
 		}
-		return workspaceConfig
+		return _workspaceConfig
+    }
+    
+    protected def void setWorkspaceConfig(IWorkspaceConfig workspaceConfig) {
+    	this._workspaceConfig = workspaceConfig
     }
 	
 	protected def void afterBuild(List<Delta> deltas) {
@@ -142,12 +146,12 @@ import org.eclipse.xtext.workspace.IWorkspaceConfig
     }
 
     def URI getProjectBaseDir(URI uri) {
-        val projectConfig = getWorkspaceConfig.findProjectContaining(uri)
+        val projectConfig = workspaceConfig.findProjectContaining(uri)
         return projectConfig?.path
     }
     
     def ProjectManager getProjectManager(URI uri) {
-        val projectConfig = getWorkspaceConfig.findProjectContaining(uri)
+        val projectConfig = workspaceConfig.findProjectContaining(uri)
         return projectName2ProjectManager.get(projectConfig?.name)
     }
     

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/WorkspaceManager.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/WorkspaceManager.xtend
@@ -87,7 +87,7 @@ import org.eclipse.xtext.workspace.IWorkspaceConfig
         refreshWorkspaceConfig(cancelIndicator)
     }
     
-    protected def refreshWorkspaceConfig(CancelIndicator cancelIndicator) {
+    protected def void refreshWorkspaceConfig(CancelIndicator cancelIndicator) {
         workspaceConfig = workspaceConfigFactory.getWorkspaceConfig(baseDir)
         val newProjects = newArrayList
         val Set<String> remainingProjectNames = new HashSet(projectName2ProjectManager.keySet)
@@ -110,14 +110,15 @@ import org.eclipse.xtext.workspace.IWorkspaceConfig
         afterBuild(result)
     }
     
-    protected def checkInitialized() {
+    protected def IWorkspaceConfig getWorkspaceConfig() {
     	if (workspaceConfig === null) {
     		val error = new ResponseError(ResponseErrorCode.serverNotInitialized, "Workspace has not been initialized yet.", null)
     		throw new ResponseErrorException(error)
 		}
+		return workspaceConfig
     }
 	
-	protected def afterBuild(List<Delta> deltas) {
+	protected def void afterBuild(List<Delta> deltas) {
 		for (listener : buildListeners) {
 			listener.afterBuild(deltas)
 		}
@@ -141,14 +142,12 @@ import org.eclipse.xtext.workspace.IWorkspaceConfig
     }
 
     def URI getProjectBaseDir(URI uri) {
-    	checkInitialized()
-        val projectConfig = workspaceConfig.findProjectContaining(uri)
+        val projectConfig = getWorkspaceConfig.findProjectContaining(uri)
         return projectConfig?.path
     }
     
     def ProjectManager getProjectManager(URI uri) {
-    	checkInitialized()
-        val projectConfig = workspaceConfig.findProjectContaining(uri)
+        val projectConfig = getWorkspaceConfig.findProjectContaining(uri)
         return projectName2ProjectManager.get(projectConfig?.name)
     }
     

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/WorkspaceManager.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/WorkspaceManager.java
@@ -21,6 +21,9 @@ import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.eclipse.xtext.ide.server.BuildManager;
 import org.eclipse.xtext.ide.server.Document;
 import org.eclipse.xtext.ide.server.ILanguageServerAccess;
@@ -145,6 +148,13 @@ public class WorkspaceManager {
     this.afterBuild(result);
   }
   
+  protected void checkInitialized() {
+    if ((this.workspaceConfig == null)) {
+      final ResponseError error = new ResponseError(ResponseErrorCode.serverNotInitialized, "Workspace has not been initialized yet.", null);
+      throw new ResponseErrorException(error);
+    }
+  }
+  
   protected void afterBuild(final List<IResourceDescription.Delta> deltas) {
     for (final ILanguageServerAccess.IBuildListener listener : this.buildListeners) {
       listener.afterBuild(deltas);
@@ -169,20 +179,18 @@ public class WorkspaceManager {
     return new ChunkedResourceDescriptions(this.fullIndex);
   }
   
-  public URI getProjectBaseDir(final URI candidate) {
-    URI _xblockexpression = null;
-    {
-      final IProjectConfig projectConfig = this.workspaceConfig.findProjectContaining(candidate);
-      URI _path = null;
-      if (projectConfig!=null) {
-        _path=projectConfig.getPath();
-      }
-      _xblockexpression = _path;
+  public URI getProjectBaseDir(final URI uri) {
+    this.checkInitialized();
+    final IProjectConfig projectConfig = this.workspaceConfig.findProjectContaining(uri);
+    URI _path = null;
+    if (projectConfig!=null) {
+      _path=projectConfig.getPath();
     }
-    return _xblockexpression;
+    return _path;
   }
   
   public ProjectManager getProjectManager(final URI uri) {
+    this.checkInitialized();
     final IProjectConfig projectConfig = this.workspaceConfig.findProjectContaining(uri);
     String _name = null;
     if (projectConfig!=null) {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/WorkspaceManager.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/WorkspaceManager.java
@@ -71,7 +71,7 @@ public class WorkspaceManager {
   
   private Procedure2<? super URI, ? super Iterable<Issue>> issueAcceptor;
   
-  private IWorkspaceConfig workspaceConfig;
+  private IWorkspaceConfig _workspaceConfig;
   
   private List<ILanguageServerAccess.IBuildListener> buildListeners = CollectionLiterals.<ILanguageServerAccess.IBuildListener>newArrayList();
   
@@ -118,7 +118,7 @@ public class WorkspaceManager {
   }
   
   protected void refreshWorkspaceConfig(final CancelIndicator cancelIndicator) {
-    this.workspaceConfig = this.workspaceConfigFactory.getWorkspaceConfig(this.baseDir);
+    this.setWorkspaceConfig(this.workspaceConfigFactory.getWorkspaceConfig(this.baseDir));
     final ArrayList<ProjectDescription> newProjects = CollectionLiterals.<ProjectDescription>newArrayList();
     Set<String> _keySet = this.projectName2ProjectManager.keySet();
     final Set<String> remainingProjectNames = new HashSet<String>(_keySet);
@@ -137,7 +137,7 @@ public class WorkspaceManager {
         newProjects.add(projectDescription);
       }
     };
-    this.workspaceConfig.getProjects().forEach(_function);
+    this.getWorkspaceConfig().getProjects().forEach(_function);
     for (final String deletedProject : remainingProjectNames) {
       {
         this.projectName2ProjectManager.remove(deletedProject);
@@ -149,11 +149,15 @@ public class WorkspaceManager {
   }
   
   protected IWorkspaceConfig getWorkspaceConfig() {
-    if ((this.workspaceConfig == null)) {
+    if ((this._workspaceConfig == null)) {
       final ResponseError error = new ResponseError(ResponseErrorCode.serverNotInitialized, "Workspace has not been initialized yet.", null);
       throw new ResponseErrorException(error);
     }
-    return this.workspaceConfig;
+    return this._workspaceConfig;
+  }
+  
+  protected void setWorkspaceConfig(final IWorkspaceConfig workspaceConfig) {
+    this._workspaceConfig = workspaceConfig;
   }
   
   protected void afterBuild(final List<IResourceDescription.Delta> deltas) {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/WorkspaceManager.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/WorkspaceManager.java
@@ -148,11 +148,12 @@ public class WorkspaceManager {
     this.afterBuild(result);
   }
   
-  protected void checkInitialized() {
+  protected IWorkspaceConfig getWorkspaceConfig() {
     if ((this.workspaceConfig == null)) {
       final ResponseError error = new ResponseError(ResponseErrorCode.serverNotInitialized, "Workspace has not been initialized yet.", null);
       throw new ResponseErrorException(error);
     }
+    return this.workspaceConfig;
   }
   
   protected void afterBuild(final List<IResourceDescription.Delta> deltas) {
@@ -180,8 +181,7 @@ public class WorkspaceManager {
   }
   
   public URI getProjectBaseDir(final URI uri) {
-    this.checkInitialized();
-    final IProjectConfig projectConfig = this.workspaceConfig.findProjectContaining(uri);
+    final IProjectConfig projectConfig = this.getWorkspaceConfig().findProjectContaining(uri);
     URI _path = null;
     if (projectConfig!=null) {
       _path=projectConfig.getPath();
@@ -190,8 +190,7 @@ public class WorkspaceManager {
   }
   
   public ProjectManager getProjectManager(final URI uri) {
-    this.checkInitialized();
-    final IProjectConfig projectConfig = this.workspaceConfig.findProjectContaining(uri);
+    final IProjectConfig projectConfig = this.getWorkspaceConfig().findProjectContaining(uri);
     String _name = null;
     if (projectConfig!=null) {
       _name=projectConfig.getName();


### PR DESCRIPTION
Fixes #378.

Also added missing `void` return types to some WorkspaceManager methods. This changes their signature, since previously `didOpen` and `didClose` returned the build result. However, `didChange` was already `void` before, so I assume the previous implicit return types were not on purpose.