### PR TITLE
made o.e.xtext.ide dep. to org.eclipse.core.runtime optional #446

### DIFF
--- a/org.eclipse.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ide/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse Xtext
 Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtend.lib,
- org.eclipse.core.runtime;bundle-version="3.6.0",
+ org.eclipse.core.runtime;bundle-version="3.6.0";resolution:=optional;x-installation:=greedy,
+ org.eclipse.equinox.common;bundle-version="3.5.0",
  org.eclipse.lsp4j;bundle-version="[0.2.0,0.3.0)";resolution:=optional,
  org.eclipse.lsp4j.jsonrpc;bundle-version="[0.2.0,0.3.0)";resolution:=optional,
  org.eclipse.emf.ecore.change;bundle-version="[2.10.0,3)"


### PR DESCRIPTION
made o.e.xtext.ide dep. to org.eclipse.core.runtime optional #446
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>