### PR TITLE
Throw an IllegalStateException if a language server extension tries to read a file before the server is initialized

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/LspExtensionTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/LspExtensionTest.xtend
@@ -7,14 +7,17 @@
  *******************************************************************************/
 package org.eclipse.xtext.ide.tests.server
 
+import java.lang.reflect.InvocationTargetException
 import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.TextDocumentItem
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode
 import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints
 import org.eclipse.xtext.ide.tests.testlanguage.ide.TestLangLSPExtension
+import org.eclipse.xtext.ide.tests.testlanguage.ide.TestLangLSPExtension.BuildNotification
 import org.eclipse.xtext.ide.tests.testlanguage.ide.TestLangLSPExtension.TextOfLineParam
 import org.junit.Assert
 import org.junit.Test
-import org.eclipse.xtext.ide.tests.testlanguage.ide.TestLangLSPExtension.BuildNotification
 
 /**
  * @author efftinge - Initial contribution and API
@@ -41,6 +44,26 @@ class LspExtensionTest extends AbstractTestLangLanguageServerTest {
 		]).get
 		Assert.assertEquals("baz test", result.text)
 		Assert.assertEquals(2, notifications.map[value].filter(BuildNotification).size)
+	}
+	
+	@Test def void testMissingInitialize() {
+		try {
+			val fileURI = "mydoc.testlang".writeFile("")
+			val ext = ServiceEndpoints.toServiceObject(languageServer, TestLangLSPExtension)
+			ext.getTextOfLine(new TextOfLineParam => [
+				uri = fileURI
+				line = 1
+			]).get
+			Assert.fail("Expected an exception")
+		} catch (Exception exception) {
+			var Throwable t = exception
+			while (t instanceof InvocationTargetException || t.class == RuntimeException) {
+				t = t.cause
+			}
+			Assert.assertTrue(t instanceof IllegalStateException)
+			Assert.assertTrue(t.cause instanceof ResponseErrorException)
+			Assert.assertEquals(ResponseErrorCode.serverNotInitialized.value, (t.cause as ResponseErrorException).responseError.code)
+		}
 	}
 	
 }

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/LspExtensionTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/LspExtensionTest.java
@@ -7,9 +7,13 @@
  */
 package org.eclipse.xtext.ide.tests.server;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
+import java.lang.reflect.InvocationTargetException;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
@@ -69,6 +73,37 @@ public class LspExtensionTest extends AbstractTestLangLanguageServerTest {
       Assert.assertEquals(2, IterableExtensions.size(Iterables.<TestLangLSPExtension.BuildNotification>filter(ListExtensions.<Pair<String, Object>, Object>map(this.notifications, _function_2), TestLangLSPExtension.BuildNotification.class)));
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testMissingInitialize() {
+    try {
+      final String fileURI = this.writeFile("mydoc.testlang", "");
+      final TestLangLSPExtension ext = ServiceEndpoints.<TestLangLSPExtension>toServiceObject(this.languageServer, TestLangLSPExtension.class);
+      TestLangLSPExtension.TextOfLineParam _textOfLineParam = new TestLangLSPExtension.TextOfLineParam();
+      final Procedure1<TestLangLSPExtension.TextOfLineParam> _function = (TestLangLSPExtension.TextOfLineParam it) -> {
+        it.uri = fileURI;
+        it.line = 1;
+      };
+      TestLangLSPExtension.TextOfLineParam _doubleArrow = ObjectExtensions.<TestLangLSPExtension.TextOfLineParam>operator_doubleArrow(_textOfLineParam, _function);
+      ext.getTextOfLine(_doubleArrow).get();
+      Assert.fail("Expected an exception");
+    } catch (final Throwable _t) {
+      if (_t instanceof Exception) {
+        final Exception exception = (Exception)_t;
+        Throwable t = exception;
+        while (((t instanceof InvocationTargetException) || Objects.equal(t.getClass(), RuntimeException.class))) {
+          t = t.getCause();
+        }
+        Assert.assertTrue((t instanceof IllegalStateException));
+        Throwable _cause = t.getCause();
+        Assert.assertTrue((_cause instanceof ResponseErrorException));
+        Throwable _cause_1 = t.getCause();
+        Assert.assertEquals(ResponseErrorCode.serverNotInitialized.getValue(), ((ResponseErrorException) _cause_1).getResponseError().getCode());
+      } else {
+        throw Exceptions.sneakyThrow(_t);
+      }
     }
   }
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ILanguageServerAccess.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ILanguageServerAccess.xtend
@@ -33,7 +33,9 @@ interface ILanguageServerAccess {
 	}
 
 	/**
-	 * provides read access to a fully resolved resource and Document.
+	 * Provides read access to a fully resolved resource and Document.
+	 * 
+	 * @throws IllegalStateException if the language server is not initialized yet
 	 */
 	def <T> CompletableFuture<T> doRead(String uri, Function<Context, T> function)
 	
@@ -42,12 +44,12 @@ interface ILanguageServerAccess {
 	}
 
 	/**
-	 * registers a build listener on the this language server
+	 * Registers a build listener on the this language server.
 	 */
 	def void addBuildListener(IBuildListener listener)
 	
 	/**
-	 * returns the language client facade. It usually also implements Endpoint, which can be used to
+	 * Returns the language client facade. It usually also implements Endpoint, which can be used to
 	 * call non-standard extensions to the LSP.
 	 */
 	def LanguageClient getLanguageClient();

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/ILanguageServerAccess.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/ILanguageServerAccess.java
@@ -123,17 +123,19 @@ public interface ILanguageServerAccess {
   }
   
   /**
-   * provides read access to a fully resolved resource and Document.
+   * Provides read access to a fully resolved resource and Document.
+   * 
+   * @throws IllegalStateException if the language server is not initialized yet
    */
   public abstract <T extends Object> CompletableFuture<T> doRead(final String uri, final Function<ILanguageServerAccess.Context, T> function);
   
   /**
-   * registers a build listener on the this language server
+   * Registers a build listener on the this language server.
    */
   public abstract void addBuildListener(final ILanguageServerAccess.IBuildListener listener);
   
   /**
-   * returns the language client facade. It usually also implements Endpoint, which can be used to
+   * Returns the language client facade. It usually also implements Endpoint, which can be used to
    * call non-standard extensions to the LSP.
    */
   public abstract LanguageClient getLanguageClient();

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/LanguageServerImpl.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/LanguageServerImpl.java
@@ -69,9 +69,11 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.jsonrpc.Endpoint;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod;
 import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethodProvider;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
@@ -775,15 +777,34 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
   private ILanguageServerAccess access = new ILanguageServerAccess() {
     @Override
     public <T extends Object> CompletableFuture<T> doRead(final String uri, final Function<ILanguageServerAccess.Context, T> function) {
-      final Function1<CancelIndicator, T> _function = (CancelIndicator cancelIndicator) -> {
-        final Function2<Document, XtextResource, T> _function_1 = (Document document, XtextResource resource) -> {
-          boolean _isDocumentOpen = LanguageServerImpl.this.workspaceManager.isDocumentOpen(resource.getURI());
-          final ILanguageServerAccess.Context ctx = new ILanguageServerAccess.Context(resource, document, _isDocumentOpen, cancelIndicator);
-          return function.apply(ctx);
+      CompletableFuture<T> _xtrycatchfinallyexpression = null;
+      try {
+        final Function1<CancelIndicator, T> _function = (CancelIndicator cancelIndicator) -> {
+          final Function2<Document, XtextResource, T> _function_1 = (Document document, XtextResource resource) -> {
+            boolean _isDocumentOpen = LanguageServerImpl.this.workspaceManager.isDocumentOpen(resource.getURI());
+            final ILanguageServerAccess.Context ctx = new ILanguageServerAccess.Context(resource, document, _isDocumentOpen, cancelIndicator);
+            return function.apply(ctx);
+          };
+          return LanguageServerImpl.this.workspaceManager.<T>doRead(LanguageServerImpl.this._uriExtensions.toUri(uri), _function_1);
         };
-        return LanguageServerImpl.this.workspaceManager.<T>doRead(LanguageServerImpl.this._uriExtensions.toUri(uri), _function_1);
-      };
-      return LanguageServerImpl.this.requestManager.<T>runRead(_function);
+        _xtrycatchfinallyexpression = LanguageServerImpl.this.requestManager.<T>runRead(_function);
+      } catch (final Throwable _t) {
+        if (_t instanceof ResponseErrorException) {
+          final ResponseErrorException exception = (ResponseErrorException)_t;
+          int _code = exception.getResponseError().getCode();
+          boolean _matched = false;
+          int _value = ResponseErrorCode.serverNotInitialized.getValue();
+          if (Objects.equal(_code, _value)) {
+            _matched=true;
+            String _message = exception.getMessage();
+            throw new IllegalStateException(_message, exception);
+          }
+          throw exception;
+        } else {
+          throw Exceptions.sneakyThrow(_t);
+        }
+      }
+      return _xtrycatchfinallyexpression;
     }
     
     @Override


### PR DESCRIPTION
The fix for #378 leads to a ResponseErrorException when the workspace is accessed before it is initialized. This is ok for client requests, but for local accesses an IllegalStateException is more appropriate. This PR translates the exception accordingly.