### PR TITLE
Refactoring: Cleaning up warnings

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/RenameIssue520Test.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/RenameIssue520Test.xtend
@@ -31,7 +31,7 @@ class RenameIssue520Test extends AbstractTestLangLanguageServerTest {
 				Foo ref
 			}
         '''
-        val file2 = 'foo/Bar.testlang'.writeFile(model2)
+        'foo/Bar.testlang'.writeFile(model2)
         initialize
         
         val params = new RenameParams(new TextDocumentIdentifier(file), new Position(0, 6), 'FooNeu')

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/IChangeSerializer.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/IChangeSerializer.java
@@ -15,7 +15,6 @@ import org.eclipse.xtext.formatting2.regionaccess.ITextRegionDiffBuilder;
 import org.eclipse.xtext.formatting2.regionaccess.ITextReplacement;
 import org.eclipse.xtext.ide.serializer.hooks.IReferenceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.ChangeSerializer;
-import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.serializer.ISerializer;
 import org.eclipse.xtext.util.IAcceptor;

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/NodeSemanticRegion.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/NodeSemanticRegion.java
@@ -9,7 +9,6 @@ package org.eclipse.xtext.formatting2.regionaccess.internal;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.xtext.AbstractElement;
 import org.eclipse.xtext.Assignment;
 import org.eclipse.xtext.CrossReference;
 import org.eclipse.xtext.GrammarUtil;

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/StringBasedTextRegionAccessDiffAppender.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/StringBasedTextRegionAccessDiffAppender.java
@@ -10,7 +10,6 @@ package org.eclipse.xtext.formatting2.regionaccess.internal;
 import java.util.List;
 
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.xtext.AbstractElement;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.formatting2.regionaccess.IComment;
 import org.eclipse.xtext.formatting2.regionaccess.IEObjectRegion;

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/StringSemanticRegion.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/StringSemanticRegion.java
@@ -9,7 +9,6 @@ package org.eclipse.xtext.formatting2.regionaccess.internal;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.xtext.AbstractElement;
 import org.eclipse.xtext.Assignment;
 import org.eclipse.xtext.GrammarUtil;
 import org.eclipse.xtext.formatting2.regionaccess.IEObjectRegion;


### PR DESCRIPTION
Removed four unused imports and one unused local variable declaration.

Signed-off-by: Florian Stolte <fstolte@itemis.de>