### PR TITLE
[#617] fixed typo in AbstractLanguageServerTest

### DIFF
--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/WorkspaceSymbolTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/WorkspaceSymbolTest.java
@@ -9,7 +9,7 @@ package org.eclipse.xtext.ide.tests.server;
 
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
-import org.eclipse.xtext.testing.WorkspaceSymbolConfiguraiton;
+import org.eclipse.xtext.testing.WorkspaceSymbolConfiguration;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Test;
 
@@ -20,7 +20,7 @@ import org.junit.Test;
 public class WorkspaceSymbolTest extends AbstractTestLangLanguageServerTest {
   @Test
   public void testSymbol_01() {
-    final Procedure1<WorkspaceSymbolConfiguraiton> _function = (WorkspaceSymbolConfiguraiton it) -> {
+    final Procedure1<WorkspaceSymbolConfiguration> _function = (WorkspaceSymbolConfiguration it) -> {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("type Foo {");
       _builder.newLine();
@@ -86,7 +86,7 @@ public class WorkspaceSymbolTest extends AbstractTestLangLanguageServerTest {
   
   @Test
   public void testSymbol_02() {
-    final Procedure1<WorkspaceSymbolConfiguraiton> _function = (WorkspaceSymbolConfiguraiton it) -> {
+    final Procedure1<WorkspaceSymbolConfiguration> _function = (WorkspaceSymbolConfiguration it) -> {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("type Foo {");
       _builder.newLine();

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
@@ -504,8 +504,8 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		}
 	}
 
-	protected def void testSymbol((WorkspaceSymbolConfiguraiton)=>void configurator) {
-		val extension configuration = new WorkspaceSymbolConfiguraiton
+	protected def void testSymbol((WorkspaceSymbolConfiguration)=>void configurator) {
+		val extension configuration = new WorkspaceSymbolConfiguration
 		configuration.filePath = 'MyModel.' + fileExtension
 		configurator.apply(configuration)
 
@@ -645,7 +645,7 @@ class ReferenceTestConfiguration extends TextDocumentPositionConfiguration {
 }
 
 @Accessors
-class WorkspaceSymbolConfiguraiton extends TextDocumentConfiguration {
+class WorkspaceSymbolConfiguration extends TextDocumentConfiguration {
 	String query = ''
 	String expectedSymbols = ''
 	(List<? extends SymbolInformation>)=>void assertSymbols = null

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
@@ -90,7 +90,7 @@ import org.eclipse.xtext.testing.SignatureHelpConfiguration;
 import org.eclipse.xtext.testing.TestCompletionConfiguration;
 import org.eclipse.xtext.testing.TextDocumentConfiguration;
 import org.eclipse.xtext.testing.TextDocumentPositionConfiguration;
-import org.eclipse.xtext.testing.WorkspaceSymbolConfiguraiton;
+import org.eclipse.xtext.testing.WorkspaceSymbolConfiguration;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.Files;
 import org.eclipse.xtext.util.Modules2;
@@ -984,10 +984,10 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
     }
   }
   
-  protected void testSymbol(final Procedure1<? super WorkspaceSymbolConfiguraiton> configurator) {
+  protected void testSymbol(final Procedure1<? super WorkspaceSymbolConfiguration> configurator) {
     try {
       @Extension
-      final WorkspaceSymbolConfiguraiton configuration = new WorkspaceSymbolConfiguraiton();
+      final WorkspaceSymbolConfiguration configuration = new WorkspaceSymbolConfiguration();
       configuration.setFilePath(("MyModel." + this.fileExtension));
       configurator.apply(configuration);
       this.initializeContext(configuration);

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/WorkspaceSymbolConfiguration.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/WorkspaceSymbolConfiguration.java
@@ -16,7 +16,7 @@ import org.eclipse.xtext.xbase.lib.Pure;
 
 @Accessors
 @SuppressWarnings("all")
-public class WorkspaceSymbolConfiguraiton extends TextDocumentConfiguration {
+public class WorkspaceSymbolConfiguration extends TextDocumentConfiguration {
   private String query = "";
   
   private String expectedSymbols = "";


### PR DESCRIPTION
[#617] fixed typo in AbstractLanguageServerTest
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>