### PR TITLE
#481: Improve performance of ResourceStorageLoadable

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/persistence/ResourceStorageLoadable.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/persistence/ResourceStorageLoadable.xtend
@@ -8,6 +8,7 @@
 package org.eclipse.xtext.resource.persistence
 
 import com.google.common.io.CharStreams
+import java.io.BufferedInputStream
 import java.io.DataInputStream
 import java.io.IOException
 import java.io.InputStream
@@ -51,14 +52,14 @@ import org.eclipse.xtext.parser.ParseResult
 	 */
 	protected def void loadEntries(StorageAwareResource resource, ZipInputStream zipIn) throws IOException {
 		zipIn.nextEntry
-		readContents(resource, zipIn)
+		readContents(resource, new BufferedInputStream(zipIn))
 
 		zipIn.nextEntry
-		readResourceDescription(resource, zipIn)
+		readResourceDescription(resource, new BufferedInputStream(zipIn))
 
 		if (storeNodeModel) {
 			zipIn.nextEntry
-			readNodeModel(resource, zipIn)
+			readNodeModel(resource, new BufferedInputStream(zipIn))
 		}
 	}
 	

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/resource/persistence/ResourceStorageLoadable.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/resource/persistence/ResourceStorageLoadable.java
@@ -8,6 +8,7 @@
 package org.eclipse.xtext.resource.persistence;
 
 import com.google.common.io.CharStreams;
+import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,12 +63,15 @@ public class ResourceStorageLoadable {
    */
   protected void loadEntries(final StorageAwareResource resource, final ZipInputStream zipIn) throws IOException {
     zipIn.getNextEntry();
-    this.readContents(resource, zipIn);
+    BufferedInputStream _bufferedInputStream = new BufferedInputStream(zipIn);
+    this.readContents(resource, _bufferedInputStream);
     zipIn.getNextEntry();
-    this.readResourceDescription(resource, zipIn);
+    BufferedInputStream _bufferedInputStream_1 = new BufferedInputStream(zipIn);
+    this.readResourceDescription(resource, _bufferedInputStream_1);
     if (this.storeNodeModel) {
       zipIn.getNextEntry();
-      this.readNodeModel(resource, zipIn);
+      BufferedInputStream _bufferedInputStream_2 = new BufferedInputStream(zipIn);
+      this.readNodeModel(resource, _bufferedInputStream_2);
     }
   }
   


### PR DESCRIPTION
Wrap ZipInputStream in a BufferedInputStream before reading from it with
with a DataInputStream or ObjectInputStream. This improves performance
quite significantly (overall roughly by a factor 4), as the
decompression works much more efficiently with larger chunks of data.

Signed-off-by: Knut Wannheden <knut.wannheden@paranor.ch>