### PR TITLE
Decode file URL

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.xtend
@@ -7,43 +7,51 @@
  *******************************************************************************/
 package org.eclipse.xtext.ide.tests.server
 
+import javax.inject.Inject
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.ide.server.UriExtensions
+import org.eclipse.xtext.ide.tests.testlanguage.TestLanguageIdeInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
 import org.junit.Test
+import org.junit.runner.RunWith
 
 import static org.junit.Assert.*
+import java.io.File
 
-class UriExtensionsTest extends AbstractTestLangLanguageServerTest {
+@RunWith(XtextRunner)
+@InjectWith(TestLanguageIdeInjectorProvider)
+class UriExtensionsTest {
+
+	@Inject
+	extension UriExtensions;
+
 	@Test
-	def void testFilesWithSpaces() {
-		initialize
-
-		val fileURI = 'Foo Bar.testlang'.virtualFile
-		fileURI.open('''
-			type FooBar {
-			}
-		''')
-
-		diagnostics.get(fileURI).forEach [
-			println("err: " + it.message)
-		]
-
-		assertTrue(diagnostics.get(fileURI).empty)
+	def void testConversion() {
+		assertEquals("file:///dir/name.ext", "file:///dir/name.ext".toUri.toPath)
 	}
 
 	@Test
-	def void testFilesWithCyrillic() {
-		initialize
+	def void testFileUriConversion() {
+		assertEquals("file:///dir/name.ext", URI.createFileURI("/dir/name.ext").toPath)
+	}
 
-		val fileURI = "\u0424\u0443 \u0411\u0430\u0440.testlang".virtualFile
-		fileURI.open('''
-			type FooBar {
-			}
-		''')
+	@Test
+	def void testFilesWithSpaces() {
+		assertEquals("file:///dir/Foo Bar.testlang", "file:///dir/Foo Bar.testlang".toUri.toPath)
+	}
 
-		diagnostics.get(fileURI).forEach [
-			println("err: " + it.message)
-		]
+	@Test
+	def void testFilesWithCyrillicSymbols() {
+		assertEquals("file:///dir/\u0424\u0443 \u0411\u0430\u0440.testlang",
+			"file:///dir/\u0424\u0443 \u0411\u0430\u0440.testlang".toUri.toPath)
+	}
 
-		assertTrue(diagnostics.get(fileURI).empty)
+	@Test
+	def void testFolderIsPrefix() {
+		var directory = new File("./test-data/test-project")
+		var uri = URI.createFileURI(directory.absolutePath).toPath.toUri
+		assertTrue(uri.isPrefix)
 	}
 }
 

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.xtend
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.server
+
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+class UriExtensionsTest extends AbstractTestLangLanguageServerTest {
+	@Test
+	def void testFilesWithSpaces() {
+		initialize
+
+		val fileURI = 'Foo Bar.testlang'.virtualFile
+		fileURI.open('''
+			type FooBar {
+			}
+		''')
+
+		diagnostics.get(fileURI).forEach [
+			println("err: " + it.message)
+		]
+
+		assertTrue(diagnostics.get(fileURI).empty)
+	}
+
+	@Test
+	def void testFilesWithCyrillic() {
+		initialize
+
+		val fileURI = "\u0424\u0443 \u0411\u0430\u0440.testlang".virtualFile
+		fileURI.open('''
+			type FooBar {
+			}
+		''')
+
+		diagnostics.get(fileURI).forEach [
+			println("err: " + it.message)
+		]
+
+		assertTrue(diagnostics.get(fileURI).empty)
+	}
+}
+

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.tests.server;
+
+import java.util.function.Consumer;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
+import org.eclipse.xtext.xbase.lib.InputOutput;
+import org.junit.Assert;
+import org.junit.Test;
+
+@SuppressWarnings("all")
+public class UriExtensionsTest extends AbstractTestLangLanguageServerTest {
+  @Test
+  public void testFilesWithSpaces() {
+    this.initialize();
+    final String fileURI = this.getVirtualFile("Foo Bar.testlang");
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("type FooBar {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.open(fileURI, _builder.toString());
+    final Consumer<Diagnostic> _function = (Diagnostic it) -> {
+      String _message = it.getMessage();
+      String _plus = ("err: " + _message);
+      InputOutput.<String>println(_plus);
+    };
+    this.getDiagnostics().get(fileURI).forEach(_function);
+    Assert.assertTrue(this.getDiagnostics().get(fileURI).isEmpty());
+  }
+  
+  @Test
+  public void testFilesWithCyrillic() {
+    this.initialize();
+    final String fileURI = this.getVirtualFile("\u0424\u0443 \u0411\u0430\u0440.testlang");
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("type FooBar {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.open(fileURI, _builder.toString());
+    final Consumer<Diagnostic> _function = (Diagnostic it) -> {
+      String _message = it.getMessage();
+      String _plus = ("err: " + _message);
+      InputOutput.<String>println(_plus);
+    };
+    this.getDiagnostics().get(fileURI).forEach(_function);
+    Assert.assertTrue(this.getDiagnostics().get(fileURI).isEmpty());
+  }
+}
+

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.java
@@ -7,52 +7,52 @@
  */
 package org.eclipse.xtext.ide.tests.server;
 
-import java.util.function.Consumer;
-import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.xtend2.lib.StringConcatenation;
-import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
-import org.eclipse.xtext.xbase.lib.InputOutput;
+import java.io.File;
+import javax.inject.Inject;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtext.ide.server.UriExtensions;
+import org.eclipse.xtext.ide.tests.testlanguage.TestLanguageIdeInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.xbase.lib.Extension;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(XtextRunner.class)
+@InjectWith(TestLanguageIdeInjectorProvider.class)
 @SuppressWarnings("all")
-public class UriExtensionsTest extends AbstractTestLangLanguageServerTest {
+public class UriExtensionsTest {
+  @Inject
+  @Extension
+  private UriExtensions _uriExtensions;
+  
   @Test
-  public void testFilesWithSpaces() {
-    this.initialize();
-    final String fileURI = this.getVirtualFile("Foo Bar.testlang");
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("type FooBar {");
-    _builder.newLine();
-    _builder.append("}");
-    _builder.newLine();
-    this.open(fileURI, _builder.toString());
-    final Consumer<Diagnostic> _function = (Diagnostic it) -> {
-      String _message = it.getMessage();
-      String _plus = ("err: " + _message);
-      InputOutput.<String>println(_plus);
-    };
-    this.getDiagnostics().get(fileURI).forEach(_function);
-    Assert.assertTrue(this.getDiagnostics().get(fileURI).isEmpty());
+  public void testConversion() {
+    Assert.assertEquals("file:///dir/name.ext", this._uriExtensions.toPath(this._uriExtensions.toUri("file:///dir/name.ext")));
   }
   
   @Test
-  public void testFilesWithCyrillic() {
-    this.initialize();
-    final String fileURI = this.getVirtualFile("\u0424\u0443 \u0411\u0430\u0440.testlang");
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("type FooBar {");
-    _builder.newLine();
-    _builder.append("}");
-    _builder.newLine();
-    this.open(fileURI, _builder.toString());
-    final Consumer<Diagnostic> _function = (Diagnostic it) -> {
-      String _message = it.getMessage();
-      String _plus = ("err: " + _message);
-      InputOutput.<String>println(_plus);
-    };
-    this.getDiagnostics().get(fileURI).forEach(_function);
-    Assert.assertTrue(this.getDiagnostics().get(fileURI).isEmpty());
+  public void testFileUriConversion() {
+    Assert.assertEquals("file:///dir/name.ext", this._uriExtensions.toPath(URI.createFileURI("/dir/name.ext")));
+  }
+  
+  @Test
+  public void testFilesWithSpaces() {
+    Assert.assertEquals("file:///dir/Foo Bar.testlang", this._uriExtensions.toPath(this._uriExtensions.toUri("file:///dir/Foo Bar.testlang")));
+  }
+  
+  @Test
+  public void testFilesWithCyrillicSymbols() {
+    Assert.assertEquals("file:///dir/\u0424\u0443 \u0411\u0430\u0440.testlang", 
+      this._uriExtensions.toPath(this._uriExtensions.toUri("file:///dir/\u0424\u0443 \u0411\u0430\u0440.testlang")));
+  }
+  
+  @Test
+  public void testFolderIsPrefix() {
+    File directory = new File("./test-data/test-project");
+    URI uri = this._uriExtensions.toUri(this._uriExtensions.toPath(URI.createFileURI(directory.getAbsolutePath())));
+    Assert.assertTrue(uri.isPrefix());
   }
 }
 

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/UriExtensions.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/UriExtensions.xtend
@@ -28,7 +28,7 @@ class UriExtensions {
 	}
 
 	def String toPath(URI uri) {
-		return uri.toString
+		return URI.createURI(uri.path.toPath).toString
 	}
 
 	def String toPath(java.net.URI uri) {

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/UriExtensions.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/UriExtensions.xtend
@@ -11,6 +11,8 @@ import com.google.inject.Singleton
 import java.nio.file.FileSystemNotFoundException
 import java.nio.file.Paths
 import org.eclipse.emf.common.util.URI
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
 /**
  * @author kosyakov - Initial contribution and API
@@ -20,21 +22,31 @@ import org.eclipse.emf.common.util.URI
 class UriExtensions {
 
 	def URI toUri(String pathWithScheme) {
-		val javaNetUri = java.net.URI.create(pathWithScheme);
-		val path = javaNetUri.toPath
-		return URI.createURI(path)
+		// URI is used to get path of the uri without scheme
+		var path = URI.createURI(pathWithScheme).path
+		return URI.createURI(path.toPath)
 	}
 
 	def String toPath(URI uri) {
-		return java.net.URI.create(uri.toString).toPath
+		return uri.toString
 	}
 
 	def String toPath(java.net.URI uri) {
+		return uri.path.toPath
+	}
+
+	/**
+	 * We need to check if current path represents directory in file system
+	 * and need to add trailing slash if path represents directory.
+	 */
+	private def toPath(String uri) {
 		try {
 			val path = Paths.get(uri)
-			return path.toUri.toString
+			// On Linux Paths.get returns encoded URI (e.x. cyrillic)
+			return URLDecoder.decode(path.toUri.toString, StandardCharsets.UTF_8.name);
 		} catch (FileSystemNotFoundException e) {
-			return uri.toString
+			return uri
 		}
 	}
 }
+

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/UriExtensions.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/UriExtensions.java
@@ -29,7 +29,7 @@ public class UriExtensions {
   }
   
   public String toPath(final URI uri) {
-    return uri.toString();
+    return URI.createURI(this.toPath(uri.path())).toString();
   }
   
   public String toPath(final java.net.URI uri) {


### PR DESCRIPTION
Decodes URL-encoded file paths.
Original implementation fails on Linux when LSP request contains Cyrillic characters in file name.

Signed-off-by: Alexander Kozinko <xcariba@gmail.com>