### PR TITLE
[formatter/perf] Avoid calling List.newArrayList() during autowrap

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/ITextReplacerContext.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/ITextReplacerContext.java
@@ -45,6 +45,11 @@ public interface ITextReplacerContext {
 
 	Iterable<ITextReplacement> getLocalReplacements();
 
+	/**
+	 * @since 2.13
+	 */
+	Iterable<ITextReplacement> getLocalReplacementsReverse();
+
 	String getNewLinesString(int count);
 
 	ITextReplacerContext getPreviousContext();

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/ArrayListTextSegmentSet.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/ArrayListTextSegmentSet.java
@@ -139,6 +139,25 @@ public class ArrayListTextSegmentSet<T> extends TextSegmentSet<T> {
 		};
 	}
 
+	@Override
+	public Iterable<T> reverseIterable() {
+		return new Iterable<T>() {
+			@Override
+			public Iterator<T> iterator() {
+				return new AbstractIterator<T>() {
+					private int index = contents.size() - 1;
+
+					@Override
+					protected T computeNext() {
+						if (index < 0)
+							return endOfData();
+						return contents.get(index--);
+					}
+				};
+			}
+		};
+	}
+
 	protected void replaceExistingEntry(T segment, int index, IMerger<T> merger)
 			throws ConflictingRegionsException, RegionTraceMissingException {
 		T existing = contents.get(index);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/TextReplacerContext.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/TextReplacerContext.java
@@ -4,6 +4,7 @@ import static java.lang.String.*;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.xtext.formatting2.AbstractFormatter2;
@@ -102,9 +103,9 @@ public class TextReplacerContext implements ITextReplacerContext {
 		ITextReplacerContext current = this;
 		int count = 0;
 		while (current != null) {
-			List<ITextReplacement> localReplacements = Lists.newArrayList(current.getLocalReplacements());
-			for (int i = localReplacements.size() - 1; i >= 0; i--) {
-				ITextReplacement rep = localReplacements.get(i);
+			Iterator<ITextReplacement> localReplacements = current.getLocalReplacementsReverse().iterator();
+			while (localReplacements.hasNext()) {
+				ITextReplacement rep = localReplacements.next();
 				int endOffset = rep.getEndOffset();
 				if (endOffset > lastOffset) {
 					// System.out.println("error");
@@ -136,6 +137,14 @@ public class TextReplacerContext implements ITextReplacerContext {
 	public Iterable<ITextReplacement> getLocalReplacements() {
 		if (replacements != null)
 			return replacements;
+		else
+			return Collections.<ITextReplacement>emptyList();
+	}
+
+	@Override
+	public Iterable<ITextReplacement> getLocalReplacementsReverse() {
+		if (replacements != null)
+			return replacements.reverseIterable();
 		else
 			return Collections.<ITextReplacement>emptyList();
 	}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/TextSegmentSet.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/TextSegmentSet.java
@@ -97,6 +97,11 @@ public abstract class TextSegmentSet<T> implements Iterable<T> {
 
 	public abstract Iterator<T> iteratorAfter(T segment);
 
+	/**
+	 * @since 2.13
+	 */
+	public abstract Iterable<T> reverseIterable();
+
 	@Override
 	public String toString() {
 		TextRegionsToString toString = new TextRegionsToString();


### PR DESCRIPTION
To navigate the TextReplacers in reverse order, this change introduces a
reversed iterable. Thus, it is no longer necessary to copy all the 
TextReplacers into a list for reverse navigation.


Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>