### PR TITLE
Decode file URL

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/UriExtensions.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/UriExtensions.xtend
@@ -11,6 +11,8 @@ import com.google.inject.Singleton
 import java.nio.file.FileSystemNotFoundException
 import java.nio.file.Paths
 import org.eclipse.emf.common.util.URI
+import java.net.URLDecoder
+import java.io.File
 
 /**
  * @author kosyakov - Initial contribution and API
@@ -31,8 +33,8 @@ class UriExtensions {
 
 	def String toPath(java.net.URI uri) {
 		try {
-			val path = Paths.get(uri)
-			return path.toUri.toString
+			val path = Paths.get(uri.path)
+			return URLDecoder.decode(path.toUri.toString, "UTF-8");
 		} catch (FileSystemNotFoundException e) {
 			return uri.toString
 		}

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/UriExtensions.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/UriExtensions.java
@@ -8,6 +8,7 @@
 package org.eclipse.xtext.ide.server;
 
 import com.google.inject.Singleton;
+import java.net.URLDecoder;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,15 +34,19 @@ public class UriExtensions {
   
   public String toPath(final java.net.URI uri) {
     try {
-      final Path path = Paths.get(uri);
-      return path.toUri().toString();
-    } catch (final Throwable _t) {
-      if (_t instanceof FileSystemNotFoundException) {
-        final FileSystemNotFoundException e = (FileSystemNotFoundException)_t;
-        return uri.toString();
-      } else {
-        throw Exceptions.sneakyThrow(_t);
+      try {
+        final Path path = Paths.get(uri.getPath());
+        return URLDecoder.decode(path.toUri().toString(), "UTF-8");
+      } catch (final Throwable _t) {
+        if (_t instanceof FileSystemNotFoundException) {
+          final FileSystemNotFoundException e = (FileSystemNotFoundException)_t;
+          return uri.toString();
+        } else {
+          throw Exceptions.sneakyThrow(_t);
+        }
       }
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
     }
   }
 }


### PR DESCRIPTION
Decodes URL-encoded file paths.
Original implementation fails on Linux when LSP request contains Cyrillic characters in file name.