### PR TITLE
[eclipse/xtext#1152] Java 9 - Added Automatic-Module-Name header

### DIFF
--- a/org.eclipse.xtext.ide.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ide.tests/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.testlanguages,
  org.eclipse.xtext.testlanguages.ide
 Import-Package: org.apache.log4j;version="1.2.15"
+Automatic-Module-Name: org.eclipse.xtext.ide.tests

--- a/org.eclipse.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ide/META-INF/MANIFEST.MF
@@ -49,3 +49,4 @@ Export-Package: org.eclipse.xtext.ide;x-friends:="org.eclipse.xtend.ide",
  org.eclipse.xtext.ide.server.signatureHelp,
  org.eclipse.xtext.ide.server.symbol,
  org.eclipse.xtext.ide.util
+Automatic-Module-Name: org.eclipse.xtext.ide

--- a/org.eclipse.xtext.testing/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testing/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
 Import-Package: org.apache.log4j;version="1.2.15",
  org.apache.log4j.spi;version="1.2.15"
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.xtext.testing

--- a/org.eclipse.xtext.testlanguages.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testlanguages.ide/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Require-Bundle: org.eclipse.xtext.ide;visibility:=reexport,
  org.antlr.runtime,
  org.eclipse.xtend.lib;bundle-version="2.14.0"
 
+Automatic-Module-Name: org.eclipse.xtext.testlanguages.ide

--- a/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
@@ -77,3 +77,4 @@ Export-Package: org.eclipse.xtext.testlanguages.backtracking,
  org.eclipse.xtext.testlanguages.fileAware.generator,
  org.eclipse.xtext.testlanguages.fileAware.tests;x-internal=true
 
+Automatic-Module-Name: org.eclipse.xtext.testlanguages

--- a/org.eclipse.xtext.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/META-INF/MANIFEST.MF
@@ -610,3 +610,4 @@ Export-Package: org.eclipse.xtext,
  org.eclipse.xtext.xtextTest,
  org.eclipse.xtext.xtextTest.impl,
  org.eclipse.xtext.xtextTest.util
+Automatic-Module-Name: org.eclipse.xtext.tests

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin.ide/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.xtext.example.eclipsePlugin,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.eclipsePlugin.ide

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin.tests/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Require-Bundle: org.xtext.example.eclipsePlugin,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.eclipsePlugin.tests

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin.ui.tests/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Require-Bundle: org.xtext.example.eclipsePlugin.ui,
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.eclipsePlugin.ui.tests

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin.ui/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Require-Bundle: org.xtext.example.eclipsePlugin,
  org.eclipse.ui.ide;bundle-version="3.5.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.eclipsePlugin.ui

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
  org.eclipse.equinox.common;bundle-version="3.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.eclipsePlugin

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2.ide/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.xtext.example.eclipsePluginP2,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.eclipsePluginP2.ide

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2.tests/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Require-Bundle: org.xtext.example.eclipsePluginP2,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.eclipsePluginP2.tests

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2.ui.tests/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Require-Bundle: org.xtext.example.eclipsePluginP2.ui,
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.eclipsePluginP2.ui.tests

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2.ui/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Require-Bundle: org.xtext.example.eclipsePluginP2,
  org.eclipse.ui.ide;bundle-version="3.5.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.eclipsePluginP2.ui

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
  org.eclipse.equinox.common;bundle-version="3.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.eclipsePluginP2

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ide/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.xtext.example.full,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.full.ide

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.tests/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Require-Bundle: org.xtext.example.full,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.full.tests

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ui.tests/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Require-Bundle: org.xtext.example.full.ui,
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.full.ui.tests

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ui/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Require-Bundle: org.xtext.example.full,
  org.eclipse.ui.ide;bundle-version="3.5.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.full.ui

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
  org.eclipse.equinox.common;bundle-version="3.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.full

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.ide/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.xtext.example.lsMavenTychoApp,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.lsMavenTychoApp.ide

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.ui/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Require-Bundle: org.xtext.example.lsMavenTychoApp,
  org.eclipse.ui.ide;bundle-version="3.5.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.lsMavenTychoApp.ui

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
  org.eclipse.equinox.common;bundle-version="3.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.lsMavenTychoApp

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.ide/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.xtext.example.lsMavenTychoFatjar,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.lsMavenTychoFatjar.ide

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.ui/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Require-Bundle: org.xtext.example.lsMavenTychoFatjar,
  org.eclipse.ui.ide;bundle-version="3.5.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.lsMavenTychoFatjar.ui

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
  org.eclipse.equinox.common;bundle-version="3.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.lsMavenTychoFatjar

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ide/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.xtext.example.mavenTycho,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.mavenTycho.ide

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.tests/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Require-Bundle: org.xtext.example.mavenTycho,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.mavenTycho.tests

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ui.tests/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Require-Bundle: org.xtext.example.mavenTycho.ui,
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.mavenTycho.ui.tests

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ui/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Require-Bundle: org.xtext.example.mavenTycho,
  org.eclipse.ui.ide;bundle-version="3.5.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.mavenTycho.ui

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
  org.eclipse.equinox.common;bundle-version="3.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.mavenTycho

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ide/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.xtext.example.mavenTychoP2,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.mavenTychoP2.ide

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.tests/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Require-Bundle: org.xtext.example.mavenTychoP2,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.mavenTychoP2.tests

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ui.tests/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Require-Bundle: org.xtext.example.mavenTychoP2.ui,
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.mavenTychoP2.ui.tests

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ui/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Require-Bundle: org.xtext.example.mavenTychoP2,
  org.eclipse.ui.ide;bundle-version="3.5.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.mavenTychoP2.ui

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
  org.eclipse.equinox.common;bundle-version="3.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.xtext.example.mavenTychoP2

--- a/org.eclipse.xtext.util/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.util/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.10.2",
  javax.inject;bundle-version="1.0.0";resolution:=optional;visibility:=reexport;x-installation:=greedy,
  org.eclipse.xtend.lib
 Import-Package: org.apache.log4j;version="1.2.15"
+Automatic-Module-Name: org.eclipse.xtext.util

--- a/org.eclipse.xtext.xtext.generator/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.generator/META-INF/MANIFEST.MF
@@ -63,3 +63,4 @@ Export-Package: org.eclipse.xtext.xtext.generator,
  org.eclipse.xtext.xtext.generator.validation;x-internal:=true,
  org.eclipse.xtext.xtext.generator.web;x-internal:=true,
  org.eclipse.xtext.xtext.generator.xbase;x-internal:=true
+Automatic-Module-Name: org.eclipse.xtext.xtext.generator

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/ManifestAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/ManifestAccess.xtend
@@ -124,6 +124,7 @@ class ManifestAccess extends TextFileAccess implements IGuiceAwareGeneratorCompo
 		«IF activator !== null»
 			Bundle-Activator: «activator»
 		«ENDIF»
+		Automatic-Module-Name: «symbolicName ?: bundleName»
 	'''
 	
 	override void writeTo(IFileSystemAccess2 fileSystemAccess) {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/ManifestAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/ManifestAccess.java
@@ -244,6 +244,15 @@ public class ManifestAccess extends TextFileAccess implements IGuiceAwareGenerat
         _builder.newLineIfNotEmpty();
       }
     }
+    _builder.append("Automatic-Module-Name: ");
+    String _elvis_1 = null;
+    if (this.symbolicName != null) {
+      _elvis_1 = this.symbolicName;
+    } else {
+      _elvis_1 = this.bundleName;
+    }
+    _builder.append(_elvis_1);
+    _builder.newLineIfNotEmpty();
     return _builder;
   }
   

--- a/org.eclipse.xtext.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ide/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Import-Package: org.apache.log4j;version="1.2.15"
 Export-Package: org.eclipse.xtext.xtext.ide;x-friends:="org.eclipse.xtext.xtext.ui",
  org.eclipse.xtext.xtext.ide.contentassist.antlr;x-friends:="org.eclipse.xtext.xtext.ui",
  org.eclipse.xtext.xtext.ide.contentassist.antlr.internal;x-friends:="org.eclipse.xtext.xtext.ui"
+Automatic-Module-Name: org.eclipse.xtext.xtext.ide

--- a/org.eclipse.xtext.xtext.wizard/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.wizard/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.eclipse.xtend.lib;resolution:=optional,
  org.eclipse.xtext.util,
  org.eclipse.emf.ecore;bundle-version="2.10.2"
+Automatic-Module-Name: org.eclipse.xtext.xtext.wizard

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ProjectDescriptor.xtend
@@ -114,6 +114,7 @@ abstract class ProjectDescriptor {
 		«manifestEntry("Require-Bundle", requiredBundles)»
 		«manifestEntry("Import-Package", importedPackages)»
 		Bundle-RequiredExecutionEnvironment: «bree»
+		Automatic-Module-Name: «name»
 	'''
 	
 	

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ProjectDescriptor.java
@@ -210,6 +210,10 @@ public abstract class ProjectDescriptor {
     String _bree = this.getBree();
     _builder.append(_bree);
     _builder.newLineIfNotEmpty();
+    _builder.append("Automatic-Module-Name: ");
+    String _name_2 = this.getName();
+    _builder.append(_name_2);
+    _builder.newLineIfNotEmpty();
     return _builder.toString();
   }
   

--- a/org.eclipse.xtext/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext/META-INF/MANIFEST.MF
@@ -107,3 +107,4 @@ Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.10.2";visibility:=re
 Import-Package: org.apache.log4j;version="1.2.15",org.osgi.framework
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.xtext.internal.Activator
+Automatic-Module-Name: org.eclipse.xtext


### PR DESCRIPTION
Signed-off-by: Florian Stolte <fstolte@itemis.de>