### PR TITLE
Fix an NPE during ValueConversion of xtext.xtext.GrammarID

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextValueConverters.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextValueConverters.java
@@ -40,16 +40,27 @@ public class XtextValueConverters extends DefaultTerminalConverters {
 		return new AbstractNullSafeConverter<String>() {
 			@Override
 			protected String internalToValue(String string, INode node) throws ValueConverterException {
-				StringBuilder result = new StringBuilder();
-				for(ILeafNode leaf: node.getLeafNodes()) {
-					if (!leaf.isHidden()) {
-						if (leaf.getGrammarElement() instanceof Keyword)
-							result.append(leaf.getText());
-						else
-							result.append(ID().toValue(leaf.getText(), leaf));
+				if (node != null) {
+					StringBuilder result = new StringBuilder();
+					for (ILeafNode leaf : node.getLeafNodes()) {
+						if (!leaf.isHidden()) {
+							if (leaf.getGrammarElement() instanceof Keyword)
+								result.append(leaf.getText());
+							else
+								result.append(ID().toValue(leaf.getText(), leaf));
+						}
 					}
+					return result.toString();
+				} else {
+					String[] splitted = string.split("\\.");
+					StringBuilder result = new StringBuilder(string.length());
+					for (int i = 0; i < splitted.length; i++) {
+						if (i != 0)
+							result.append('.');
+						result.append(ID().toValue(splitted[i], null));
+					}
+					return result.toString();
 				}
-				return result.toString();
 			}
 
 			@Override


### PR DESCRIPTION
```
java.lang.NullPointerException: null
	at
org.eclipse.xtext.xtext.XtextValueConverters$1.internalToValue(XtextValueConverters.java:44)
	at
org.eclipse.xtext.xtext.XtextValueConverters$1.internalToValue(XtextValueConverters.java:40)
	at
org.eclipse.xtext.conversion.impl.AbstractNullSafeConverter.toValue(AbstractNullSafeConverter.java:31)
	at
org.eclipse.xtext.conversion.impl.AbstractDeclarativeValueConverterService.toValue(AbstractDeclarativeValueConverterService.java:79)
	at
org.eclipse.xtext.ide.serializer.impl.ReferenceUpdater.getQualifiedName(ReferenceUpdater.java:124)
	at
org.eclipse.xtext.ide.serializer.impl.ReferenceUpdater.needsUpdating(ReferenceUpdater.java:146)
	at
org.eclipse.xtext.ide.serializer.impl.ReferenceUpdater.update(ReferenceUpdater.java:172)
	at
org.eclipse.xtext.ide.serializer.impl.RecordingXtextResourceUpdater.applyChange(RecordingXtextResourceUpdater.java:70)
	at
org.eclipse.xtext.ide.serializer.impl.ChangeSerializer.endRecordChanges(ChangeSerializer.java:136)
	at
org.eclipse.xtext.ide.serializer.impl.ChangeSerializer.applyModifications(ChangeSerializer.java:75)
	at
org.eclipse.xtext.ui.editor.quickfix.WorkbenchMarkerResolutionAdapter$1.lambda$1(WorkbenchMarkerResolutionAdapter.java:131)
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:684)
	at
org.eclipse.xtext.ui.editor.quickfix.WorkbenchMarkerResolutionAdapter$1.execute(WorkbenchMarkerResolutionAdapter.java:139)
	at
org.eclipse.ui.actions.WorkspaceModifyOperation$1.run(WorkspaceModifyOperation.java:106)
	at
org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2313)
	at
org.eclipse.ui.actions.WorkspaceModifyOperation.run(WorkspaceModifyOperation.java:118)
	at
org.eclipse.xtext.ui.editor.quickfix.WorkbenchMarkerResolutionAdapter.run(WorkbenchMarkerResolutionAdapter.java:142)
	at
org.eclipse.xtext.xtext.ui.editor.quickfix.XtextGrammarQuickfixProviderTest.assertAndApplyAllResolutions(XtextGrammarQuickfixProviderTest.java:172)
	at
org.eclipse.xtext.xtext.ui.editor.quickfix.XtextGrammarQuickfixProviderTest.testFixAllEmptyEnumLiteral(XtextGrammarQuickfixProviderTest.java:106)
```
