### PR TITLE
#483: Remove last whitespaces only when appending separator in for-loops

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/trace/node/TemplateNodeTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/trace/node/TemplateNodeTest.xtend
@@ -77,6 +77,33 @@ class TemplateNodeTest {
 		''')
 	}
 	
+	@Test def void testSeparatorLoopWithWhitespace() {
+		val strings = #['a', 'b', 'c']
+		assertEquals('''
+			«FOR s : strings SEPARATOR ', '»«s» «s»«ENDFOR»
+		''')
+	}
+	
+	@Test def void testSeparatorLoopWithWhitespace2() {
+		val strings = #['a', 'b', 'c']
+		assertEquals('''
+			«FOR s : strings SEPARATOR ','»
+				«s» «s»
+			«ENDFOR»
+		''')
+	}
+
+	@Test def void testSeparatorLoopWithWhitespace3() {
+		val strings = #['a', 'b', 'c']
+		assertEquals('''
+			«FOR s : strings SEPARATOR ','»
+				
+				«s» 
+				
+			«ENDFOR»
+		''')
+	}
+	
 	@Test def void testIndentedIf() {
 		val condition = true
 		val string = 'foo'
@@ -95,6 +122,8 @@ class TemplateNodeTest {
 				«FOR s : list»	«s»«ENDFOR»
 		''')
 	}
+	
+
 	
 	@Test def void testIndentedTemplate() {
 		val StringConcatenationClient template = '''

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/generator/trace/node/TemplateNodeTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/generator/trace/node/TemplateNodeTest.java
@@ -173,6 +173,82 @@ public class TemplateNodeTest {
   }
   
   @Test
+  public void testSeparatorLoopWithWhitespace() {
+    final List<String> strings = Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("a", "b", "c"));
+    StringConcatenationClient _client = new StringConcatenationClient() {
+      @Override
+      protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
+        {
+          boolean _hasElements = false;
+          for(final String s : strings) {
+            if (!_hasElements) {
+              _hasElements = true;
+            } else {
+              _builder.appendImmediate(", ", "");
+            }
+            _builder.append(s);
+            _builder.append(" ");
+            _builder.append(s);
+          }
+        }
+        _builder.newLineIfNotEmpty();
+      }
+    };
+    this.assertEquals(_client);
+  }
+  
+  @Test
+  public void testSeparatorLoopWithWhitespace2() {
+    final List<String> strings = Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("a", "b", "c"));
+    StringConcatenationClient _client = new StringConcatenationClient() {
+      @Override
+      protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
+        {
+          boolean _hasElements = false;
+          for(final String s : strings) {
+            if (!_hasElements) {
+              _hasElements = true;
+            } else {
+              _builder.appendImmediate(",", "");
+            }
+            _builder.append(s);
+            _builder.append(" ");
+            _builder.append(s);
+            _builder.newLineIfNotEmpty();
+          }
+        }
+      }
+    };
+    this.assertEquals(_client);
+  }
+  
+  @Test
+  public void testSeparatorLoopWithWhitespace3() {
+    final List<String> strings = Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("a", "b", "c"));
+    StringConcatenationClient _client = new StringConcatenationClient() {
+      @Override
+      protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
+        {
+          boolean _hasElements = false;
+          for(final String s : strings) {
+            if (!_hasElements) {
+              _hasElements = true;
+            } else {
+              _builder.appendImmediate(",", "");
+            }
+            _builder.newLine();
+            _builder.append(s);
+            _builder.append(" ");
+            _builder.newLineIfNotEmpty();
+            _builder.newLine();
+          }
+        }
+      }
+    };
+    this.assertEquals(_client);
+  }
+  
+  @Test
   public void testIndentedIf() {
     final boolean condition = true;
     final String string = "foo";

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/TemplateNode.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/TemplateNode.xtend
@@ -12,6 +12,7 @@ import com.google.common.collect.Iterables
 import java.util.regex.Pattern
 import org.eclipse.xtend2.lib.StringConcatenationClient
 import org.eclipse.xtend2.lib.StringConcatenationClient.TargetStringConcatenation
+import com.google.common.collect.Lists
 
 /**
  * A template node applies a {@link StringConcatenationClient} to compute its children.
@@ -85,12 +86,17 @@ class TemplateNode extends CompositeGeneratorNode implements TargetStringConcate
 	}
 
 	override appendImmediate(Object object, String indentation) {
+		val removed = Lists.newArrayList
 		for (var i = currentParent.children.size - 1; i >= 0; i--) {
 			val node = currentParent.children.get(i)
-			if (node instanceof TextNode) {
-				if (!node.text.hasContent) {
-					currentParent.children.remove(i)					
-				}
+			if (node instanceof TextNode && !(node as TextNode).text.hasContent) {
+				removed += currentParent.children.remove(i)
+			} else if (node instanceof NewLineNode) {
+				removed += currentParent.children.remove(i)
+			} else {
+				append(object, indentation)
+				removed.reverse.forEach[append(it, indentation)]
+				return
 			}
 		}
 		append(object, indentation)

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/TemplateNode.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/TemplateNode.java
@@ -9,15 +9,19 @@ package org.eclipse.xtext.generator.trace.node;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.generator.trace.node.CompositeGeneratorNode;
 import org.eclipse.xtext.generator.trace.node.GeneratorNodeExtensions;
 import org.eclipse.xtext.generator.trace.node.IGeneratorNode;
 import org.eclipse.xtext.generator.trace.node.IndentNode;
+import org.eclipse.xtext.generator.trace.node.NewLineNode;
 import org.eclipse.xtext.generator.trace.node.TextNode;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
@@ -126,14 +130,24 @@ public class TemplateNode extends CompositeGeneratorNode implements StringConcat
   
   @Override
   public void appendImmediate(final Object object, final String indentation) {
+    final ArrayList<IGeneratorNode> removed = Lists.<IGeneratorNode>newArrayList();
     for (int i = (this.currentParent.getChildren().size() - 1); (i >= 0); i--) {
       {
         final IGeneratorNode node = this.currentParent.getChildren().get(i);
-        if ((node instanceof TextNode)) {
-          boolean _hasContent = TemplateNode.hasContent(((TextNode)node).getText());
-          boolean _not = (!_hasContent);
-          if (_not) {
-            this.currentParent.getChildren().remove(i);
+        if (((node instanceof TextNode) && (!TemplateNode.hasContent(((TextNode) node).getText())))) {
+          IGeneratorNode _remove = this.currentParent.getChildren().remove(i);
+          removed.add(_remove);
+        } else {
+          if ((node instanceof NewLineNode)) {
+            IGeneratorNode _remove_1 = this.currentParent.getChildren().remove(i);
+            removed.add(_remove_1);
+          } else {
+            this.append(object, indentation);
+            final Consumer<IGeneratorNode> _function = (IGeneratorNode it) -> {
+              this.append(it, indentation);
+            };
+            ListExtensions.<IGeneratorNode>reverse(removed).forEach(_function);
+            return;
           }
         }
       }


### PR DESCRIPTION
Fixes #483 