### PR TITLE
[eclipse/xtext-eclipse#463] Fixed faulty editor binding

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/xbase/XbaseGeneratorFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/xbase/XbaseGeneratorFragment2.xtend
@@ -210,7 +210,7 @@ class XbaseGeneratorFragment2 extends AbstractXtextGeneratorFragment {
 				.addTypeToType('org.eclipse.xtext.xbase.ui.quickfix.JavaTypeQuickfixes'.typeRef,
 						'org.eclipse.xtext.xbase.ui.quickfix.JavaTypeQuickfixesNoImportSection'.typeRef)
 		}
-		bindingFactory.addTypeToType(grammar.eclipsePluginXbaseEditor, grammar.eclipsePluginEditor)
+		bindingFactory.addTypeToType(grammar.eclipsePluginDefaultEditor, grammar.eclipsePluginEditor)
 		
 		bindingFactory.contributeTo(language.eclipsePluginGenModule)
 		

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/xbase/XbaseGeneratorFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/xbase/XbaseGeneratorFragment2.java
@@ -299,7 +299,7 @@ public class XbaseGeneratorFragment2 extends AbstractXtextGeneratorFragment {
       bindingFactory.addTypeToType(TypeReference.typeRef("org.eclipse.xtext.xbase.ui.quickfix.JavaTypeQuickfixes"), 
         TypeReference.typeRef("org.eclipse.xtext.xbase.ui.quickfix.JavaTypeQuickfixesNoImportSection"));
     }
-    bindingFactory.addTypeToType(this._xtextGeneratorNaming.getEclipsePluginXbaseEditor(this.getGrammar()), this._xtextGeneratorNaming.getEclipsePluginEditor(this.getGrammar()));
+    bindingFactory.addTypeToType(this._xtextGeneratorNaming.getEclipsePluginDefaultEditor(this.getGrammar()), this._xtextGeneratorNaming.getEclipsePluginEditor(this.getGrammar()));
     bindingFactory.contributeTo(this.getLanguage().getEclipsePluginGenModule());
     boolean _inheritsXbaseWithAnnotations = this._xbaseUsageDetector.inheritsXbaseWithAnnotations(this.getLanguage().getGrammar());
     if (_inheritsXbaseWithAnnotations) {


### PR DESCRIPTION
For xbase languages, the language specific editor is now correctly bound to XtextEditor instead of XbaseEditor (issue introduced in [eclipse/xtext-eclipse#463]).
Fixes [eclipse/xtext-xtend#334]

Signed-off-by: Florian Stolte <fstolte@itemis.de>