### PR TITLE
[468777] [formatter] ITextRegionAccess.regionForEObject(EObject) should throw exception for resource-external eobjects

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/regionaccess/internal/SemanticRegionFinderTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/regionaccess/internal/SemanticRegionFinderTest.xtend
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith
 
 import static org.eclipse.xtext.formatting2.regionaccess.internal.regionaccesstestlanguage.RegionaccesstestlanguagePackage.Literals.*
 import static org.junit.Assert.*
+import org.eclipse.xtext.formatting2.regionaccess.internal.regionaccesstestlanguage.RegionaccesstestlanguageFactory
 
 /**
  * @author Moritz Eysholdt - Initial contribution and API
@@ -237,6 +238,11 @@ class SemanticRegionFinderTest {
 		val expected = "(b); ((b) + c); (a + ((b) + c) + d)"
 		assertEquals(expected, actual1)
 		assertEquals(expected, actual2)
+	}
+
+	@Test(expected=IllegalArgumentException) def void regionForExternalObject() {
+		val expr = '''5 (foo)'''.parseAs(Expression)
+		expr.toAccess.regionForEObject(RegionaccesstestlanguageFactory.eINSTANCE.createExpression)
 	}
 
 	def private String pairsToString(Iterable<Pair<ISemanticRegion, ISemanticRegion>> pairs) {

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/regionaccess/internal/SemanticRegionFinderTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/regionaccess/internal/SemanticRegionFinderTest.java
@@ -24,6 +24,7 @@ import org.eclipse.xtext.formatting2.regionaccess.TextRegionAccessBuilder;
 import org.eclipse.xtext.formatting2.regionaccess.internal.regionaccesstestlanguage.AssignedAction;
 import org.eclipse.xtext.formatting2.regionaccess.internal.regionaccesstestlanguage.Expression;
 import org.eclipse.xtext.formatting2.regionaccess.internal.regionaccesstestlanguage.Mixed;
+import org.eclipse.xtext.formatting2.regionaccess.internal.regionaccesstestlanguage.RegionaccesstestlanguageFactory;
 import org.eclipse.xtext.formatting2.regionaccess.internal.regionaccesstestlanguage.RegionaccesstestlanguagePackage;
 import org.eclipse.xtext.formatting2.regionaccess.internal.regionaccesstestlanguage.Root;
 import org.eclipse.xtext.formatting2.regionaccess.internal.services.RegionAccessTestLanguageGrammarAccess;
@@ -352,6 +353,14 @@ public class SemanticRegionFinderTest {
     final String expected = "(b); ((b) + c); (a + ((b) + c) + d)";
     Assert.assertEquals(expected, actual1);
     Assert.assertEquals(expected, actual2);
+  }
+  
+  @Test(expected = IllegalArgumentException.class)
+  public void regionForExternalObject() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("5 (foo)");
+    final Expression expr = this.<Expression>parseAs(_builder, Expression.class);
+    this.toAccess(expr).regionForEObject(RegionaccesstestlanguageFactory.eINSTANCE.createExpression());
   }
   
   private String pairsToString(final Iterable<Pair<ISemanticRegion, ISemanticRegion>> pairs) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/NodeModelBasedRegionAccess.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/NodeModelBasedRegionAccess.java
@@ -46,7 +46,11 @@ public class NodeModelBasedRegionAccess extends AbstractRegionAccess {
 
 	@Override
 	public AbstractEObjectRegion regionForEObject(EObject obj) {
-		return eObjectToTokens.get(obj);
+		AbstractEObjectRegion region = eObjectToTokens.get(obj);
+		if (region == null && obj != null && obj.eResource() != resource) {
+			throw new IllegalArgumentException("ITextRegionAccess.regionForEObject may not be called for resource external EObjects.");
+		}
+		return region;
 	}
 
 	@Override

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/StringBasedRegionAccess.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/StringBasedRegionAccess.java
@@ -57,7 +57,11 @@ public class StringBasedRegionAccess extends AbstractRegionAccess {
 
 	@Override
 	public AbstractEObjectRegion regionForEObject(EObject obj) {
-		return eObjectToTokens.get(obj);
+		AbstractEObjectRegion region = eObjectToTokens.get(obj);
+		if (region == null && obj != null && obj.eResource() != resource) {
+			throw new IllegalArgumentException("ITextRegionAccess.regionForEObject may not be called for resource external EObjects.");
+		}
+		return region;
 	}
 
 	@Override


### PR DESCRIPTION
[468777] [formatter] ITextRegionAccess.regionForEObject(EObject) should throw exception for resource-external eobjects

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>