### PR TITLE
Lb/generated maven pom

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/pom.xml
@@ -135,10 +135,6 @@
 								<includes>
 									<include>**/*</include>
 								</includes>
-								<directory>${basedir}/xtend-gen</directory>
-								<includes>
-									<include>**/*</include>
-								</includes>
 							</fileset>
 						</filesets>
 					</configuration>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/pom.xml
@@ -49,10 +49,6 @@
 								<includes>
 									<include>**/*</include>
 								</includes>
-								<directory>${basedir}/xtend-gen</directory>
-								<includes>
-									<include>**/*</include>
-								</includes>
 							</fileset>
 						</filesets>
 					</configuration>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenFatjar/org.xtext.example.lsMavenFatjar.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenFatjar/org.xtext.example.lsMavenFatjar.parent/pom.xml
@@ -49,10 +49,6 @@
 								<includes>
 									<include>**/*</include>
 								</includes>
-								<directory>${basedir}/xtend-gen</directory>
-								<includes>
-									<include>**/*</include>
-								</includes>
 							</fileset>
 						</filesets>
 					</configuration>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/pom.xml
@@ -91,10 +91,6 @@
 								<includes>
 									<include>**/*</include>
 								</includes>
-								<directory>${basedir}/xtend-gen</directory>
-								<includes>
-									<include>**/*</include>
-								</includes>
 							</fileset>
 						</filesets>
 					</configuration>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/pom.xml
@@ -91,10 +91,6 @@
 								<includes>
 									<include>**/*</include>
 								</includes>
-								<directory>${basedir}/xtend-gen</directory>
-								<includes>
-									<include>**/*</include>
-								</includes>
 							</fileset>
 						</filesets>
 					</configuration>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/pom.xml
@@ -94,10 +94,6 @@
 								<includes>
 									<include>**/*</include>
 								</includes>
-								<directory>${basedir}/xtend-gen</directory>
-								<includes>
-									<include>**/*</include>
-								</includes>
 							</fileset>
 						</filesets>
 					</configuration>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/pom.xml
@@ -94,10 +94,6 @@
 								<includes>
 									<include>**/*</include>
 								</includes>
-								<directory>${basedir}/xtend-gen</directory>
-								<includes>
-									<include>**/*</include>
-								</includes>
 							</fileset>
 						</filesets>
 					</configuration>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/pom.xml
@@ -137,10 +137,6 @@
 								<includes>
 									<include>**/*</include>
 								</includes>
-								<directory>${basedir}/xtend-gen</directory>
-								<includes>
-									<include>**/*</include>
-								</includes>
 							</fileset>
 						</filesets>
 					</configuration>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
@@ -339,7 +339,7 @@ class ParentProjectDescriptor extends ProjectDescriptor {
 								<configuration>
 									<filesets>
 										<fileset>
-											«FOR dir : #[Outlet.MAIN_XTEND_GEN, Outlet.TEST_XTEND_GEN].toSet.map[sourceFolder]»
+											«FOR dir : #[Outlet.MAIN_XTEND_GEN, Outlet.TEST_XTEND_GEN].map[sourceFolder].toSet»
 												<directory>${basedir}/«dir»</directory>
 												<includes>
 													<include>**/*</include>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
@@ -22,6 +22,7 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xtext.wizard.AbstractFile;
@@ -1097,8 +1098,8 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
         final Function1<Outlet, String> _function_2 = (Outlet it_1) -> {
           return this.sourceFolder(it_1);
         };
-        Iterable<String> _map = IterableExtensions.<Outlet, String>map(IterableExtensions.<Outlet>toSet(Collections.<Outlet>unmodifiableList(CollectionLiterals.<Outlet>newArrayList(Outlet.MAIN_XTEND_GEN, Outlet.TEST_XTEND_GEN))), _function_2);
-        for(final String dir : _map) {
+        Set<String> _set = IterableExtensions.<String>toSet(ListExtensions.<Outlet, String>map(Collections.<Outlet>unmodifiableList(CollectionLiterals.<Outlet>newArrayList(Outlet.MAIN_XTEND_GEN, Outlet.TEST_XTEND_GEN)), _function_2));
+        for(final String dir : _set) {
           _builder.append("\t\t\t\t\t\t\t");
           _builder.append("<directory>${basedir}/");
           _builder.append(dir, "\t\t\t\t\t\t\t");


### PR DESCRIPTION
avoid duplicate directories in maven-clean-plugin.

This was due to the fact that Outlets were turned into a set, while we should turn into a set the mapping to sourceFolder, see https://github.com/eclipse/xtext-core/compare/lb/generated-maven-pom?expand=1#diff-e44a9708efdcab029644c899d54d0ef0R342