### PR TITLE
[#580] Updated maven assembly/war plugins to latest versions

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/org.xtext.example.lsMavenApp/jar-with-ecore-model.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/org.xtext.example.lsMavenApp/jar-with-ecore-model.xml
@@ -1,6 +1,6 @@
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" 
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" 
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
 	<id>jar-with-ecore-model</id>
 	<formats>
 		<format>jar</format>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/org.xtext.example.lsMavenApp/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/org.xtext.example.lsMavenApp/pom.xml
@@ -107,7 +107,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.5.5</version>
+				<version>3.1.0</version>
 				<configuration>
 					<descriptors>
 						<descriptor>jar-with-ecore-model.xml</descriptor>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenFatjar/org.xtext.example.lsMavenFatjar.parent/org.xtext.example.lsMavenFatjar/jar-with-ecore-model.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenFatjar/org.xtext.example.lsMavenFatjar.parent/org.xtext.example.lsMavenFatjar/jar-with-ecore-model.xml
@@ -1,6 +1,6 @@
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" 
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" 
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
 	<id>jar-with-ecore-model</id>
 	<formats>
 		<format>jar</format>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenFatjar/org.xtext.example.lsMavenFatjar.parent/org.xtext.example.lsMavenFatjar/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenFatjar/org.xtext.example.lsMavenFatjar.parent/org.xtext.example.lsMavenFatjar/pom.xml
@@ -107,7 +107,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.5.5</version>
+				<version>3.1.0</version>
 				<configuration>
 					<descriptors>
 						<descriptor>jar-with-ecore-model.xml</descriptor>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.web/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.web/pom.xml
@@ -27,7 +27,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.6</version>
+				<version>3.2.0</version>
 				<configuration>
 					<warSourceDirectory>WebRoot</warSourceDirectory>
 					<failOnMissingWebXml>false</failOnMissingWebXml>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.web/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.web/pom.xml
@@ -27,7 +27,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.6</version>
+				<version>3.2.0</version>
 				<configuration>
 					<warSourceDirectory>WebRoot</warSourceDirectory>
 					<failOnMissingWebXml>false</failOnMissingWebXml>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/org.xtext.example.plainMaven.web/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/org.xtext.example.plainMaven.web/pom.xml
@@ -17,7 +17,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.6</version>
+				<version>3.2.0</version>
 				<configuration>
 					<warSourceDirectory>src/main/webapp</warSourceDirectory>
 					<failOnMissingWebXml>false</failOnMissingWebXml>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/org.xtext.example.plainMaven/jar-with-ecore-model.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/org.xtext.example.plainMaven/jar-with-ecore-model.xml
@@ -1,6 +1,6 @@
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" 
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" 
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
 	<id>jar-with-ecore-model</id>
 	<formats>
 		<format>jar</format>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/org.xtext.example.plainMaven/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/org.xtext.example.plainMaven/pom.xml
@@ -128,7 +128,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.5.5</version>
+				<version>3.1.0</version>
 				<configuration>
 					<descriptors>
 						<descriptor>jar-with-ecore-model.xml</descriptor>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
@@ -476,7 +476,7 @@ class RuntimeProjectDescriptor extends TestedProjectDescriptor {
 							«IF isPlainMavenBuild»
 								<plugin>
 									<artifactId>maven-assembly-plugin</artifactId>
-									<version>2.5.5</version>
+									<version>3.1.0</version>
 									<configuration>
 										<descriptors>
 											<descriptor>jar-with-ecore-model.xml</descriptor>
@@ -536,9 +536,9 @@ class RuntimeProjectDescriptor extends TestedProjectDescriptor {
 	}
 	
 	def jarDescriptor() '''
-		<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" 
+		<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" 
 			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+			xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
 			<id>jar-with-ecore-model</id>
 			<formats>
 				<format>jar</format>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/WebProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/WebProjectDescriptor.xtend
@@ -101,7 +101,7 @@ class WebProjectDescriptor extends ProjectDescriptor {
 						</plugin>
 						<plugin>
 							<artifactId>maven-war-plugin</artifactId>
-							<version>2.6</version>
+							<version>3.2.0</version>
 							<configuration>
 								<warSourceDirectory>«Outlet.WEBAPP.sourceFolder»</warSourceDirectory>
 								<failOnMissingWebXml>false</failOnMissingWebXml>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
@@ -1330,7 +1330,7 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
               _builder.newLine();
               _builder.append("\t\t");
               _builder.append("\t");
-              _builder.append("<version>2.5.5</version>");
+              _builder.append("<version>3.1.0</version>");
               _builder.newLine();
               _builder.append("\t\t");
               _builder.append("\t");
@@ -1513,13 +1513,13 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
   
   public CharSequence jarDescriptor() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("<assembly xmlns=\"http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3\" ");
+    _builder.append("<assembly xmlns=\"http://maven.apache.org/ASSEMBLY/2.0.0\" ");
     _builder.newLine();
     _builder.append("\t");
     _builder.append("xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("xsi:schemaLocation=\"http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd\">");
+    _builder.append("xsi:schemaLocation=\"http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd\">");
     _builder.newLine();
     _builder.append("\t");
     _builder.append("<id>jar-with-ecore-model</id>");

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/WebProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/WebProjectDescriptor.java
@@ -223,7 +223,7 @@ public class WebProjectDescriptor extends ProjectDescriptor {
       _builder.append("<artifactId>maven-war-plugin</artifactId>");
       _builder.newLine();
       _builder.append("\t\t\t");
-      _builder.append("<version>2.6</version>");
+      _builder.append("<version>3.2.0</version>");
       _builder.newLine();
       _builder.append("\t\t\t");
       _builder.append("<configuration>");


### PR DESCRIPTION
Solves issue [#580]
- updated the wizard to use maven-assembly-plugin version 3.1.0
- updated the assembly descriptors to version 2.0.0
- updated the wizard to use maven-war-plugin version 3.2.0
- updated the tests to these versions, as well

Signed-off-by: Florian Stolte <fstolte@itemis.de>