### PR TITLE
Added null guard for result of listFiles

### DIFF
--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/IFileSystemScanner.xtend
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/IFileSystemScanner.xtend
@@ -36,8 +36,11 @@ interface IFileSystemScanner {
             val uri = URI.createURI(path.toUri.toString)
             acceptor.accept(uri)
             if (file.isDirectory) {
-                for (f : file.listFiles) {
-                    scanRec(f, acceptor)
+                val files = file.listFiles
+                if (files !== null) {
+                    for (f : files) {
+                        scanRec(f, acceptor)
+                    }
                 }
             }
         }

--- a/org.eclipse.xtext.util/xtend-gen/org/eclipse/xtext/util/IFileSystemScanner.java
+++ b/org.eclipse.xtext.util/xtend-gen/org/eclipse/xtext/util/IFileSystemScanner.java
@@ -35,9 +35,11 @@ public interface IFileSystemScanner {
       acceptor.accept(uri);
       boolean _isDirectory = file.isDirectory();
       if (_isDirectory) {
-        File[] _listFiles = file.listFiles();
-        for (final File f : _listFiles) {
-          this.scanRec(f, acceptor);
+        final File[] files = file.listFiles();
+        if ((files != null)) {
+          for (final File f : files) {
+            this.scanRec(f, acceptor);
+          }
         }
       }
     }


### PR DESCRIPTION
According to contract of File.listFiles() the result can be null if an
I/O error occurred.
