### PR TITLE
[refactoring] Core part https://github.com/eclipse/xtext-eclipse/issues/284

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/EcoreUtil2Test.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/EcoreUtil2Test.java
@@ -24,6 +24,7 @@ import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.resource.ContentHandler;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
@@ -299,6 +300,29 @@ public class EcoreUtil2Test extends AbstractXtextTests {
 		assertNull(EcoreUtil2.getEReferenceFromExternalForm(EPackage.Registry.INSTANCE, brokenShortExternalFrom));
 		brokenShortExternalFrom = shortExternalForm.replace('A', 'a');
 		assertNull(EcoreUtil2.getEReferenceFromExternalForm(EPackage.Registry.INSTANCE, brokenShortExternalFrom));
+	}
+	
+	@Test public void testPathFragment() {
+		EClass foo = EcoreFactory.eINSTANCE.createEClass();
+		foo.setName("foo");
+		EClass bar = EcoreFactory.eINSTANCE.createEClass();
+		foo.setName("bar");
+		EPackage p = EcoreFactory.eINSTANCE.createEPackage();
+		bar.setName("p");
+		p.getEClassifiers().add(foo);
+		p.getEClassifiers().add(bar);
+		
+		assertEquals("/-1", EcoreUtil2.getFragmentPath(foo));
+		assertEquals("/-1", EcoreUtil2.getFragmentPath(bar));
+		assertEquals("/-1", EcoreUtil2.getFragmentPath(p));
+		Resource resource = new ResourceImpl(URI.createURI("platform:/resource/res"));
+		resource.getContents().add(p);
+		assertEquals(URI.createURI("platform:/resource/res#//@eClassifiers.0"), EcoreUtil2.getFragmentPathURI(foo));
+		assertEquals(URI.createURI("platform:/resource/res#//@eClassifiers.1"), EcoreUtil2.getFragmentPathURI(bar));
+		assertEquals(URI.createURI("platform:/resource/res#/"), EcoreUtil2.getFragmentPathURI(p));
+		assertEquals(resource.getEObject("//@eClassifiers.0"), foo);
+		assertEquals(resource.getEObject("//@eClassifiers.1"), bar);
+		assertEquals(resource.getEObject("/"), p);
 	}
 
 	protected String makeInvalid(String externalForm) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/EcoreUtil2.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/EcoreUtil2.java
@@ -31,6 +31,7 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.common.util.AbstractTreeIterator;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.SegmentSequence;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
@@ -41,6 +42,7 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.EClassImpl;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -55,10 +57,10 @@ import org.eclipse.xtext.resource.DerivedStateAwareResource;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.Strings;
 
+import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
-import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.MapMaker;
 
 /**
@@ -773,4 +775,59 @@ public class EcoreUtil2 extends EcoreUtil {
 			}
 		};
 	}
+	
+	public static URI getFragmentPathURI(final EObject object) {
+		Resource resource = object.eResource();
+		if(resource != null) {
+			String fragment = getFragmentPath(object);
+			URI resourceURI = getPlatformResourceOrNormalizedURI(resource);
+			return resourceURI.appendFragment(fragment);
+		} else {
+			return getPlatformResourceOrNormalizedURI(object);
+		}
+	}
+
+	public static String getFragmentPath(EObject object) {
+		SegmentSequence.Builder builder = SegmentSequence.newBuilder("/");
+		InternalEObject internalEObject = (InternalEObject) object;
+		boolean isContained = internalEObject.eDirectResource() != null;
+		for (InternalEObject container = internalEObject.eInternalContainer(); 
+			container != null && !isContained; 
+			container = internalEObject.eInternalContainer()) {
+			builder.append(getFragmentPathSegment(container, internalEObject.eContainingFeature(), internalEObject));
+			internalEObject = container;
+			if (container.eDirectResource() != null) {
+				isContained = true;
+			}
+		}
+		if (!isContained) {
+			return "/-1";
+		}
+		builder.append(getFragmentPathRootSegment(internalEObject));
+		builder.append("");
+		builder.reverse();
+		return builder.toSegmentSequence().toString();
+	}
+	
+	@SuppressWarnings("unchecked")
+	protected static String getFragmentPathSegment(InternalEObject container, EStructuralFeature feature, InternalEObject contained) {
+	    StringBuilder result = new StringBuilder();
+	    result.append('@');
+	    result.append(feature.getName());
+	    if(feature.isMany()) {
+			int index = ((List<EObject>) container.eGet(feature)).indexOf(contained);
+		    	result.append(".");
+		    	result.append(index);
+	    }
+	    return result.toString();
+	}
+	
+	protected static String getFragmentPathRootSegment(EObject eObject) {
+		List<EObject> contents = eObject.eResource().getContents();
+		if (contents.size() > 1)
+			return Integer.toString(contents.indexOf(eObject));
+		else
+			return "";
+	}
+
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/findReferences/ReferenceAcceptor.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/findReferences/ReferenceAcceptor.xtend
@@ -17,6 +17,7 @@ import org.eclipse.xtext.resource.IReferenceDescription
 import org.eclipse.xtext.resource.IResourceServiceProvider
 import org.eclipse.xtext.resource.impl.DefaultReferenceDescription
 import org.eclipse.xtext.util.IAcceptor
+import org.eclipse.xtext.EcoreUtil2
 
 /**
  * For local references, populates an {@link IReferenceDescription} that knows its exported container URI.
@@ -45,7 +46,7 @@ class ReferenceAcceptor implements IReferenceFinder.Acceptor {
 			computeExportedObjectsMap(source)
 			currentResource = source.eResource()
 		}
-		accept(createReferenceDescription(sourceURI, targetURI, eReference, index, findExportedContainer(source)))
+		accept(createReferenceDescription(EcoreUtil2.getFragmentPathURI(source), targetURI, eReference, index, findExportedContainer(source)))
 	}
 
 	protected def void computeExportedObjectsMap(EObject source) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/impl/DefaultReferenceDescription.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/impl/DefaultReferenceDescription.java
@@ -25,8 +25,8 @@ public class DefaultReferenceDescription implements IReferenceDescription {
 	private URI containerEObjectURI;
 
 	public DefaultReferenceDescription(EObject from, EObject to, EReference eReference, int i, URI containerEObjectURI) {
-		this.sourceEObjectUri = EcoreUtil2.getPlatformResourceOrNormalizedURI(from);
-		this.targetEObjectUri = EcoreUtil2.getPlatformResourceOrNormalizedURI(to);
+		this.sourceEObjectUri = EcoreUtil2.getFragmentPathURI(from);
+		this.targetEObjectUri = EcoreUtil2.getFragmentPathURI(to);
 		this.eReference = eReference;
 		this.indexInList = i;
 		this.containerEObjectURI = containerEObjectURI;

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/impl/DefaultResourceDescriptionStrategy.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/impl/DefaultResourceDescriptionStrategy.java
@@ -15,6 +15,7 @@ import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
+import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.linking.lazy.LazyURIEncoder;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.naming.QualifiedName;

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/findReferences/ReferenceAcceptor.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/findReferences/ReferenceAcceptor.java
@@ -13,6 +13,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
+import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.findReferences.IReferenceFinder;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.IReferenceDescription;
@@ -45,7 +46,7 @@ public class ReferenceAcceptor implements IReferenceFinder.Acceptor {
       this.computeExportedObjectsMap(source);
       this.currentResource = source.eResource();
     }
-    this.accept(this.createReferenceDescription(sourceURI, targetURI, eReference, index, this.findExportedContainer(source)));
+    this.accept(this.createReferenceDescription(EcoreUtil2.getFragmentPathURI(source), targetURI, eReference, index, this.findExportedContainer(source)));
   }
   
   protected void computeExportedObjectsMap(final EObject source) {


### PR DESCRIPTION
Reference descriptions should always use path URIs for the source. 

Signed-off-by: Jan Koehnlein <jan.koehnlein@typefox.io>