### PR TITLE
fixed formatting of annotations (e.g. @Override) in Xtext Grammars #534

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/XtextFormatterExpected.xtext
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/XtextFormatterExpected.xtext
@@ -43,3 +43,7 @@ terminal STRING2:
 
 terminal ML_COMMENT2:
 	'/*'->'*/';
+
+@Override
+terminal ID:
+	super;

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/XtextFormatterMessy.xtext
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/XtextFormatterMessy.xtext
@@ -41,4 +41,7 @@ terminal STRING2	:
 			"'" ( '\\' ('b'|'t'|'n'|'f'|'r'|'"'|"'"|'\\') | !('\\'|"'") )* "'"
 		; 
 terminal ML_COMMENT2	: '/*' -> '*/';
+
+
+@ Override terminal ID : super;
  

--- a/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextFormatter.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextFormatter.java
@@ -13,6 +13,7 @@ import org.eclipse.xtext.formatting.impl.FormattingConfig;
 import org.eclipse.xtext.services.XtextGrammarAccess;
 import org.eclipse.xtext.services.XtextGrammarAccess.AbstractTokenWithCardinalityElements;
 import org.eclipse.xtext.services.XtextGrammarAccess.ActionElements;
+import org.eclipse.xtext.services.XtextGrammarAccess.AnnotationElements;
 import org.eclipse.xtext.services.XtextGrammarAccess.AssignmentElements;
 import org.eclipse.xtext.services.XtextGrammarAccess.CharacterRangeElements;
 import org.eclipse.xtext.services.XtextGrammarAccess.CrossReferenceElements;
@@ -147,6 +148,11 @@ public class XtextFormatter extends AbstractDeclarativeFormatter {
 		cfg.setNoSpace().around(naa.getCalledByNameAssignment_0_1());
 		cfg.setNoSpace().around(naa.getValueAssignment_1());
 		cfg.setNoSpace().around(naa.getParameterAssignment_0_0());
+		
+		// @Override
+		AnnotationElements a = g.getAnnotationAccess();
+		cfg.setNoSpace().between(a.getCommercialAtKeyword_0(), a.getNameAssignment_1());
+		cfg.setLinewrap().after(g.getAnnotationRule());
 
 		//saveDebugGraphvizDiagram("XtextFormatting.dot");
 	}


### PR DESCRIPTION
fixed formatting of annotations (e.g. @Override) in Xtext Grammars #534

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>