### PR TITLE
[eclipse/xtext#1155] Cleaned up javadoc to remove some warnings.

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/refactoring/IResourceRelocationStrategy.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/refactoring/IResourceRelocationStrategy.xtend
@@ -15,7 +15,7 @@ package org.eclipse.xtext.ide.refactoring
  * would make sense is Java, where the package name and the name of the first 
  * public top-level class must match the resource's path.
  * 
- * Clients usually call {@link ResourceRelocationContext.addModification()} to 
+ * Clients usually call {@link ResourceRelocationContext#addModification} to 
  * register their side effects. This way it is ensured that the resource is 
  * properly loaded and watched for changes.
  * 

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/refactoring/ResourceRelocationContext.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/refactoring/ResourceRelocationContext.xtend
@@ -48,7 +48,7 @@ class ResourceRelocationContext {
 
 	/**
 	 * Loads and watches the respective resource and applies the relocation change.
-	 * Clients may usually rather call {@link #addModification()} to register their
+	 * Clients may usually rather call {@link #addModification} to register their
 	 * side-effects.
 	 *  
 	 * @param change the change to execute

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/IChangeSerializer.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/IChangeSerializer.java
@@ -25,7 +25,7 @@ import com.google.inject.ImplementedBy;
  * Converts changes from EMF models to the smallest possible text changes.
  * 
  * The ChangeSerializer records changes in modifications that are added using
- * {@link #addModification(T,IModification<T>)}. All corresponding {@link ITextDocumentChange}s can be retrieved in the
+ * {@link #addModification(Notifier, IModification) addModification(T, IModification&lt;T&gt;)}. All corresponding {@link ITextDocumentChange}s can be retrieved in the
  * end by calling {@link #applyModifications(IAcceptor)}. They contain {@link ITextReplacement} which may then be
  * applied to an editor's contents or to a persisted file.
  * 

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/refactoring/IResourceRelocationStrategy.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/refactoring/IResourceRelocationStrategy.java
@@ -17,7 +17,7 @@ import org.eclipse.xtext.ide.refactoring.ResourceRelocationContext;
  * would make sense is Java, where the package name and the name of the first
  * public top-level class must match the resource's path.
  * 
- * Clients usually call {@link ResourceRelocationContext.addModification()} to
+ * Clients usually call {@link ResourceRelocationContext#addModification} to
  * register their side effects. This way it is ensured that the resource is
  * properly loaded and watched for changes.
  * 

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/refactoring/ResourceRelocationContext.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/refactoring/ResourceRelocationContext.java
@@ -58,7 +58,7 @@ public class ResourceRelocationContext {
   
   /**
    * Loads and watches the respective resource and applies the relocation change.
-   * Clients may usually rather call {@link #addModification()} to register their
+   * Clients may usually rather call {@link #addModification} to register their
    * side-effects.
    * 
    * @param change the change to execute

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.xtend
@@ -159,7 +159,7 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 	}
 	
 	/**
-	 * @deprecated Use {@link CodeConfig#isPreferXtendStubs(boolean)} instead
+	 * @deprecated Use {@link CodeConfig#isPreferXtendStubs()} instead
 	 */
 	@Deprecated
 	override isGenerateXtendStubs() {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.java
@@ -194,7 +194,7 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
   }
   
   /**
-   * @deprecated Use {@link CodeConfig#isPreferXtendStubs(boolean)} instead
+   * @deprecated Use {@link CodeConfig#isPreferXtendStubs()} instead
    */
   @Deprecated
   @Override

--- a/org.eclipse.xtext/src/org/eclipse/xtext/conversion/IValueConverter.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/conversion/IValueConverter.java
@@ -62,10 +62,12 @@ public interface IValueConverter<Type> {
 	 * that is converted, may implement this interface. The framework will
 	 * set the rule according to the annotation of the method that provides
 	 * the value converter.
-	 * 
-	 * @throws IllegalArgumentException if the rule doesn't match the expectation of the value converter
 	 */
 	interface RuleSpecific {
+		
+		/**
+		 * @throws IllegalArgumentException if the rule doesn't match the expectation of the value converter
+		 */
 		void setRule(AbstractRule rule) throws IllegalArgumentException;
 	}
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/IResourceDescription.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/IResourceDescription.java
@@ -163,9 +163,9 @@ public interface IResourceDescription extends ISelectable {
 
 			/**
 			 * Add a listener to the event source. Listeners will not be added twice. Subsequent calls to
-			 * {@link #addListener(Listener)} will not affect the number of events that the listener receives.
-			 * {@link #removeListener(Listener)} will remove the listener immediately independently from the number of
-			 * invocations of {@link #addListener(Listener)} for the given listener.
+			 * {@link #addListener} will not affect the number of events that the listener receives.
+			 * {@link #removeListener} will remove the listener immediately independently from the number of
+			 * invocations of {@link #addListener} for the given listener.
 			 * 
 			 * @param listener
 			 *            the listener to be registered. May not be <code>null</code>.
@@ -173,9 +173,9 @@ public interface IResourceDescription extends ISelectable {
 			void addListener(Listener listener);
 
 			/**
-			 * Immediately removes a registered listener from the source. However if {@link #removeListener(Listener)}
+			 * Immediately removes a registered listener from the source. However if {@link #removeListener}
 			 * is called during a notification, the removed listener will still receive the event. If the listener has
-			 * not been registered before, the {@link #removeListener(Listener)} does nothing.
+			 * not been registered before, the {@link #removeListener} does nothing.
 			 * 
 			 * @param listener
 			 *            the listener to be removed. May not be <code>null</code>.


### PR DESCRIPTION
Contribution to issue [eclipse/xtext#1155].

The remaining warnings related to javadoc do not seem to be caused by actual problems. For most of them I cannot even understand why there are warnings (e.g. there is a warning "... @propertyDescription can only be used in JavaFX properties ..." for `org.eclipse.xtext.generator.OutputConfiguration` although that class does not contain such an annotation).

Signed-off-by: Florian Stolte <fstolte@itemis.de>