### PR TITLE
fix #301: Improved support for IAutoWrapFormatter

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/FormattableDocumentTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/FormattableDocumentTest.xtend
@@ -127,6 +127,54 @@ class FormattableDocumentTest {
 			'''
 		]
 	}
+	
+	@Test def void autoWrapRewrite() {
+		assertFormatted[
+			preferences[
+				put(maxLineWidth, 10)
+			]
+			toBeFormatted = '''
+				kwlist  kw1  kw2
+			'''
+			formatter = [ KWList model, extension regions, extension document |
+				model.regionFor.keyword("kwlist").append [
+					autowrap;
+					onAutowrap = [ region, wrapped, extension doc |
+						model.regionFor.keyword("kw1").append[space = "!"]
+					]
+					model.regionFor.keyword("kw1").append[space = "@"; lowPriority]
+				]
+			]
+			expectation = '''
+				kwlist
+				kw1!kw2
+			'''
+		]
+	}
+	
+	@Test def void autoWrapInsert() {
+		assertFormatted[
+			preferences[
+				put(maxLineWidth, 10)
+			]
+			toBeFormatted = '''
+				kwlist  kw1  kw2
+			'''
+			formatter = [ KWList model, extension regions, extension document |
+				model.regionFor.keyword("kwlist").append [
+					autowrap;
+					onAutowrap = [ region, wrapped, extension doc |
+						model.regionFor.keyword("kw1").append[space = "!"]
+					]
+					model.regionFor.keyword("kw2").append[space = "@\n"]
+				]
+			]
+			expectation = '''
+				kwlist
+				kw1!kw2@
+			'''
+		]
+	}
 
 	@Test def void conditionalFormatting1() {
 		assertFormatted[
@@ -227,4 +275,6 @@ class FormattableDocumentTest {
 			expectation = '''idlist'''
 		]
 	}
+	
+	
 }

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/FormattableDocumentTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/FormattableDocumentTest.java
@@ -13,9 +13,11 @@ import java.util.function.Consumer;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.formatting2.FormatterPreferenceKeys;
+import org.eclipse.xtext.formatting2.IAutowrapFormatter;
 import org.eclipse.xtext.formatting2.IFormattableDocument;
 import org.eclipse.xtext.formatting2.IFormattableSubDocument;
 import org.eclipse.xtext.formatting2.IHiddenRegionFormatter;
+import org.eclipse.xtext.formatting2.IHiddenRegionFormatting;
 import org.eclipse.xtext.formatting2.ISubFormatter;
 import org.eclipse.xtext.formatting2.internal.GenericFormatter;
 import org.eclipse.xtext.formatting2.internal.GenericFormatterTestRequest;
@@ -26,6 +28,7 @@ import org.eclipse.xtext.formatting2.internal.services.FormatterTestLanguageGram
 import org.eclipse.xtext.formatting2.internal.tests.FormatterTestLanguageInjectorProvider;
 import org.eclipse.xtext.formatting2.regionaccess.ISemanticRegion;
 import org.eclipse.xtext.formatting2.regionaccess.ITextRegionExtensions;
+import org.eclipse.xtext.formatting2.regionaccess.ITextSegment;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
@@ -239,6 +242,91 @@ public class FormattableDocumentTest {
       _builder_1.append("kw1 kw2");
       _builder_1.newLine();
       _builder_1.append("kw3 kw4");
+      _builder_1.newLine();
+      it.setExpectation(_builder_1);
+    };
+    this._genericFormatterTester.assertFormatted(_function);
+  }
+  
+  @Test
+  public void autoWrapRewrite() {
+    final Procedure1<GenericFormatterTestRequest> _function = (GenericFormatterTestRequest it) -> {
+      final Procedure1<MapBasedPreferenceValues> _function_1 = (MapBasedPreferenceValues it_1) -> {
+        it_1.<Integer>put(FormatterPreferenceKeys.maxLineWidth, Integer.valueOf(10));
+      };
+      it.preferences(_function_1);
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("kwlist  kw1  kw2");
+      _builder.newLine();
+      it.setToBeFormatted(_builder);
+      final GenericFormatter<KWList> _function_2 = new GenericFormatter<KWList>() {
+        @Override
+        protected void format(final KWList model, @Extension final ITextRegionExtensions regions, @Extension final IFormattableDocument document) {
+          final Procedure1<IHiddenRegionFormatter> _function = (IHiddenRegionFormatter it_1) -> {
+            it_1.autowrap();
+            final IAutowrapFormatter _function_1 = (ITextSegment region, IHiddenRegionFormatting wrapped, IFormattableDocument doc) -> {
+              final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it_2) -> {
+                it_2.setSpace("!");
+              };
+              doc.append(regions.regionFor(model).keyword("kw1"), _function_2);
+            };
+            it_1.setOnAutowrap(_function_1);
+            final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it_2) -> {
+              it_2.setSpace("@");
+              it_2.lowPriority();
+            };
+            document.append(regions.regionFor(model).keyword("kw1"), _function_2);
+          };
+          document.append(regions.regionFor(model).keyword("kwlist"), _function);
+        }
+      };
+      it.setFormatter(_function_2);
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("kwlist");
+      _builder_1.newLine();
+      _builder_1.append("kw1!kw2");
+      _builder_1.newLine();
+      it.setExpectation(_builder_1);
+    };
+    this._genericFormatterTester.assertFormatted(_function);
+  }
+  
+  @Test
+  public void autoWrapInsert() {
+    final Procedure1<GenericFormatterTestRequest> _function = (GenericFormatterTestRequest it) -> {
+      final Procedure1<MapBasedPreferenceValues> _function_1 = (MapBasedPreferenceValues it_1) -> {
+        it_1.<Integer>put(FormatterPreferenceKeys.maxLineWidth, Integer.valueOf(10));
+      };
+      it.preferences(_function_1);
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("kwlist  kw1  kw2");
+      _builder.newLine();
+      it.setToBeFormatted(_builder);
+      final GenericFormatter<KWList> _function_2 = new GenericFormatter<KWList>() {
+        @Override
+        protected void format(final KWList model, @Extension final ITextRegionExtensions regions, @Extension final IFormattableDocument document) {
+          final Procedure1<IHiddenRegionFormatter> _function = (IHiddenRegionFormatter it_1) -> {
+            it_1.autowrap();
+            final IAutowrapFormatter _function_1 = (ITextSegment region, IHiddenRegionFormatting wrapped, IFormattableDocument doc) -> {
+              final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it_2) -> {
+                it_2.setSpace("!");
+              };
+              doc.append(regions.regionFor(model).keyword("kw1"), _function_2);
+            };
+            it_1.setOnAutowrap(_function_1);
+            final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it_2) -> {
+              it_2.setSpace("@\n");
+            };
+            document.append(regions.regionFor(model).keyword("kw2"), _function_2);
+          };
+          document.append(regions.regionFor(model).keyword("kwlist"), _function);
+        }
+      };
+      it.setFormatter(_function_2);
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("kwlist");
+      _builder_1.newLine();
+      _builder_1.append("kw1!kw2@");
       _builder_1.newLine();
       it.setExpectation(_builder_1);
     };

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/ArrayListTextSegmentSet.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/ArrayListTextSegmentSet.java
@@ -16,6 +16,7 @@ import org.eclipse.xtext.formatting2.regionaccess.ITextSegment;
 
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -118,6 +119,24 @@ public class ArrayListTextSegmentSet<T> extends TextSegmentSet<T> {
 	@Override
 	public Iterator<T> iterator() {
 		return Iterables.unmodifiableIterable(contents).iterator();
+	}
+
+	@Override
+	public Iterator<T> iteratorAfter(T segment) {
+		int searchResult = 1 + Collections.binarySearch(contents, segment, new RegionComparator<T>(getRegionAccess()));
+		if (searchResult < 1) {
+			return Collections.emptyIterator();
+		}
+		return new AbstractIterator<T>() {
+			private int index = searchResult;
+
+			@Override
+			protected T computeNext() {
+				if (index >= contents.size())
+					return endOfData();
+				return contents.get(index++);
+			}
+		};
 	}
 
 	protected void replaceExistingEntry(T segment, int index, IMerger<T> merger)

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/FormattableDocument.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/FormattableDocument.java
@@ -9,7 +9,7 @@ package org.eclipse.xtext.formatting2.internal;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -125,13 +125,9 @@ public abstract class FormattableDocument implements IFormattableDocument {
 		ITextReplacerContext context = previous.withDocument(this);
 		ITextReplacerContext wrappable = null;
 		Set<ITextReplacer> wrapped = Sets.newHashSet();
-		LinkedList<ITextReplacer> queue = new LinkedList<ITextReplacer>();
-		TextSegmentSet<ITextReplacer> replacers = getReplacers();
-		for (ITextReplacer replacer : replacers) {
-			queue.add(replacer);
-		}
-		while (!queue.isEmpty()) {
-			ITextReplacer replacer = queue.poll();
+		Iterator<ITextReplacer> replacers = getReplacers().iterator();
+		while (replacers.hasNext()) {
+			ITextReplacer replacer = replacers.next();
 			context = context.withReplacer(replacer);
 			if (wrappable != null && context.isWrapSincePrevious()) {
 				wrappable = null;
@@ -140,20 +136,10 @@ public abstract class FormattableDocument implements IFormattableDocument {
 				// TODO: raise report if replacer claims it can do autowrap but
 				// then doesn't
 				while (context != wrappable) {
-					ITextReplacer r = context.getReplacer();
-					if (r != null) {
-						ITextReplacer r2 = replacers.get(r);
-						if (r2 instanceof ICompositeTextReplacer) {
-							if (r == r2) {
-								queue.addFirst(r2);
-							}
-						} else if (r2 != null) {
-							queue.addFirst(r2);
-						}
-					}
 					context = context.getPreviousContext();
 				}
 				replacer = context.getReplacer();
+				replacers = getReplacers().iteratorAfter(replacer);
 				context.setAutowrap(true);
 				wrappable = null;
 			}
@@ -233,7 +219,7 @@ public abstract class FormattableDocument implements IFormattableDocument {
 	}
 
 	@Override
-	public <T1 extends ISemanticRegion, T2 extends ISemanticRegion> // 
+	public <T1 extends ISemanticRegion, T2 extends ISemanticRegion> //
 	Pair<T1, T2> interior(Pair<T1, T2> pair, Procedure1<? super IHiddenRegionFormatter> init) {
 		return interior(pair.getKey(), pair.getValue(), init);
 	}
@@ -254,7 +240,7 @@ public abstract class FormattableDocument implements IFormattableDocument {
 	}
 
 	@Override
-	public <T1 extends ISemanticRegion, T2 extends ISemanticRegion> // 
+	public <T1 extends ISemanticRegion, T2 extends ISemanticRegion> //
 	Pair<T1, T2> interior(T1 first, T2 second, Procedure1<? super IHiddenRegionFormatter> init) {
 		if (first != null && second != null) {
 			set(first.getNextHiddenRegion(), second.getPreviousHiddenRegion(), init);
@@ -269,13 +255,14 @@ public abstract class FormattableDocument implements IFormattableDocument {
 		int length = context.getReplacer().getRegion().getEndOffset() - offset;
 		if (length > wrappable.canAutowrap())
 			return false;
-		//		for (ITextReplacement rep : context.getReplacementsUntil(wrappable))
-		//			if (rep.getReplacementText().contains("\n"))
-		//				return true;
-		//		TextSegment region = new TextSegment(getTextRegionAccess(), offset, length);
-		//		String text = TextReplacements.apply(region, );
-		//		if (text.contains("\n"))
-		//			return true;
+		// for (ITextReplacement rep : context.getReplacementsUntil(wrappable))
+		// if (rep.getReplacementText().contains("\n"))
+		// return true;
+		// TextSegment region = new TextSegment(getTextRegionAccess(), offset,
+		// length);
+		// String text = TextReplacements.apply(region, );
+		// if (text.contains("\n"))
+		// return true;
 		return false;
 	}
 
@@ -350,7 +337,7 @@ public abstract class FormattableDocument implements IFormattableDocument {
 	public <T extends EObject> T surround(T owner, Procedure1<? super IHiddenRegionFormatter> beforeAndAfter) {
 		if (owner != null && !owner.eIsProxy()) {
 			IEObjectRegion region = getTextRegionAccess().regionForEObject(owner);
-			if (region == null) 
+			if (region == null)
 				return owner;
 			IHiddenRegion previous = region.getPreviousHiddenRegion();
 			IHiddenRegion next = region.getNextHiddenRegion();

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/TextSegmentSet.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/TextSegmentSet.java
@@ -8,6 +8,7 @@
 package org.eclipse.xtext.formatting2.internal;
 
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.xtext.formatting2.IMerger;
@@ -43,7 +44,7 @@ public abstract class TextSegmentSet<T> implements Iterable<T> {
 	}
 
 	public abstract void add(T segment, IMerger<T> merger) throws ConflictingRegionsException;
-	
+
 	public abstract T get(T segment);
 
 	protected ITextSegment getRegion(T t) {
@@ -61,12 +62,6 @@ public abstract class TextSegmentSet<T> implements Iterable<T> {
 	@Deprecated
 	public IdentityHashMap<T, RegionTrace> getTraces() {
 		return traces;
-	}
-
-	protected void trace(T segment) {
-		if (traces != null) {
-			traces.put(segment, new RegionTrace(getTitle(segment), getRegion(segment)));
-		}
 	}
 
 	protected void handleConflict(List<T> conflicts, Exception cause)
@@ -100,6 +95,8 @@ public abstract class TextSegmentSet<T> implements Iterable<T> {
 		return isConflict(getRegion(t1), getRegion(t2));
 	}
 
+	public abstract Iterator<T> iteratorAfter(T segment);
+
 	@Override
 	public String toString() {
 		TextRegionsToString toString = new TextRegionsToString();
@@ -107,5 +104,11 @@ public abstract class TextSegmentSet<T> implements Iterable<T> {
 		for (T t : this)
 			toString.add(getRegion(t), getTitle(t));
 		return toString.toString();
+	}
+
+	protected void trace(T segment) {
+		if (traces != null) {
+			traces.put(segment, new RegionTrace(getTitle(segment), getRegion(segment)));
+		}
 	}
 }


### PR DESCRIPTION
The previous fix 
https://github.com/eclipse/xtext-core/commit/906be319a46dc8d8d7e2e03a9a90e3b7e5afb494
dind't handle insertion of new ITextReplacers

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>