### PR TITLE
[#582] Updated version of xtext-gradle-plugin

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -8,7 +8,7 @@ ext.versions = [
 	'xtext': version,
 	'xtext_bootstrap': '2.13.0',
 	'gradle_plugins': '0.1.0',
-	'xtext_gradle_plugin': '1.0.19',
+	'xtext_gradle_plugin': '1.0.20',
 	'lsp4j': '[0.3.0,0.4)',
 	'log4j': '1.2.16',
 	'equinoxCommon' : '3.8.0',

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/build.gradle
@@ -3,8 +3,8 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'org.xtext:xtext-gradle-plugin:1.0.19'
-		classpath 'org.xtext:xtext-idea-gradle-plugin:1.0.19'
+		classpath 'org.xtext:xtext-gradle-plugin:1.0.20'
+		classpath 'org.xtext:xtext-idea-gradle-plugin:1.0.20'
 	}
 }
 

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.gradle/org.xtext.example.gradle.parent/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.gradle/org.xtext.example.gradle.parent/build.gradle
@@ -3,8 +3,8 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'org.xtext:xtext-gradle-plugin:1.0.19'
-		classpath 'org.xtext:xtext-idea-gradle-plugin:1.0.19'
+		classpath 'org.xtext:xtext-gradle-plugin:1.0.20'
+		classpath 'org.xtext:xtext-idea-gradle-plugin:1.0.20'
 	}
 }
 

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsGradleApp/org.xtext.example.lsGradleApp.parent/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsGradleApp/org.xtext.example.lsGradleApp.parent/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'org.xtext:xtext-gradle-plugin:1.0.19'
+		classpath 'org.xtext:xtext-gradle-plugin:1.0.20'
 	}
 }
 

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsGradleFatjar/org.xtext.example.lsGradleFatjar.parent/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsGradleFatjar/org.xtext.example.lsGradleFatjar.parent/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'org.xtext:xtext-gradle-plugin:1.0.19'
+		classpath 'org.xtext:xtext-gradle-plugin:1.0.20'
 	}
 }
 

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/XtextVersion.xtend
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/XtextVersion.xtend
@@ -20,7 +20,7 @@ class XtextVersion {
 	}
 
 	def getXtextGradlePluginVersion() {
-		'1.0.19'
+		'1.0.20'
 	}
 
 	/**

--- a/org.eclipse.xtext.util/xtend-gen/org/eclipse/xtext/util/XtextVersion.java
+++ b/org.eclipse.xtext.util/xtend-gen/org/eclipse/xtext/util/XtextVersion.java
@@ -43,7 +43,7 @@ public class XtextVersion {
   }
   
   public String getXtextGradlePluginVersion() {
-    return "1.0.19";
+    return "1.0.20";
   }
   
   /**


### PR DESCRIPTION
Related to issue [eclipse/xtext-core#582]
- updated from 1.0.19 to 1.0.20
- updated the version in the gradle file
- updated the version used by the wizard
- updated the version in one example

Signed-off-by: Florian Stolte <fstolte@itemis.de>