### PR TITLE
refreshWorkspaceConfig - Fixed initialization of remainingProjectNames

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/WorkspaceManager.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/WorkspaceManager.xtend
@@ -10,10 +10,13 @@ package org.eclipse.xtext.ide.server
 import com.google.inject.Inject
 import com.google.inject.Provider
 import java.util.ArrayList
+import java.util.HashSet
 import java.util.List
 import java.util.Map
+import java.util.Set
 import org.eclipse.emf.common.util.URI
 import org.eclipse.lsp4j.TextEdit
+import org.eclipse.xtext.ide.server.BuildManager.Buildable
 import org.eclipse.xtext.ide.server.ILanguageServerAccess.IBuildListener
 import org.eclipse.xtext.resource.IExternalContentSupport.IExternalContentProvider
 import org.eclipse.xtext.resource.IResourceDescription
@@ -26,7 +29,6 @@ import org.eclipse.xtext.util.CancelIndicator
 import org.eclipse.xtext.util.internal.Log
 import org.eclipse.xtext.validation.Issue
 import org.eclipse.xtext.workspace.IWorkspaceConfig
-import org.eclipse.xtext.ide.server.BuildManager.Buildable
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -85,7 +87,7 @@ import org.eclipse.xtext.ide.server.BuildManager.Buildable
     protected def refreshWorkspaceConfig(CancelIndicator cancelIndicator) {
         workspaceConfig = workspaceConfigFactory.getWorkspaceConfig(baseDir)
         val newProjects = newArrayList
-        val remainingProjectNames = newHashSet(projectName2ProjectManager.keySet)
+        val Set<String> remainingProjectNames = new HashSet(projectName2ProjectManager.keySet)
         workspaceConfig.projects.forEach [ projectConfig | 
             if(projectName2ProjectManager.containsKey(projectConfig.name)) {
                 remainingProjectNames.remove(projectConfig.name)
@@ -182,7 +184,10 @@ import org.eclipse.xtext.ide.server.BuildManager.Buildable
     }
     
     protected def boolean exists(URI uri) {
-        getProjectManager(uri)?.resourceSet.URIConverter.exists(uri, null)
+        val rs = getProjectManager(uri)?.resourceSet
+        if (rs === null)
+           return false
+        return rs.URIConverter.exists(uri, null)
     }
     
     def <T> T doRead(URI uri, (Document, XtextResource)=>T work) {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/WorkspaceManager.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/WorkspaceManager.java
@@ -117,7 +117,8 @@ public class WorkspaceManager {
   protected void refreshWorkspaceConfig(final CancelIndicator cancelIndicator) {
     this.workspaceConfig = this.workspaceConfigFactory.getWorkspaceConfig(this.baseDir);
     final ArrayList<ProjectDescription> newProjects = CollectionLiterals.<ProjectDescription>newArrayList();
-    final HashSet<Set<String>> remainingProjectNames = CollectionLiterals.<Set<String>>newHashSet(this.projectName2ProjectManager.keySet());
+    Set<String> _keySet = this.projectName2ProjectManager.keySet();
+    final Set<String> remainingProjectNames = new HashSet<String>(_keySet);
     final Consumer<IProjectConfig> _function = (IProjectConfig projectConfig) -> {
       boolean _containsKey = this.projectName2ProjectManager.containsKey(projectConfig.getName());
       if (_containsKey) {
@@ -134,7 +135,7 @@ public class WorkspaceManager {
       }
     };
     this.workspaceConfig.getProjects().forEach(_function);
-    for (final Set<String> deletedProject : remainingProjectNames) {
+    for (final String deletedProject : remainingProjectNames) {
       {
         this.projectName2ProjectManager.remove(deletedProject);
         this.fullIndex.remove(deletedProject);
@@ -247,7 +248,11 @@ public class WorkspaceManager {
     if (_projectManager!=null) {
       _resourceSet=_projectManager.getResourceSet();
     }
-    return _resourceSet.getURIConverter().exists(uri, null);
+    final XtextResourceSet rs = _resourceSet;
+    if ((rs == null)) {
+      return false;
+    }
+    return rs.getURIConverter().exists(uri, null);
   }
   
   public <T extends Object> T doRead(final URI uri, final Function2<? super Document, ? super XtextResource, ? extends T> work) {


### PR DESCRIPTION
It is wrong to initialize the remainingProjectNames with the newHashSet
function since it has the side effect that it will put the keySet as
whole as single entry to the new map instead of putting its values in
the map.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>