### PR TITLE
[525746] Lower bound constraint for Xbase / Xtend libraries

### DIFF
--- a/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.emf.ecore;bundle-version="2.10.2",
  org.eclipse.emf.common;bundle-version="2.10.1",
  org.antlr.runtime,
- org.eclipse.xtext.xbase.lib;bundle-version="2.11.0",
+ org.eclipse.xtext.xbase.lib;bundle-version="2.13.0",
  org.eclipse.xtend.lib,
  org.eclipse.xtext.testing
 Import-Package: org.apache.log4j;version="1.2.15",

--- a/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.emf.ecore;bundle-version="2.10.2",
  org.eclipse.emf.common;bundle-version="2.10.1",
  org.antlr.runtime,
- org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtext.xbase.lib;bundle-version="2.11.0",
  org.eclipse.xtend.lib,
  org.eclipse.xtext.testing
 Import-Package: org.apache.log4j;version="1.2.15",

--- a/org.eclipse.xtext.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/META-INF/MANIFEST.MF
@@ -20,7 +20,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.xtend.lib,
  org.eclipse.ui.workbench;resolution:=optional,
- org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtext.xbase.lib;bundle-version="2.11.0",
  org.eclipse.xtext.xtext.generator,
  org.eclipse.xtext.xtext.wizard,
  org.eclipse.emf.mwe.core;bundle-version="1.2.0"

--- a/org.eclipse.xtext.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/META-INF/MANIFEST.MF
@@ -20,7 +20,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.xtend.lib,
  org.eclipse.ui.workbench;resolution:=optional,
- org.eclipse.xtext.xbase.lib;bundle-version="2.11.0",
+ org.eclipse.xtext.xbase.lib;bundle-version="2.13.0",
  org.eclipse.xtext.xtext.generator,
  org.eclipse.xtext.xtext.wizard,
  org.eclipse.emf.mwe.core;bundle-version="1.2.0"

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ImplicitFragment.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ImplicitFragment.xtend
@@ -33,7 +33,7 @@ package class ImplicitFragment extends AbstractStubGeneratingFragment {
 			])
 			
 			if (generateXtendStub) {
-				projectConfig.runtime.manifest.requiredBundles += 'org.eclipse.xtend.lib'
+				projectConfig.runtime.manifest.requiredBundles += 'org.eclipse.xtend.lib;bundle-version="'+projectConfig.runtime.xtendLibVersionLowerBound+'"'
 			}
 			
 			projectConfig.runtime.manifest.importedPackages.add('org.apache.log4j')
@@ -45,7 +45,7 @@ package class ImplicitFragment extends AbstractStubGeneratingFragment {
 			])
 			
 			if (generateXtendStub) {
-				projectConfig.eclipsePlugin.manifest.requiredBundles += 'org.eclipse.xtend.lib'
+				projectConfig.eclipsePlugin.manifest.requiredBundles += 'org.eclipse.xtend.lib;bundle-version="'+projectConfig.runtime.xtendLibVersionLowerBound+'"'
 			}
 			
 			projectConfig.eclipsePlugin.manifest.importedPackages.add('org.apache.log4j')

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/generator/GeneratorFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/generator/GeneratorFragment2.xtend
@@ -97,7 +97,7 @@ class GeneratorFragment2 extends AbstractStubGeneratingFragment {
 				.addTypeToType(IGenerator2.typeRef, language.grammar.generatorStub)
 				.contributeTo(language.runtimeGenModule)
 			if (projectConfig.runtime.manifest !== null)
-				projectConfig.runtime.manifest.requiredBundles += 'org.eclipse.xtext.xbase.lib'
+				projectConfig.runtime.manifest.requiredBundles += 'org.eclipse.xtext.xbase.lib;bundle-version="'+projectConfig.runtime.xbaseLibVersionLowerBound+'"'
 
 			if (generateXtendStub) {
 				doGenerateXtendStubFile

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.xtend
@@ -55,7 +55,7 @@ class Junit4Fragment2 extends AbstractStubGeneratingFragment {
 				requiredBundles.addAll(
 					testingPackage,
 					xbaseTestingPackage,
-					"org.eclipse.xtext.xbase.lib"
+					'org.eclipse.xtext.xbase.lib;bundle-version="'+projectConfig.runtime.xbaseLibVersionLowerBound+'"'
 				)
 				exportedPackages.add(grammar.runtimeTestBasePackage+";x-internal=true")
 			]

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/IRuntimeProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/IRuntimeProjectConfig.xtend
@@ -20,4 +20,14 @@ interface IRuntimeProjectConfig extends IBundleProjectConfig {
 	
 	def String getEcoreModelFolder()
 	
+	/**
+	 * @since 2.13
+	 */
+	def String getXbaseLibVersionLowerBound()
+	
+	/**
+	 * @since 2.13
+	 */
+	def String getXtendLibVersionLowerBound()
+	
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/RuntimeProjectConfig.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/RuntimeProjectConfig.xtend
@@ -51,5 +51,13 @@ class RuntimeProjectConfig extends BundleProjectConfig implements IRuntimeProjec
 			ecoreModel.initialize(injector)
 		}
 	}
+	
+	override getXbaseLibVersionLowerBound() {
+		"2.13.0"
+	}
+
+	override getXtendLibVersionLowerBound() {
+		return getXbaseLibVersionLowerBound()
+	}
 
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/scoping/ImportNamespacesScopingFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/scoping/ImportNamespacesScopingFragment2.xtend
@@ -93,7 +93,7 @@ class ImportNamespacesScopingFragment2 extends AbstractInheritingFragment {
 			if (projectConfig.runtime.manifest !== null) {
 				projectConfig.runtime.manifest.exportedPackages += grammar.scopeProviderClass.packageName
 				if (generateXtendStub)
-					projectConfig.runtime.manifest.requiredBundles += 'org.eclipse.xtext.xbase.lib'
+					projectConfig.runtime.manifest.requiredBundles += 'org.eclipse.xtext.xbase.lib;bundle-version="'+projectConfig.runtime.xbaseLibVersionLowerBound+'"'
 			}
 		}
 	}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.xtend
@@ -135,7 +135,7 @@ import static extension org.eclipse.xtext.xtext.generator.util.GenModelUtil2.*
 		
 		if (projectConfig.runtime.manifest !== null) {
 			projectConfig.runtime.manifest.exportedPackages += grammar.serializerBasePackage
-			projectConfig.runtime.manifest.requiredBundles += 'org.eclipse.xtext.xbase.lib'
+			projectConfig.runtime.manifest.requiredBundles += 'org.eclipse.xtext.xbase.lib;bundle-version="'+projectConfig.runtime.xbaseLibVersionLowerBound+'"'
 		}
 		
 		generateAbstractSemanticSequencer()

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.xtend
@@ -89,8 +89,8 @@ class ContentAssistFragment2 extends AbstractInheritingFragment {
 				generateXtendProposalProviderStub
 
 				if (projectConfig.eclipsePlugin.manifest !== null) {
-					projectConfig.eclipsePlugin.manifest.requiredBundles += "org.eclipse.xtext.xbase.lib"
-					projectConfig.eclipsePlugin.manifest.requiredBundles += "org.eclipse.xtend.lib;resolution:=optional"
+					projectConfig.eclipsePlugin.manifest.requiredBundles += 'org.eclipse.xtext.xbase.lib;bundle-version="'+projectConfig.runtime.xbaseLibVersionLowerBound+'"'
+					projectConfig.eclipsePlugin.manifest.requiredBundles += 'org.eclipse.xtend.lib;resolution:=optional'
 				}
 			} else {
 				generateJavaProposalProviderStub

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/xbase/XbaseGeneratorFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/xbase/XbaseGeneratorFragment2.xtend
@@ -65,7 +65,7 @@ class XbaseGeneratorFragment2 extends AbstractXtextGeneratorFragment {
 		
 		if (projectConfig.runtime.manifest !== null) {
 			projectConfig.runtime.manifest.requiredBundles.addAll(#[
-				'org.eclipse.xtext.xbase', 'org.eclipse.xtext.xbase.lib'
+				'org.eclipse.xtext.xbase', 'org.eclipse.xtext.xbase.lib;bundle-version="'+projectConfig.runtime.xbaseLibVersionLowerBound+'"'
 			])
 			if ((generateXtendInferrer || useInferredJvmModel) && !skipExportedPackage) {
 				projectConfig.runtime.manifest.exportedPackages += jvmModelInferrer.packageName

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ImplicitFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ImplicitFragment.java
@@ -50,7 +50,10 @@ class ImplicitFragment extends AbstractStubGeneratingFragment {
       boolean _isGenerateXtendStub = this.isGenerateXtendStub();
       if (_isGenerateXtendStub) {
         Set<String> _requiredBundles = this.getProjectConfig().getRuntime().getManifest().getRequiredBundles();
-        _requiredBundles.add("org.eclipse.xtend.lib");
+        String _xtendLibVersionLowerBound = this.getProjectConfig().getRuntime().getXtendLibVersionLowerBound();
+        String _plus = ("org.eclipse.xtend.lib;bundle-version=\"" + _xtendLibVersionLowerBound);
+        String _plus_1 = (_plus + "\"");
+        _requiredBundles.add(_plus_1);
       }
       this.getProjectConfig().getRuntime().getManifest().getImportedPackages().add("org.apache.log4j");
     }
@@ -62,7 +65,10 @@ class ImplicitFragment extends AbstractStubGeneratingFragment {
       boolean _isGenerateXtendStub_1 = this.isGenerateXtendStub();
       if (_isGenerateXtendStub_1) {
         Set<String> _requiredBundles_1 = this.getProjectConfig().getEclipsePlugin().getManifest().getRequiredBundles();
-        _requiredBundles_1.add("org.eclipse.xtend.lib");
+        String _xtendLibVersionLowerBound_1 = this.getProjectConfig().getRuntime().getXtendLibVersionLowerBound();
+        String _plus_2 = ("org.eclipse.xtend.lib;bundle-version=\"" + _xtendLibVersionLowerBound_1);
+        String _plus_3 = (_plus_2 + "\"");
+        _requiredBundles_1.add(_plus_3);
       }
       this.getProjectConfig().getEclipsePlugin().getManifest().getImportedPackages().add("org.apache.log4j");
     }

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/generator/GeneratorFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/generator/GeneratorFragment2.java
@@ -121,7 +121,10 @@ public class GeneratorFragment2 extends AbstractStubGeneratingFragment {
       boolean _tripleNotEquals = (_manifest != null);
       if (_tripleNotEquals) {
         Set<String> _requiredBundles = this.getProjectConfig().getRuntime().getManifest().getRequiredBundles();
-        _requiredBundles.add("org.eclipse.xtext.xbase.lib");
+        String _xbaseLibVersionLowerBound = this.getProjectConfig().getRuntime().getXbaseLibVersionLowerBound();
+        String _plus = ("org.eclipse.xtext.xbase.lib;bundle-version=\"" + _xbaseLibVersionLowerBound);
+        String _plus_1 = (_plus + "\"");
+        _requiredBundles.add(_plus_1);
       }
       boolean _isGenerateXtendStub = this.isGenerateXtendStub();
       if (_isGenerateXtendStub) {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.java
@@ -90,13 +90,15 @@ public class Junit4Fragment2 extends AbstractStubGeneratingFragment {
     if (_tripleNotEquals) {
       ManifestAccess _manifest_1 = this.getProjectConfig().getRuntimeTest().getManifest();
       final Procedure1<ManifestAccess> _function = (ManifestAccess it) -> {
-        CollectionExtensions.<String>addAll(it.getRequiredBundles(), 
-          this.getTestingPackage(), 
-          this.getXbaseTestingPackage(), 
-          "org.eclipse.xtext.xbase.lib");
+        String _testingPackage = this.getTestingPackage();
+        String _xbaseTestingPackage = this.getXbaseTestingPackage();
+        String _xbaseLibVersionLowerBound = this.getProjectConfig().getRuntime().getXbaseLibVersionLowerBound();
+        String _plus = ("org.eclipse.xtext.xbase.lib;bundle-version=\"" + _xbaseLibVersionLowerBound);
+        String _plus_1 = (_plus + "\"");
+        CollectionExtensions.<String>addAll(it.getRequiredBundles(), _testingPackage, _xbaseTestingPackage, _plus_1);
         String _runtimeTestBasePackage = this._xtextGeneratorNaming.getRuntimeTestBasePackage(this.getGrammar());
-        String _plus = (_runtimeTestBasePackage + ";x-internal=true");
-        it.getExportedPackages().add(_plus);
+        String _plus_2 = (_runtimeTestBasePackage + ";x-internal=true");
+        it.getExportedPackages().add(_plus_2);
       };
       ObjectExtensions.<ManifestAccess>operator_doubleArrow(_manifest_1, _function);
     }

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/IRuntimeProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/IRuntimeProjectConfig.java
@@ -20,4 +20,14 @@ public interface IRuntimeProjectConfig extends IBundleProjectConfig {
   public abstract IXtextGeneratorFileSystemAccess getEcoreModel();
   
   public abstract String getEcoreModelFolder();
+  
+  /**
+   * @since 2.13
+   */
+  public abstract String getXbaseLibVersionLowerBound();
+  
+  /**
+   * @since 2.13
+   */
+  public abstract String getXtendLibVersionLowerBound();
 }

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/RuntimeProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/RuntimeProjectConfig.java
@@ -71,6 +71,16 @@ public class RuntimeProjectConfig extends BundleProjectConfig implements IRuntim
     }
   }
   
+  @Override
+  public String getXbaseLibVersionLowerBound() {
+    return "2.13.0";
+  }
+  
+  @Override
+  public String getXtendLibVersionLowerBound() {
+    return this.getXbaseLibVersionLowerBound();
+  }
+  
   @Pure
   public String getEcoreModelPath() {
     return this.ecoreModelPath;

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/scoping/ImportNamespacesScopingFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/scoping/ImportNamespacesScopingFragment2.java
@@ -136,7 +136,10 @@ public class ImportNamespacesScopingFragment2 extends AbstractInheritingFragment
         boolean _isGenerateXtendStub_1 = this.isGenerateXtendStub();
         if (_isGenerateXtendStub_1) {
           Set<String> _requiredBundles = this.getProjectConfig().getRuntime().getManifest().getRequiredBundles();
-          _requiredBundles.add("org.eclipse.xtext.xbase.lib");
+          String _xbaseLibVersionLowerBound = this.getProjectConfig().getRuntime().getXbaseLibVersionLowerBound();
+          String _plus = ("org.eclipse.xtext.xbase.lib;bundle-version=\"" + _xbaseLibVersionLowerBound);
+          String _plus_1 = (_plus + "\"");
+          _requiredBundles.add(_plus_1);
         }
       }
     }

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.java
@@ -205,7 +205,10 @@ public class SerializerFragment2 extends AbstractStubGeneratingFragment {
       String _serializerBasePackage = this.getSerializerBasePackage(this.getGrammar());
       _exportedPackages.add(_serializerBasePackage);
       Set<String> _requiredBundles = this.getProjectConfig().getRuntime().getManifest().getRequiredBundles();
-      _requiredBundles.add("org.eclipse.xtext.xbase.lib");
+      String _xbaseLibVersionLowerBound = this.getProjectConfig().getRuntime().getXbaseLibVersionLowerBound();
+      String _plus = ("org.eclipse.xtext.xbase.lib;bundle-version=\"" + _xbaseLibVersionLowerBound);
+      String _plus_1 = (_plus + "\"");
+      _requiredBundles.add(_plus_1);
     }
     this.generateAbstractSemanticSequencer();
     this.generateAbstractSyntacticSequencer();

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.java
@@ -127,7 +127,10 @@ public class ContentAssistFragment2 extends AbstractInheritingFragment {
         boolean _tripleNotEquals_2 = (_manifest_1 != null);
         if (_tripleNotEquals_2) {
           Set<String> _requiredBundles_1 = this.getProjectConfig().getEclipsePlugin().getManifest().getRequiredBundles();
-          _requiredBundles_1.add("org.eclipse.xtext.xbase.lib");
+          String _xbaseLibVersionLowerBound = this.getProjectConfig().getRuntime().getXbaseLibVersionLowerBound();
+          String _plus = ("org.eclipse.xtext.xbase.lib;bundle-version=\"" + _xbaseLibVersionLowerBound);
+          String _plus_1 = (_plus + "\"");
+          _requiredBundles_1.add(_plus_1);
           Set<String> _requiredBundles_2 = this.getProjectConfig().getEclipsePlugin().getManifest().getRequiredBundles();
           _requiredBundles_2.add("org.eclipse.xtend.lib;resolution:=optional");
         }

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/xbase/XbaseGeneratorFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/xbase/XbaseGeneratorFragment2.java
@@ -92,8 +92,11 @@ public class XbaseGeneratorFragment2 extends AbstractXtextGeneratorFragment {
     ManifestAccess _manifest = this.getProjectConfig().getRuntime().getManifest();
     boolean _tripleNotEquals_1 = (_manifest != null);
     if (_tripleNotEquals_1) {
+      String _xbaseLibVersionLowerBound = this.getProjectConfig().getRuntime().getXbaseLibVersionLowerBound();
+      String _plus = ("org.eclipse.xtext.xbase.lib;bundle-version=\"" + _xbaseLibVersionLowerBound);
+      String _plus_1 = (_plus + "\"");
       this.getProjectConfig().getRuntime().getManifest().getRequiredBundles().addAll(
-        Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("org.eclipse.xtext.xbase", "org.eclipse.xtext.xbase.lib")));
+        Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("org.eclipse.xtext.xbase", _plus_1)));
       if (((this.generateXtendInferrer || this.useInferredJvmModel) && (!this.skipExportedPackage))) {
         Set<String> _exportedPackages = this.getProjectConfig().getRuntime().getManifest().getExportedPackages();
         String _packageName = this.getJvmModelInferrer().getPackageName();

--- a/org.eclipse.xtext.xtext.wizard/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.wizard/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.xtext.wizard;x-friends:="org.eclipse.xtext.xtext.ui,org.eclipse.xtext.xtext.ui.tests",
  org.eclipse.xtext.xtext.wizard.cli;x-internal:=true,
  org.eclipse.xtext.xtext.wizard.ecore2xtext;x-friends:="org.eclipse.xtext.xtext.ui,org.eclipse.xtext.xtext.ui.tests"
-Require-Bundle: org.eclipse.xtext.xbase.lib,
+Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.11.0",
  org.eclipse.xtend.lib;resolution:=optional,
  org.eclipse.xtext.util,
  org.eclipse.emf.ecore;bundle-version="2.10.2"

--- a/org.eclipse.xtext.xtext.wizard/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.wizard/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.xtext.wizard;x-friends:="org.eclipse.xtext.xtext.ui,org.eclipse.xtext.xtext.ui.tests",
  org.eclipse.xtext.xtext.wizard.cli;x-internal:=true,
  org.eclipse.xtext.xtext.wizard.ecore2xtext;x-friends:="org.eclipse.xtext.xtext.ui,org.eclipse.xtext.xtext.ui.tests"
-Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.11.0",
+Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.13.0",
  org.eclipse.xtend.lib;resolution:=optional,
  org.eclipse.xtext.util,
  org.eclipse.emf.ecore;bundle-version="2.10.2"


### PR DESCRIPTION
- set lower bound for org.eclipse.xtext.xbase.lib to 2.11 (no API added afterwards)
- extended runtime project config by lower versions for Xbase/Xtend lib
- changed fragments to evaluate the lower version constraint of runtime project config to add a lower version constraint