### PR TITLE
[479137]improved Misleading error message 'Cannot create datatype' for terminal rule #91

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/tests/TestErrorAcceptor.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/tests/TestErrorAcceptor.java
@@ -28,7 +28,12 @@ public class TestErrorAcceptor extends Assert implements ErrorAcceptor {
 
 				@Override
 				public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-					return "toString".equals(method.getName()) ? "ANY_EOBJECT" : null;
+					if ("toString".equals(method.getName())) {
+						return "ANY_EOBJECT";
+					} else if ("equals".equals(method.getName()) && args.length == 1) {
+						return args[0] instanceof EObject;
+					}
+					return null;
 				}
 			});
 

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/ecoreInference/Xtext2EcoreTransformerTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/ecoreInference/Xtext2EcoreTransformerTest.xtend
@@ -2123,5 +2123,21 @@ class Xtext2EcoreTransformerTest extends AbstractXtextTests {
 		var featureB_a = clazzB.feature("a")
 		assertEquals("Model", featureB_a.EType.name)
 	}
+	
+	@Test def void testIssue91() {
+		var String grammar = '''
+		grammar test.Test
+		generate test 'http://test'
+		Foo:
+			bar = BAR
+		;
+		terminal BAR:
+			'bar'
+		;
+		'''
+		errorAcceptorMock.acceptError(TransformationErrorCode.NoSuchTypeAvailable,
+			"Cannot create datatype BAR. Make sure you have imported 'http://www.eclipse.org/emf/2002/Ecore'", TestErrorAcceptor.ANY_EOBJECT)
+		getEPackageFromGrammar(grammar, 1)
+	}
 
 }

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/ecoreInference/Xtext2EcoreTransformerTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/ecoreInference/Xtext2EcoreTransformerTest.java
@@ -43,6 +43,7 @@ import org.eclipse.xtext.tests.AbstractXtextTests;
 import org.eclipse.xtext.tests.TestErrorAcceptor;
 import org.eclipse.xtext.util.OnChangeEvictingCache;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xtext.XtextLinker;
 import org.eclipse.xtext.xtext.ecoreInference.EClassifierInfos;
@@ -2870,5 +2871,36 @@ public class Xtext2EcoreTransformerTest extends AbstractXtextTests {
     EClass clazzB = ((EClass) _type_1);
     EStructuralFeature featureB_a = this.<EStructuralFeature>feature(clazzB, "a");
     Assert.assertEquals("Model", featureB_a.getEType().getName());
+  }
+  
+  @Test
+  public void testIssue91() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("grammar test.Test");
+      _builder.newLine();
+      _builder.append("generate test \'http://test\'");
+      _builder.newLine();
+      _builder.append("Foo:");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("bar = BAR");
+      _builder.newLine();
+      _builder.append(";");
+      _builder.newLine();
+      _builder.append("terminal BAR:");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("\'bar\'");
+      _builder.newLine();
+      _builder.append(";");
+      _builder.newLine();
+      String grammar = _builder.toString();
+      this.errorAcceptorMock.acceptError(TransformationErrorCode.NoSuchTypeAvailable, 
+        "Cannot create datatype BAR. Make sure you have imported \'http://www.eclipse.org/emf/2002/Ecore\'", TestErrorAcceptor.ANY_EOBJECT);
+      this.getEPackageFromGrammar(grammar, 1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
   }
 }


### PR DESCRIPTION
[479137]improved Misleading error message 'Cannot create datatype' for terminal rule #91

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>