### PR TITLE
GH-520 more tests for live scoping

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/resource/containers/LiveShadowedChunkedContainerTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/resource/containers/LiveShadowedChunkedContainerTest.xtend
@@ -107,6 +107,9 @@ class LiveShadowedChunkedContainerTest {
 		assertTrue(barContainer.hasResourceDescription(barURI))
 		assertFalse(barContainer.hasResourceDescription(fooURI))
 		assertEquals(barURI, barContainer.getResourceDescription(barURI).URI)
+		
+		assertEquals('foo', (liveShadowedChunkedResourceDescriptions.globalDescriptions as ChunkedResourceDescriptions).getContainer('foo').getExportedObjects.map[qualifiedName.toString].join(','))
+		assertEquals('bar', (liveShadowedChunkedResourceDescriptions.globalDescriptions as ChunkedResourceDescriptions).getContainer('bar').getExportedObjects.map[qualifiedName.toString].join(','))
 	}
 	
 	@Test 

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/resource/containers/LiveShadowedChunkedContainerTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/resource/containers/LiveShadowedChunkedContainerTest.java
@@ -17,6 +17,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.IResourceDescription;
+import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.resource.LiveContainerTestLanguageInjectorProvider;
 import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.resource.containers.LiveShadowedChunkedContainer;
@@ -152,6 +153,16 @@ public class LiveShadowedChunkedContainerTest {
       Assert.assertTrue(this.barContainer.hasResourceDescription(this.barURI));
       Assert.assertFalse(this.barContainer.hasResourceDescription(this.fooURI));
       Assert.assertEquals(this.barURI, this.barContainer.getResourceDescription(this.barURI).getURI());
+      IResourceDescriptions _globalDescriptions = this.liveShadowedChunkedResourceDescriptions.getGlobalDescriptions();
+      final Function1<IEObjectDescription, String> _function_6 = (IEObjectDescription it) -> {
+        return it.getQualifiedName().toString();
+      };
+      Assert.assertEquals("foo", IterableExtensions.join(IterableExtensions.<IEObjectDescription, String>map(((ChunkedResourceDescriptions) _globalDescriptions).getContainer("foo").getExportedObjects(), _function_6), ","));
+      IResourceDescriptions _globalDescriptions_1 = this.liveShadowedChunkedResourceDescriptions.getGlobalDescriptions();
+      final Function1<IEObjectDescription, String> _function_7 = (IEObjectDescription it) -> {
+        return it.getQualifiedName().toString();
+      };
+      Assert.assertEquals("bar", IterableExtensions.join(IterableExtensions.<IEObjectDescription, String>map(((ChunkedResourceDescriptions) _globalDescriptions_1).getContainer("bar").getExportedObjects(), _function_7), ","));
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/LiveShadowedChunkedContainer.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/LiveShadowedChunkedContainer.xtend
@@ -19,6 +19,7 @@ import org.eclipse.xtext.resource.IContainer
 import org.eclipse.xtext.resource.impl.ChunkedResourceDescriptions
 import org.eclipse.xtext.resource.impl.LiveShadowedChunkedResourceDescriptions
 import org.eclipse.xtext.workspace.IProjectConfig
+import org.eclipse.xtext.resource.impl.ResourceDescriptionsData
 
 /**
  * @author koehnlein - Initial contribution and API
@@ -50,7 +51,7 @@ class LiveShadowedChunkedContainer implements IContainer {
 	}
 	
 	protected def getChunk() {
-		chunkedResourceDescriptions.getContainer(containerName) 
+		chunkedResourceDescriptions.getContainer(containerName) ?: new ResourceDescriptionsData(#[])
 	}
 	
 	protected def getContainedLocalDescriptions() {

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/resource/containers/LiveShadowedChunkedContainer.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/resource/containers/LiveShadowedChunkedContainer.java
@@ -9,6 +9,7 @@ package org.eclipse.xtext.resource.containers;
 
 import com.google.common.annotations.Beta;
 import com.google.common.collect.Iterables;
+import java.util.Collections;
 import java.util.Set;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
@@ -27,6 +28,7 @@ import org.eclipse.xtext.resource.impl.ResourceDescriptionsData;
 import org.eclipse.xtext.workspace.IProjectConfig;
 import org.eclipse.xtext.workspace.ISourceFolder;
 import org.eclipse.xtext.workspace.IWorkspaceConfig;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
@@ -65,7 +67,15 @@ public class LiveShadowedChunkedContainer implements IContainer {
   }
   
   protected ResourceDescriptionsData getChunk() {
-    return this.getChunkedResourceDescriptions().getContainer(this.containerName);
+    ResourceDescriptionsData _elvis = null;
+    ResourceDescriptionsData _container = this.getChunkedResourceDescriptions().getContainer(this.containerName);
+    if (_container != null) {
+      _elvis = _container;
+    } else {
+      ResourceDescriptionsData _resourceDescriptionsData = new ResourceDescriptionsData(Collections.<IResourceDescription>unmodifiableList(CollectionLiterals.<IResourceDescription>newArrayList()));
+      _elvis = _resourceDescriptionsData;
+    }
+    return _elvis;
   }
   
   protected Iterable<IResourceDescription> getContainedLocalDescriptions() {


### PR DESCRIPTION
Signed-off-by: Jan Koehnlein <jan.koehnlein@typefox.io>

Here are more tests and a fix for new containers, as wished by @szarnekow .

Note that I am not aware of any EMF contract that defines what happens to the persistent state when you rename / delete a resource form a resource set. So these tests can only be done on the local state, i.e. I cannot rename / delete a resource form the shadowed global state by modifying the local resource set. Correct me if I am wrong, but AFAIK this doesn't work in the existing live scopes either.