### PR TITLE
[tracing] NPE thrown when a file is generated without traces

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/JavaIoFileSystemAccess.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/JavaIoFileSystemAccess.java
@@ -123,17 +123,20 @@ public class JavaIoFileSystemAccess extends AbstractFileSystemAccess2 {
 		try {
 			if (contents instanceof ITraceRegionProvider) {
 				String traceFileName = traceFileNameProvider.getTraceFromJava(generatedFile);
-				File traceFile = getFile(traceFileName, outputConfigName);
-				OutputStream out = new BufferedOutputStream(new FileOutputStream(traceFile));
+				OutputStream out = null;
 				try {
 					AbstractTraceRegion traceRegion = ((ITraceRegionProvider) contents).getTraceRegion();
+					File traceFile = getFile(traceFileName, outputConfigName);
+					out = new BufferedOutputStream(new FileOutputStream(traceFile));
 					traceSerializer.writeTraceRegionTo(traceRegion, out);
 					if(callBack != null) 
 						callBack.fileAdded(traceFile);
 				} catch (TraceNotFoundException e) {
 					// ok
 				}finally {
-					out.close();
+					if (out != null) {
+						out.close();
+					}
 				}
 			}
 		} catch (FileNotFoundException e) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/JavaIoFileSystemAccess.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/JavaIoFileSystemAccess.java
@@ -122,10 +122,10 @@ public class JavaIoFileSystemAccess extends AbstractFileSystemAccess2 {
 	protected void generateTrace(String generatedFile, String outputConfigName, CharSequence contents) {
 		try {
 			if (contents instanceof ITraceRegionProvider) {
-				String traceFileName = traceFileNameProvider.getTraceFromJava(generatedFile);
 				OutputStream out = null;
 				try {
 					AbstractTraceRegion traceRegion = ((ITraceRegionProvider) contents).getTraceRegion();
+					String traceFileName = traceFileNameProvider.getTraceFromJava(generatedFile);
 					File traceFile = getFile(traceFileName, outputConfigName);
 					out = new BufferedOutputStream(new FileOutputStream(traceFile));
 					traceSerializer.writeTraceRegionTo(traceRegion, out);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/JavaIoFileSystemAccess.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/JavaIoFileSystemAccess.java
@@ -23,6 +23,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.generator.trace.AbstractTraceRegion;
 import org.eclipse.xtext.generator.trace.ITraceRegionProvider;
 import org.eclipse.xtext.generator.trace.TraceFileNameProvider;
+import org.eclipse.xtext.generator.trace.TraceNotFoundException;
 import org.eclipse.xtext.generator.trace.TraceRegionSerializer;
 import org.eclipse.xtext.parser.IEncodingProvider;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
@@ -129,7 +130,9 @@ public class JavaIoFileSystemAccess extends AbstractFileSystemAccess2 {
 					traceSerializer.writeTraceRegionTo(traceRegion, out);
 					if(callBack != null) 
 						callBack.fileAdded(traceFile);
-				} finally {
+				} catch (TraceNotFoundException e) {
+					// ok
+				}finally {
 					out.close();
 				}
 			}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/URIBasedFileSystemAccess.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/URIBasedFileSystemAccess.xtend
@@ -92,9 +92,9 @@ class URIBasedFileSystemAccess extends AbstractFileSystemAccess2 {
 	
 	protected def void generateTrace(String generatedFile, String outputConfigName, CharSequence contents) {
 		if (isGenerateTraces && contents instanceof ITraceRegionProvider) {
-			var String traceFileName = traceFileNameProvider.getTraceFromJava(generatedFile)
 			try {
 				var AbstractTraceRegion traceRegion = (contents as ITraceRegionProvider).getTraceRegion()
+				var String traceFileName = traceFileNameProvider.getTraceFromJava(generatedFile)
 				val out = new ByteArrayOutputStream()
 				traceRegionSerializer.writeTraceRegionTo(traceRegion, out)
 				generateFile(traceFileName, outputConfigName, new ByteArrayInputStream(out.toByteArray))

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/URIBasedFileSystemAccess.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/URIBasedFileSystemAccess.xtend
@@ -93,9 +93,9 @@ class URIBasedFileSystemAccess extends AbstractFileSystemAccess2 {
 	protected def void generateTrace(String generatedFile, String outputConfigName, CharSequence contents) {
 		if (isGenerateTraces && contents instanceof ITraceRegionProvider) {
 			var String traceFileName = traceFileNameProvider.getTraceFromJava(generatedFile)
-			val out = new ByteArrayOutputStream()
 			try {
 				var AbstractTraceRegion traceRegion = (contents as ITraceRegionProvider).getTraceRegion()
+				val out = new ByteArrayOutputStream()
 				traceRegionSerializer.writeTraceRegionTo(traceRegion, out)
 				generateFile(traceFileName, outputConfigName, new ByteArrayInputStream(out.toByteArray))
 			} catch (TraceNotFoundException e) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/URIBasedFileSystemAccess.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/URIBasedFileSystemAccess.xtend
@@ -10,6 +10,9 @@ package org.eclipse.xtext.generator
 import com.google.common.io.ByteStreams
 import com.google.common.io.CharStreams
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileNotFoundException
 import java.io.InputStream
 import java.io.InputStreamReader
 import org.eclipse.emf.common.util.URI
@@ -21,9 +24,7 @@ import org.eclipse.xtext.generator.trace.TraceFileNameProvider
 import org.eclipse.xtext.generator.trace.TraceRegionSerializer
 import org.eclipse.xtext.parser.IEncodingProvider
 import org.eclipse.xtext.util.RuntimeIOException
-import java.io.ByteArrayOutputStream
-import java.io.File
-import java.io.FileNotFoundException
+import org.eclipse.xtext.generator.trace.TraceNotFoundException
 
 /**
  * A file system access implementation that is based on EMF URIs and URIConverter
@@ -93,9 +94,13 @@ class URIBasedFileSystemAccess extends AbstractFileSystemAccess2 {
 		if (isGenerateTraces && contents instanceof ITraceRegionProvider) {
 			var String traceFileName = traceFileNameProvider.getTraceFromJava(generatedFile)
 			val out = new ByteArrayOutputStream()
-			var AbstractTraceRegion traceRegion = (contents as ITraceRegionProvider).getTraceRegion()
-			traceRegionSerializer.writeTraceRegionTo(traceRegion, out)
-			generateFile(traceFileName, outputConfigName, new ByteArrayInputStream(out.toByteArray))
+			try {
+				var AbstractTraceRegion traceRegion = (contents as ITraceRegionProvider).getTraceRegion()
+				traceRegionSerializer.writeTraceRegionTo(traceRegion, out)
+				generateFile(traceFileName, outputConfigName, new ByteArrayInputStream(out.toByteArray))
+			} catch (TraceNotFoundException e) {
+				// ok
+			}
 		}
 	}
 	

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/internal/AbstractTraceForURIProvider.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/internal/AbstractTraceForURIProvider.java
@@ -205,7 +205,11 @@ public abstract class AbstractTraceForURIProvider<SomeFile, Trace extends Abstra
 			
 			@Override
 			public AbstractTraceRegion getTraceRegion() {
-				return cachedTraces.getTraceRegion(persistedTrace);
+				AbstractTraceRegion traceRegion = cachedTraces.getTraceRegion(persistedTrace);
+				if (traceRegion == null) {
+					throw new TraceNotFoundException();
+				}
+				return traceRegion;
 			}
 		});
 		return result;

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/GeneratorNodeProcessor.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/node/GeneratorNodeProcessor.xtend
@@ -31,6 +31,9 @@ class GeneratorNodeProcessor {
 		AbstractTraceRegion traceRegion
 		
 		override getTraceRegion() throws TraceNotFoundException {
+			if (traceRegion === null) {
+				throw new TraceNotFoundException()
+			}
 			return traceRegion
 		}
 		

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/URIBasedFileSystemAccess.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/URIBasedFileSystemAccess.java
@@ -24,6 +24,7 @@ import org.eclipse.xtext.generator.IFilePostProcessor;
 import org.eclipse.xtext.generator.trace.AbstractTraceRegion;
 import org.eclipse.xtext.generator.trace.ITraceRegionProvider;
 import org.eclipse.xtext.generator.trace.TraceFileNameProvider;
+import org.eclipse.xtext.generator.trace.TraceNotFoundException;
 import org.eclipse.xtext.generator.trace.TraceRegionSerializer;
 import org.eclipse.xtext.parser.IEncodingProvider;
 import org.eclipse.xtext.util.RuntimeIOException;
@@ -132,11 +133,19 @@ public class URIBasedFileSystemAccess extends AbstractFileSystemAccess2 {
       if ((this.isGenerateTraces() && (contents instanceof ITraceRegionProvider))) {
         String traceFileName = this.traceFileNameProvider.getTraceFromJava(generatedFile);
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        AbstractTraceRegion traceRegion = ((ITraceRegionProvider) contents).getTraceRegion();
-        this.traceRegionSerializer.writeTraceRegionTo(traceRegion, out);
-        byte[] _byteArray = out.toByteArray();
-        ByteArrayInputStream _byteArrayInputStream = new ByteArrayInputStream(_byteArray);
-        this.generateFile(traceFileName, outputConfigName, _byteArrayInputStream);
+        try {
+          AbstractTraceRegion traceRegion = ((ITraceRegionProvider) contents).getTraceRegion();
+          this.traceRegionSerializer.writeTraceRegionTo(traceRegion, out);
+          byte[] _byteArray = out.toByteArray();
+          ByteArrayInputStream _byteArrayInputStream = new ByteArrayInputStream(_byteArray);
+          this.generateFile(traceFileName, outputConfigName, _byteArrayInputStream);
+        } catch (final Throwable _t) {
+          if (_t instanceof TraceNotFoundException) {
+            final TraceNotFoundException e = (TraceNotFoundException)_t;
+          } else {
+            throw Exceptions.sneakyThrow(_t);
+          }
+        }
       }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/URIBasedFileSystemAccess.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/URIBasedFileSystemAccess.java
@@ -132,9 +132,9 @@ public class URIBasedFileSystemAccess extends AbstractFileSystemAccess2 {
     try {
       if ((this.isGenerateTraces() && (contents instanceof ITraceRegionProvider))) {
         String traceFileName = this.traceFileNameProvider.getTraceFromJava(generatedFile);
-        final ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {
           AbstractTraceRegion traceRegion = ((ITraceRegionProvider) contents).getTraceRegion();
+          final ByteArrayOutputStream out = new ByteArrayOutputStream();
           this.traceRegionSerializer.writeTraceRegionTo(traceRegion, out);
           byte[] _byteArray = out.toByteArray();
           ByteArrayInputStream _byteArrayInputStream = new ByteArrayInputStream(_byteArray);

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/URIBasedFileSystemAccess.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/URIBasedFileSystemAccess.java
@@ -131,9 +131,9 @@ public class URIBasedFileSystemAccess extends AbstractFileSystemAccess2 {
   protected void generateTrace(final String generatedFile, final String outputConfigName, final CharSequence contents) {
     try {
       if ((this.isGenerateTraces() && (contents instanceof ITraceRegionProvider))) {
-        String traceFileName = this.traceFileNameProvider.getTraceFromJava(generatedFile);
         try {
           AbstractTraceRegion traceRegion = ((ITraceRegionProvider) contents).getTraceRegion();
+          String traceFileName = this.traceFileNameProvider.getTraceFromJava(generatedFile);
           final ByteArrayOutputStream out = new ByteArrayOutputStream();
           this.traceRegionSerializer.writeTraceRegionTo(traceRegion, out);
           byte[] _byteArray = out.toByteArray();

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/GeneratorNodeProcessor.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/GeneratorNodeProcessor.java
@@ -51,6 +51,9 @@ public class GeneratorNodeProcessor {
     
     @Override
     public AbstractTraceRegion getTraceRegion() throws TraceNotFoundException {
+      if ((this.traceRegion == null)) {
+        throw new TraceNotFoundException();
+      }
       return this.traceRegion;
     }
     


### PR DESCRIPTION
[tracing] NPE thrown when a file is generated without traces 
https://github.com/eclipse/xtext-core/issues/359

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>