### PR TITLE
[#512] Maven AppAssembler - Reduce length of classpath

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/org.xtext.example.lsMavenApp.ide/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/org.xtext.example.lsMavenApp.ide/pom.xml
@@ -66,6 +66,8 @@
 						</goals>
 						<configuration>
 							<assembleDirectory>${project.build.directory}/languageserver</assembleDirectory>
+							<repositoryLayout>flat</repositoryLayout>
+							<useWildcardClassPath>true</useWildcardClassPath>
 							<!-- uncomment to enable remote debugging
 							<extraJvmArguments>-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000</extraJvmArguments>
 							-->

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.ide/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.ide/pom.xml
@@ -132,6 +132,8 @@
 						</goals>
 						<configuration>
 							<assembleDirectory>${project.build.directory}/languageserver</assembleDirectory>
+							<repositoryLayout>flat</repositoryLayout>
+							<useWildcardClassPath>true</useWildcardClassPath>
 							<!-- uncomment to enable remote debugging
 							<extraJvmArguments>-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000</extraJvmArguments>
 							-->

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/IdeProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/IdeProjectDescriptor.xtend
@@ -289,6 +289,8 @@ class IdeProjectDescriptor extends ProjectDescriptor {
 										</goals>
 										<configuration>
 											<assembleDirectory>${project.build.directory}/languageserver</assembleDirectory>
+											<repositoryLayout>flat</repositoryLayout>
+											<useWildcardClassPath>true</useWildcardClassPath>
 											<!-- uncomment to enable remote debugging
 											<extraJvmArguments>-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000</extraJvmArguments>
 											-->

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/IdeProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/IdeProjectDescriptor.java
@@ -1032,6 +1032,14 @@ public class IdeProjectDescriptor extends ProjectDescriptor {
           _builder.newLine();
           _builder.append("\t\t");
           _builder.append("\t\t\t\t");
+          _builder.append("<repositoryLayout>flat</repositoryLayout>");
+          _builder.newLine();
+          _builder.append("\t\t");
+          _builder.append("\t\t\t\t");
+          _builder.append("<useWildcardClassPath>true</useWildcardClassPath>");
+          _builder.newLine();
+          _builder.append("\t\t");
+          _builder.append("\t\t\t\t");
           _builder.append("<!-- uncomment to enable remote debugging");
           _builder.newLine();
           _builder.append("\t\t");


### PR DESCRIPTION
On windows the generated classpath in start scripts might become too
long. This can be avoided by additional configuration of the
appassembler-maven-plugin plugin:
- added option repositoryLayout=flat
- added option useWildcardClassPath=true

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>