### PR TITLE
[#608] Fixed reuse issue with WrappingInjectorProvider

### DIFF
--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/smoketest/internal/WrappingInjectorProvider.java
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/smoketest/internal/WrappingInjectorProvider.java
@@ -45,8 +45,14 @@ public class WrappingInjectorProvider implements IInjectorProvider, IRegistryCon
 		this.delegate = delegate;
 		stateBeforeInjectorCreation = GlobalRegistries.makeCopyOfGlobalState();
 		this.injector = createInjector();
+		if (delegate instanceof IRegistryConfigurator) {
+			((IRegistryConfigurator) delegate).setupRegistry();
+		}
 		registerFactory(injector);
 		stateAfterInjectorCreation = GlobalRegistries.makeCopyOfGlobalState();
+		if (delegate instanceof IRegistryConfigurator) {
+			((IRegistryConfigurator) delegate).restoreRegistry();
+		}
 	}
 	
 	private void registerFactory(Injector injector) {


### PR DESCRIPTION
[#608] make sure that WrappingInjectorProvider records changes to the global registry even if the delegate itself is a IRegistryConfigurator and its injector is already created so that createInjector does not do anything that could be recorded

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>