### PR TITLE
Support J9 for tycho based projects

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ui.tests/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ui.tests/pom.xml
@@ -46,17 +46,4 @@
 		</plugins>
 	</build>
 
-	<profiles>
-		<profile>
-			<id>testing-on-mac</id>
-			<activation>
-				<os>
-					<family>mac</family>
-				</os>
-			</activation>
-			<properties>
-				<tycho.testArgLine>-XstartOnFirstThread</tycho.testArgLine>
-			</properties>
-		</profile>
-	</profiles>
 </project>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/pom.xml
@@ -7,11 +7,17 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>1.0.0</tycho-version>
 		<xtextVersion>unspecified</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		<!-- Tycho settings -->
+		<tycho-version>1.0.0</tycho-version>
+		<!-- Define overridable properties for tycho-surefire-plugin -->
+		<platformSystemProperties></platformSystemProperties>
+		<moduleProperties></moduleProperties>
+		<systemProperties></systemProperties>
+		<tycho.testArgLine></tycho.testArgLine>
 	</properties>
 	<modules>
 		<module>org.xtext.example.full</module>
@@ -246,6 +252,19 @@
 						<useProjectSettings>false</useProjectSettings>
 					</configuration>
 				</plugin>
+				<!-- to skip running (and compiling) tests use commandline flag: -Dmaven.test.skip
+					To skip tests, but still compile them, use: -DskipTests
+					To allow all tests in a pom to pass/fail, use commandline flag: -fae (fail
+					at end) -->
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-surefire-plugin</artifactId>
+					<version>${tychoVersion}</version>
+					<configuration>
+						<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+						<argLine>${tycho.testArgLine} ${platformSystemProperties} ${systemProperties} ${moduleProperties}</argLine>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
@@ -275,6 +294,29 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
+	<profiles>
+		<profile>
+			<id>macos</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+				<platformSystemProperties>-XstartOnFirstThread</platformSystemProperties>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk9-or-newer</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<moduleProperties>--add-modules=ALL-SYSTEM</moduleProperties>
+			</properties>
+		</profile>
+	</profiles>
 
 	<dependencies>
 	</dependencies>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/pom.xml
@@ -135,6 +135,29 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
+	<profiles>
+		<profile>
+			<id>macos</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+				<platformSystemProperties>-XstartOnFirstThread</platformSystemProperties>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk9-or-newer</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<moduleProperties>--add-modules=ALL-SYSTEM</moduleProperties>
+			</properties>
+		</profile>
+	</profiles>
 
 	<dependencies>
 	</dependencies>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenFatjar/org.xtext.example.lsMavenFatjar.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenFatjar/org.xtext.example.lsMavenFatjar.parent/pom.xml
@@ -135,6 +135,29 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
+	<profiles>
+		<profile>
+			<id>macos</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+				<platformSystemProperties>-XstartOnFirstThread</platformSystemProperties>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk9-or-newer</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<moduleProperties>--add-modules=ALL-SYSTEM</moduleProperties>
+			</properties>
+		</profile>
+	</profiles>
 
 	<dependencies>
 	</dependencies>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/pom.xml
@@ -7,11 +7,17 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>1.0.0</tycho-version>
 		<xtextVersion>unspecified</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		<!-- Tycho settings -->
+		<tycho-version>1.0.0</tycho-version>
+		<!-- Define overridable properties for tycho-surefire-plugin -->
+		<platformSystemProperties></platformSystemProperties>
+		<moduleProperties></moduleProperties>
+		<systemProperties></systemProperties>
+		<tycho.testArgLine></tycho.testArgLine>
 	</properties>
 	<modules>
 		<module>org.xtext.example.lsMavenTychoApp</module>
@@ -202,6 +208,19 @@
 						<useProjectSettings>false</useProjectSettings>
 					</configuration>
 				</plugin>
+				<!-- to skip running (and compiling) tests use commandline flag: -Dmaven.test.skip
+					To skip tests, but still compile them, use: -DskipTests
+					To allow all tests in a pom to pass/fail, use commandline flag: -fae (fail
+					at end) -->
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-surefire-plugin</artifactId>
+					<version>${tychoVersion}</version>
+					<configuration>
+						<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+						<argLine>${tycho.testArgLine} ${platformSystemProperties} ${systemProperties} ${moduleProperties}</argLine>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
@@ -231,6 +250,29 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
+	<profiles>
+		<profile>
+			<id>macos</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+				<platformSystemProperties>-XstartOnFirstThread</platformSystemProperties>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk9-or-newer</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<moduleProperties>--add-modules=ALL-SYSTEM</moduleProperties>
+			</properties>
+		</profile>
+	</profiles>
 
 	<dependencies>
 	</dependencies>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/pom.xml
@@ -7,11 +7,17 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>1.0.0</tycho-version>
 		<xtextVersion>unspecified</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		<!-- Tycho settings -->
+		<tycho-version>1.0.0</tycho-version>
+		<!-- Define overridable properties for tycho-surefire-plugin -->
+		<platformSystemProperties></platformSystemProperties>
+		<moduleProperties></moduleProperties>
+		<systemProperties></systemProperties>
+		<tycho.testArgLine></tycho.testArgLine>
 	</properties>
 	<modules>
 		<module>org.xtext.example.lsMavenTychoFatjar</module>
@@ -202,6 +208,19 @@
 						<useProjectSettings>false</useProjectSettings>
 					</configuration>
 				</plugin>
+				<!-- to skip running (and compiling) tests use commandline flag: -Dmaven.test.skip
+					To skip tests, but still compile them, use: -DskipTests
+					To allow all tests in a pom to pass/fail, use commandline flag: -fae (fail
+					at end) -->
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-surefire-plugin</artifactId>
+					<version>${tychoVersion}</version>
+					<configuration>
+						<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+						<argLine>${tycho.testArgLine} ${platformSystemProperties} ${systemProperties} ${moduleProperties}</argLine>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
@@ -231,6 +250,29 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
+	<profiles>
+		<profile>
+			<id>macos</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+				<platformSystemProperties>-XstartOnFirstThread</platformSystemProperties>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk9-or-newer</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<moduleProperties>--add-modules=ALL-SYSTEM</moduleProperties>
+			</properties>
+		</profile>
+	</profiles>
 
 	<dependencies>
 	</dependencies>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ui.tests/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ui.tests/pom.xml
@@ -46,17 +46,4 @@
 		</plugins>
 	</build>
 
-	<profiles>
-		<profile>
-			<id>testing-on-mac</id>
-			<activation>
-				<os>
-					<family>mac</family>
-				</os>
-			</activation>
-			<properties>
-				<tycho.testArgLine>-XstartOnFirstThread</tycho.testArgLine>
-			</properties>
-		</profile>
-	</profiles>
 </project>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/pom.xml
@@ -7,11 +7,17 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>1.0.0</tycho-version>
 		<xtextVersion>unspecified</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		<!-- Tycho settings -->
+		<tycho-version>1.0.0</tycho-version>
+		<!-- Define overridable properties for tycho-surefire-plugin -->
+		<platformSystemProperties></platformSystemProperties>
+		<moduleProperties></moduleProperties>
+		<systemProperties></systemProperties>
+		<tycho.testArgLine></tycho.testArgLine>
 	</properties>
 	<modules>
 		<module>org.xtext.example.mavenTycho</module>
@@ -205,6 +211,19 @@
 						<useProjectSettings>false</useProjectSettings>
 					</configuration>
 				</plugin>
+				<!-- to skip running (and compiling) tests use commandline flag: -Dmaven.test.skip
+					To skip tests, but still compile them, use: -DskipTests
+					To allow all tests in a pom to pass/fail, use commandline flag: -fae (fail
+					at end) -->
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-surefire-plugin</artifactId>
+					<version>${tychoVersion}</version>
+					<configuration>
+						<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+						<argLine>${tycho.testArgLine} ${platformSystemProperties} ${systemProperties} ${moduleProperties}</argLine>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
@@ -234,6 +253,29 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
+	<profiles>
+		<profile>
+			<id>macos</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+				<platformSystemProperties>-XstartOnFirstThread</platformSystemProperties>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk9-or-newer</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<moduleProperties>--add-modules=ALL-SYSTEM</moduleProperties>
+			</properties>
+		</profile>
+	</profiles>
 
 	<dependencies>
 	</dependencies>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9.ui.tests/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9.ui.tests/pom.xml
@@ -49,17 +49,4 @@
 		</plugins>
 	</build>
 
-	<profiles>
-		<profile>
-			<id>testing-on-mac</id>
-			<activation>
-				<os>
-					<family>mac</family>
-				</os>
-			</activation>
-			<properties>
-				<tycho.testArgLine>-XstartOnFirstThread --add-modules=ALL-SYSTEM</tycho.testArgLine>
-			</properties>
-		</profile>
-	</profiles>
 </project>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/pom.xml
@@ -7,11 +7,17 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>1.0.0</tycho-version>
 		<xtextVersion>unspecified</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>9</maven.compiler.source>
 		<maven.compiler.target>9</maven.compiler.target>
+		<!-- Tycho settings -->
+		<tycho-version>1.0.0</tycho-version>
+		<!-- Define overridable properties for tycho-surefire-plugin -->
+		<platformSystemProperties></platformSystemProperties>
+		<moduleProperties></moduleProperties>
+		<systemProperties></systemProperties>
+		<tycho.testArgLine></tycho.testArgLine>
 	</properties>
 	<modules>
 		<module>org.xtext.example.mavenTychoJ9</module>
@@ -205,6 +211,19 @@
 						<useProjectSettings>false</useProjectSettings>
 					</configuration>
 				</plugin>
+				<!-- to skip running (and compiling) tests use commandline flag: -Dmaven.test.skip
+					To skip tests, but still compile them, use: -DskipTests
+					To allow all tests in a pom to pass/fail, use commandline flag: -fae (fail
+					at end) -->
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-surefire-plugin</artifactId>
+					<version>${tychoVersion}</version>
+					<configuration>
+						<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+						<argLine>${tycho.testArgLine} ${platformSystemProperties} ${systemProperties} ${moduleProperties}</argLine>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
@@ -234,6 +253,29 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
+	<profiles>
+		<profile>
+			<id>macos</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+				<platformSystemProperties>-XstartOnFirstThread</platformSystemProperties>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk9-or-newer</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<moduleProperties>--add-modules=ALL-SYSTEM</moduleProperties>
+			</properties>
+		</profile>
+	</profiles>
 
 	<dependencies>
 	</dependencies>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ui.tests/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ui.tests/pom.xml
@@ -46,17 +46,4 @@
 		</plugins>
 	</build>
 
-	<profiles>
-		<profile>
-			<id>testing-on-mac</id>
-			<activation>
-				<os>
-					<family>mac</family>
-				</os>
-			</activation>
-			<properties>
-				<tycho.testArgLine>-XstartOnFirstThread</tycho.testArgLine>
-			</properties>
-		</profile>
-	</profiles>
 </project>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/pom.xml
@@ -7,11 +7,17 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>1.0.0</tycho-version>
 		<xtextVersion>unspecified</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		<!-- Tycho settings -->
+		<tycho-version>1.0.0</tycho-version>
+		<!-- Define overridable properties for tycho-surefire-plugin -->
+		<platformSystemProperties></platformSystemProperties>
+		<moduleProperties></moduleProperties>
+		<systemProperties></systemProperties>
+		<tycho.testArgLine></tycho.testArgLine>
 	</properties>
 	<modules>
 		<module>org.xtext.example.mavenTychoP2</module>
@@ -248,6 +254,19 @@
 						<useProjectSettings>false</useProjectSettings>
 					</configuration>
 				</plugin>
+				<!-- to skip running (and compiling) tests use commandline flag: -Dmaven.test.skip
+					To skip tests, but still compile them, use: -DskipTests
+					To allow all tests in a pom to pass/fail, use commandline flag: -fae (fail
+					at end) -->
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-surefire-plugin</artifactId>
+					<version>${tychoVersion}</version>
+					<configuration>
+						<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+						<argLine>${tycho.testArgLine} ${platformSystemProperties} ${systemProperties} ${moduleProperties}</argLine>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
@@ -277,6 +296,29 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
+	<profiles>
+		<profile>
+			<id>macos</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+				<platformSystemProperties>-XstartOnFirstThread</platformSystemProperties>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk9-or-newer</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<moduleProperties>--add-modules=ALL-SYSTEM</moduleProperties>
+			</properties>
+		</profile>
+	</profiles>
 
 	<dependencies>
 	</dependencies>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/pom.xml
@@ -140,6 +140,29 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
+	<profiles>
+		<profile>
+			<id>macos</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
+				<platformSystemProperties>-XstartOnFirstThread</platformSystemProperties>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk9-or-newer</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<moduleProperties>--add-modules=ALL-SYSTEM</moduleProperties>
+			</properties>
+		</profile>
+	</profiles>
 
 	<dependencies>
 	</dependencies>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
@@ -149,23 +149,6 @@ abstract class TestProjectDescriptor extends ProjectDescriptor {
 					</plugins>
 				</build>
 			'''
-			if (isEclipsePluginProject && needsUiHarness) {
-				profileSection = '''
-					<profiles>
-						<profile>
-							<id>testing-on-mac</id>
-							<activation>
-								<os>
-									<family>mac</family>
-								</os>
-							</activation>
-							<properties>
-								<tycho.testArgLine>-XstartOnFirstThread«IF isAtLeastJava9» --add-modules=ALL-SYSTEM«ENDIF»</tycho.testArgLine>
-							</properties>
-						</profile>
-					</profiles>
-				'''
-			}
 		]
 	}
 	

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -574,14 +574,6 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("<properties>");
       _builder.newLine();
-      {
-        boolean _needsTychoBuild = this.getConfig().needsTychoBuild();
-        if (_needsTychoBuild) {
-          _builder.append("\t");
-          _builder.append("<tycho-version>1.0.0</tycho-version>");
-          _builder.newLine();
-        }
-      }
       _builder.append("\t");
       _builder.append("<xtextVersion>");
       XtextVersion _xtextVersion = this.getConfig().getXtextVersion();
@@ -606,6 +598,32 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append(_javaVersion_1, "\t");
       _builder.append("</maven.compiler.target>");
       _builder.newLineIfNotEmpty();
+      {
+        boolean _needsTychoBuild = this.getConfig().needsTychoBuild();
+        if (_needsTychoBuild) {
+          _builder.append("\t");
+          _builder.append("<!-- Tycho settings -->");
+          _builder.newLine();
+          _builder.append("\t");
+          _builder.append("<tycho-version>1.0.0</tycho-version>");
+          _builder.newLine();
+          _builder.append("\t");
+          _builder.append("<!-- Define overridable properties for tycho-surefire-plugin -->");
+          _builder.newLine();
+          _builder.append("\t");
+          _builder.append("<platformSystemProperties></platformSystemProperties>");
+          _builder.newLine();
+          _builder.append("\t");
+          _builder.append("<moduleProperties></moduleProperties>");
+          _builder.newLine();
+          _builder.append("\t");
+          _builder.append("<systemProperties></systemProperties>");
+          _builder.newLine();
+          _builder.append("\t");
+          _builder.append("<tycho.testArgLine></tycho.testArgLine>");
+          _builder.newLine();
+        }
+      }
       _builder.append("</properties>");
       _builder.newLine();
       _builder.append("<modules>");
@@ -1506,6 +1524,55 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
           _builder.append("\t\t\t");
           _builder.append("</plugin>");
           _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("<!-- to skip running (and compiling) tests use commandline flag: -Dmaven.test.skip");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t");
+          _builder.append("To skip tests, but still compile them, use: -DskipTests");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t");
+          _builder.append("To allow all tests in a pom to pass/fail, use commandline flag: -fae (fail");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t");
+          _builder.append("at end) -->");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("<plugin>");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t");
+          _builder.append("<groupId>org.eclipse.tycho</groupId>");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t");
+          _builder.append("<artifactId>tycho-surefire-plugin</artifactId>");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t");
+          _builder.append("<version>${tychoVersion}</version>");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t");
+          _builder.append("<configuration>");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t\t");
+          _builder.append("<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t\t");
+          _builder.append("<argLine>${tycho.testArgLine} ${platformSystemProperties} ${systemProperties} ${moduleProperties}</argLine>");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("\t");
+          _builder.append("</configuration>");
+          _builder.newLine();
+          _builder.append("\t\t\t");
+          _builder.append("</plugin>");
+          _builder.newLine();
         }
       }
       _builder.append("\t\t");
@@ -1643,6 +1710,73 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
         }
       }
       _builder.append("</pluginRepositories>");
+      _builder.newLine();
+      _builder.append("<profiles>");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("<profile>");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("<id>macos</id>");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("<activation>");
+      _builder.newLine();
+      _builder.append("\t\t\t");
+      _builder.append("<os>");
+      _builder.newLine();
+      _builder.append("\t\t\t\t");
+      _builder.append("<family>mac</family>");
+      _builder.newLine();
+      _builder.append("\t\t\t");
+      _builder.append("</os>");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("</activation>");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("<properties>");
+      _builder.newLine();
+      _builder.append("\t\t\t");
+      _builder.append("<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->");
+      _builder.newLine();
+      _builder.append("\t\t\t");
+      _builder.append("<platformSystemProperties>-XstartOnFirstThread</platformSystemProperties>");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("</properties>");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("</profile>");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("<profile>");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("<id>jdk9-or-newer</id>");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("<activation>");
+      _builder.newLine();
+      _builder.append("\t\t\t");
+      _builder.append("<jdk>[9,)</jdk>");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("</activation>");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("<properties>");
+      _builder.newLine();
+      _builder.append("\t\t\t");
+      _builder.append("<moduleProperties>--add-modules=ALL-SYSTEM</moduleProperties>");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("</properties>");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("</profile>");
+      _builder.newLine();
+      _builder.append("</profiles>");
       _builder.newLine();
       it.setBuildSection(_builder.toString());
     };

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
@@ -435,54 +435,6 @@ public abstract class TestProjectDescriptor extends ProjectDescriptor {
       _builder.append("</build>");
       _builder.newLine();
       it.setBuildSection(_builder.toString());
-      if ((this.isEclipsePluginProject() && this.needsUiHarness())) {
-        StringConcatenation _builder_1 = new StringConcatenation();
-        _builder_1.append("<profiles>");
-        _builder_1.newLine();
-        _builder_1.append("\t");
-        _builder_1.append("<profile>");
-        _builder_1.newLine();
-        _builder_1.append("\t\t");
-        _builder_1.append("<id>testing-on-mac</id>");
-        _builder_1.newLine();
-        _builder_1.append("\t\t");
-        _builder_1.append("<activation>");
-        _builder_1.newLine();
-        _builder_1.append("\t\t\t");
-        _builder_1.append("<os>");
-        _builder_1.newLine();
-        _builder_1.append("\t\t\t\t");
-        _builder_1.append("<family>mac</family>");
-        _builder_1.newLine();
-        _builder_1.append("\t\t\t");
-        _builder_1.append("</os>");
-        _builder_1.newLine();
-        _builder_1.append("\t\t");
-        _builder_1.append("</activation>");
-        _builder_1.newLine();
-        _builder_1.append("\t\t");
-        _builder_1.append("<properties>");
-        _builder_1.newLine();
-        _builder_1.append("\t\t\t");
-        _builder_1.append("<tycho.testArgLine>-XstartOnFirstThread");
-        {
-          boolean _isAtLeastJava9 = this.isAtLeastJava9();
-          if (_isAtLeastJava9) {
-            _builder_1.append(" --add-modules=ALL-SYSTEM");
-          }
-        }
-        _builder_1.append("</tycho.testArgLine>");
-        _builder_1.newLineIfNotEmpty();
-        _builder_1.append("\t\t");
-        _builder_1.append("</properties>");
-        _builder_1.newLine();
-        _builder_1.append("\t");
-        _builder_1.append("</profile>");
-        _builder_1.newLine();
-        _builder_1.append("</profiles>");
-        _builder_1.newLine();
-        it.setProfileSection(_builder_1.toString());
-      }
     };
     return ObjectExtensions.<PomFile>operator_doubleArrow(_pom, _function);
   }


### PR DESCRIPTION
Configures profiles in the parent pom that contribute parts of the tycho-surefire-plugin args via profiles. Seperate profiles are defined for 'macos' and 'jdk9-or-newer'.

Mac profile was removed from the ui.tests project pom.

This change will enable projects configured for Java8 to be buildable on Java 8 and 9.