### PR TITLE
Fix for issue [#555]

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/debug/TextRegionsToStringTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/debug/TextRegionsToStringTest.xtend
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.formatting2.debug
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.*;
+
+/**
+ * @author Florian Stolte - Initial contribution and API
+ */
+class TextRegionsToStringTest {
+	TextRegionsToString textRegionsToString;
+	
+	@Before
+	def void init() {
+		textRegionsToString = new TextRegionsToString
+		textRegionsToString.ignoreCarriageReturnInQuotes = true
+	}
+	
+	@Test
+	def testQuote() {
+
+		// insert quotes
+		assertEquals("\"import some.thing\"", textRegionsToString.quote("import some.thing", 30))
+		assertEquals("\"import some.thing\"", textRegionsToString.quote("import some.thing", 17))
+		
+		// shorten result
+		assertEquals("\"import ...\"", textRegionsToString.quote("import some.thing", 10)) 
+		assertEquals("\"import some.t...\"", textRegionsToString.quote("import some.thing", 16))
+		
+		// remove windows line endings
+		assertEquals("\"\\nimport some.thing\\n\"", textRegionsToString.quote("\r\nimport some.thing\r\n", 30))
+		assertEquals("\"\\nimport some.thing\\n\"", textRegionsToString.quote("\r\nimport some.thing\r\n", 19))
+		
+		// remove windows line endings and shorten
+		assertEquals("\"\\nimport...\"", textRegionsToString.quote("\r\nimport some.thing\r\n", 10))
+		assertEquals("\"\\nimport some.th...\"", textRegionsToString.quote("\r\nimport some.thing\r\n", 18))
+		
+		// keep windows line endings
+		textRegionsToString.ignoreCarriageReturnInQuotes = false
+		assertEquals("\"\\r\\nimport some.thing\\r\\n\"", textRegionsToString.quote("\r\nimport some.thing\r\n", 30))
+	}
+}

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/debug/TextRegionsToStringTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/debug/TextRegionsToStringTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.formatting2.debug;
+
+import org.eclipse.xtext.formatting2.debug.TextRegionsToString;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Florian Stolte - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class TextRegionsToStringTest {
+  private TextRegionsToString textRegionsToString;
+  
+  @Before
+  public void init() {
+    TextRegionsToString _textRegionsToString = new TextRegionsToString();
+    this.textRegionsToString = _textRegionsToString;
+    this.textRegionsToString.setIgnoreCarriageReturnInQuotes(true);
+  }
+  
+  @Test
+  public void testQuote() {
+    Assert.assertEquals("\"import some.thing\"", this.textRegionsToString.quote("import some.thing", 30));
+    Assert.assertEquals("\"import some.thing\"", this.textRegionsToString.quote("import some.thing", 17));
+    Assert.assertEquals("\"import ...\"", this.textRegionsToString.quote("import some.thing", 10));
+    Assert.assertEquals("\"import some.t...\"", this.textRegionsToString.quote("import some.thing", 16));
+    Assert.assertEquals("\"\\nimport some.thing\\n\"", this.textRegionsToString.quote("\r\nimport some.thing\r\n", 30));
+    Assert.assertEquals("\"\\nimport some.thing\\n\"", this.textRegionsToString.quote("\r\nimport some.thing\r\n", 19));
+    Assert.assertEquals("\"\\nimport...\"", this.textRegionsToString.quote("\r\nimport some.thing\r\n", 10));
+    Assert.assertEquals("\"\\nimport some.th...\"", this.textRegionsToString.quote("\r\nimport some.thing\r\n", 18));
+    this.textRegionsToString.setIgnoreCarriageReturnInQuotes(false);
+    Assert.assertEquals("\"\\r\\nimport some.thing\\r\\n\"", this.textRegionsToString.quote("\r\nimport some.thing\r\n", 30));
+  }
+}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/debug/TextRegionsToString.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/debug/TextRegionsToString.java
@@ -86,10 +86,10 @@ public class TextRegionsToString {
 				result.add("\\n");
 				break;
 			case '\r':
-				if (!ignoreCarriageReturnInQuotes) {
-					result.add("\\r");
-				} else {
+				if (ignoreCarriageReturnInQuotes) {
 					max = Math.min(max+1, string.length());
+				} else {
+					result.add("\\r");
 				}
 				break;
 			default:

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/debug/TextRegionsToString.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/debug/TextRegionsToString.java
@@ -88,6 +88,8 @@ public class TextRegionsToString {
 			case '\r':
 				if (!ignoreCarriageReturnInQuotes) {
 					result.add("\\r");
+				} else {
+					max = Math.min(max+1, string.length());
 				}
 				break;
 			default:


### PR DESCRIPTION
Since windows line endings are replaced by unix line endings - i.e. the `\r` character is removed -, the result string can be shorter than the input string.
Since the loop iterating over the characters of the input string is limited to `maxLength + 1` iterations, the check `result.size() > maxLength` did not give the desired result in the presence of windows line endings.

Now, the number of iterations is incremented when a character is deleted from the string.


Signed-off-by: Florian Stolte <fstolte@itemis.de>