### PR TITLE
[#570] Added error message for invalid override

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/XtextValidationTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/XtextValidationTest.java
@@ -170,6 +170,19 @@ public class XtextValidationTest extends AbstractValidationMessageAcceptingTestC
 		assertEquals(issues.toString(), 0, issues.size());
 	}
 	
+	@Test public void testExplicitOverride05() throws Exception {
+		XtextResource resource = getResourceFromString(
+				"grammar org.foo.Bar\n" +
+				"import \"http://www.eclipse.org/emf/2002/Ecore\" as ecore" +
+				"@Override\n" +
+				"terminal ID: ('a'..'z'|'A'..'Z'|'_');");
+		Diagnostic diag = Diagnostician.INSTANCE.validate(resource.getContents().get(0));
+		List<Diagnostic> issues = diag.getChildren();
+		assertEquals(issues.toString(), 1, issues.size());
+		assertEquals("This grammar has no super grammar and therefore cannot override any rules.", issues.get(0).getMessage());
+		assertEquals("diag.isError", diag.getSeverity(), Diagnostic.ERROR);
+	}
+	
 	
 	@Test public void testMissingArgument() throws Exception {
 		XtextResource resource = getResourceFromString(

--- a/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextValidator.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextValidator.java
@@ -1255,7 +1255,14 @@ public class XtextValidator extends AbstractDeclarativeValidator {
 		final boolean isOverride =
 				rule.getAnnotations().stream().anyMatch(e -> AnnotationNames.OVERRIDE.equals(e.getName()));
 		
-		for (Grammar g : GrammarUtil.getGrammar(rule).getUsedGrammars()) {
+		final List<Grammar> superGrammars = GrammarUtil.getGrammar(rule).getUsedGrammars();
+		
+		if (isOverride && superGrammars.isEmpty()) {
+			error("This grammar has no super grammar and therefore cannot override any rules.", rule,
+					XtextPackage.Literals.ABSTRACT_RULE__NAME, XtextConfigurableIssueCodes.EXPLICIT_OVERRIDE_INVALID);
+		}
+		
+		for (Grammar g : superGrammars) {
 			final AbstractRule r = GrammarUtil.findRuleForName(g, rule.getName());
 			
 			if (r != null) {


### PR DESCRIPTION
Fix for [#570]: Rules with an @Override annotation in a grammar without super grammar
now correctly display an error.

Signed-off-by: Florian Stolte <fstolte@itemis.de>