### PR TITLE
GH-459: Aligned the test assertion in the failing case.

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.xtend
@@ -224,7 +224,8 @@ class UriExtensionsTest {
 
 	@Test
 	def void testFileUriConversion() {
-		assertEquals("file:///dir/name.ext", createFileURI("/dir/name.ext").toUriString)
+		val expected = Paths.get(new File('.').canonicalPath).resolve('dir').resolve('name.ext').toUri.toString;
+		assertEquals(expected, createFileURI(new File('dir/name.ext').absolutePath).toUriString)
 	}
 
 	@Test

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.java
@@ -201,7 +201,12 @@ public class UriExtensionsTest {
   
   @Test
   public void testFileUriConversion() {
-    Assert.assertEquals("file:///dir/name.ext", this._uriExtensions.toUriString(URI.createFileURI("/dir/name.ext")));
+    try {
+      final String expected = Paths.get(new File(".").getCanonicalPath()).resolve("dir").resolve("name.ext").toUri().toString();
+      Assert.assertEquals(expected, this._uriExtensions.toUriString(URI.createFileURI(new File("dir/name.ext").getAbsolutePath())));
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
   }
   
   @Test


### PR DESCRIPTION
As the Javadoc says; the EMF file URI is created from the path of the
`java.io.File`. Paths with leading slashes are not valid paths on
Windows.

Task: #459 
Closes #459 

Signed-off-by: Akos Kitta <kittaakos@gmail.com>