### PR TITLE
[#627] Compute Xtext version from Bundle-Version

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/XtextVersionTests.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/XtextVersionTests.java
@@ -9,6 +9,10 @@ package org.eclipse.xtext.util;
 
 import static org.junit.Assert.*;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.jar.Manifest;
+
 import org.junit.Test;
 
 /**
@@ -46,6 +50,21 @@ public class XtextVersionTests {
 		assertFalse(version.isSnapshot());
 		assertFalse(version.isStable());
 		
+	}
+	
+	@Test
+	public void test_getCurrent () throws IOException {
+		XtextVersion current = XtextVersion.getCurrent();
+		try (FileInputStream fis = new FileInputStream("META-INF/MANIFEST.MF")) {
+			assertNotNull(current);
+			Manifest manifest = new Manifest(fis);
+			String bundleVersion = manifest.getMainAttributes().getValue("Bundle-Version");
+			assertNotNull(current);
+			// in development Bundle-Version will have suffix .qualifier
+			if (bundleVersion.endsWith(".qualifier")) {
+				assertEquals(bundleVersion.replace(".qualifier", "-SNAPSHOT"), current.getVersion());
+			}
+		}
 	}
 
 }

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/XtextVersion.xtend
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/XtextVersion.xtend
@@ -84,6 +84,7 @@ class XtextVersion {
 					return version.substring(0, version.lastIndexOf('.'))
 				}
 			}
+			return version
 		} catch (Exception e) {
 			return null;
 		} finally {

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/XtextVersion.xtend
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/XtextVersion.xtend
@@ -72,7 +72,18 @@ class XtextVersion {
 			val url = new URL(Plugin.INSTANCE.baseURL + 'META-INF/MANIFEST.MF')
 			is = url.openStream()
 			val manifest = new Manifest(is)
-			return manifest.getMainAttributes().getValue('Maven-Version')
+			var version = manifest.getMainAttributes().getValue('Maven-Version')
+			// in dev mode, Maven-Version has the static value 'unspecified'
+			// during a Gradle build that version gets replaced
+			if ('unspecified' == version) {
+				version = manifest.getMainAttributes().getValue('Bundle-Version')
+				if (version.endsWith(".qualifier")) {
+					return version.replace(".qualifier","-SNAPSHOT")
+				} else {
+					// strip off build qualifier
+					return version.substring(0, version.lastIndexOf('.'))
+				}
+			}
 		} catch (Exception e) {
 			return null;
 		} finally {

--- a/org.eclipse.xtext.util/xtend-gen/org/eclipse/xtext/util/XtextVersion.java
+++ b/org.eclipse.xtext.util/xtend-gen/org/eclipse/xtext/util/XtextVersion.java
@@ -110,6 +110,7 @@ public class XtextVersion {
           return version.substring(0, version.lastIndexOf("."));
         }
       }
+      return version;
     } catch (final Throwable _t) {
       if (_t instanceof Exception) {
         return null;
@@ -128,7 +129,6 @@ public class XtextVersion {
         }
       }
     }
-    return null;
   }
   
   public XtextVersion(final String version) {

--- a/org.eclipse.xtext.util/xtend-gen/org/eclipse/xtext/util/XtextVersion.java
+++ b/org.eclipse.xtext.util/xtend-gen/org/eclipse/xtext/util/XtextVersion.java
@@ -1,5 +1,6 @@
 package org.eclipse.xtext.util;
 
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -98,7 +99,17 @@ public class XtextVersion {
       final URL url = new URL(_plus);
       is = url.openStream();
       final Manifest manifest = new Manifest(is);
-      return manifest.getMainAttributes().getValue("Maven-Version");
+      String version = manifest.getMainAttributes().getValue("Maven-Version");
+      boolean _equals = Objects.equal("unspecified", version);
+      if (_equals) {
+        version = manifest.getMainAttributes().getValue("Bundle-Version");
+        boolean _endsWith = version.endsWith(".qualifier");
+        if (_endsWith) {
+          return version.replace(".qualifier", "-SNAPSHOT");
+        } else {
+          return version.substring(0, version.lastIndexOf("."));
+        }
+      }
     } catch (final Throwable _t) {
       if (_t instanceof Exception) {
         return null;
@@ -117,6 +128,7 @@ public class XtextVersion {
         }
       }
     }
+    return null;
   }
   
   public XtextVersion(final String version) {


### PR DESCRIPTION
In development mode Xtext read the version from the 'Maven-Version'
attribute from org.eclipse.xtext.util manifest, which has a static value
of 'unspecified'. This gets replaced in a Gradle build, but does not
work when using the bundle in an Eclipse development environment.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>