### PR TITLE
[eclipse/xtext#1170] Update p2-deployment.gradle & derived files

### DIFF
--- a/gradle/p2-deployment.gradle
+++ b/gradle/p2-deployment.gradle
@@ -8,19 +8,23 @@ apply plugin: 'io.typefox.gradle.p2gen'
 group = 'org.eclipse.xtext'
 
 p2gen {
-	tychoVersion '1.0.0'
+	tychoVersion '1.1.0'
 	
 	exclude 'org.eclipse.xtext.xtext.bootstrap'
 
 	dependencies {
-		repositoryUrl "http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.10.0/"
+		repositoryUrl 'http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.13.0'
 		feature 'org.eclipse.xtext.sdk'
 	}
 	dependencies {
-		repositoryUrl 'http://download.eclipse.org/releases/luna/201502271000/'
+		repositoryUrl 'http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.9.1'
+		feature 'org.eclipse.emf.mwe2.language.sdk'
 	}
 	dependencies {
-		repositoryUrl 'http://download.eclipse.org/modeling/tmf/xtext/updates/orbit/'
+		repositoryUrl 'http://download.eclipse.org/releases/luna/201502271000'
+	}
+	dependencies {
+		repositoryUrl 'http://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository'
 		bundle 'org.junit'
 		includeSource true
 	}

--- a/releng/p2/pom.xml
+++ b/releng/p2/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<properties>
-		<tycho-version>1.0.0</tycho-version>
+		<tycho-version>1.1.0</tycho-version>
 		<root-dir>${basedir}/../..</root-dir>
 	</properties>
 

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>1.0.0</tycho-version>
+		<tycho-version>1.1.0</tycho-version>
 		<root-dir>${basedir}/..</root-dir>
 	</properties>
 

--- a/releng/releng-target/xtext-core.target.target
+++ b/releng/releng-target/xtext-core.target.target
@@ -3,14 +3,18 @@
 <target name="org.eclipse.xtext.core.target" sequenceNumber="0">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.10.0/"/>
+			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.13.0"/>
 			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/releases/luna/201502271000/"/>
+			<repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.9.1"/>
+			<unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="http://download.eclipse.org/releases/luna/201502271000"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/orbit/"/>
+			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository"/>
 			<unit id="org.junit" version="0.0.0"/>
 		</location>
 	</locations>


### PR DESCRIPTION
- Upgrade to Xtext 2.13
- Upgrade to Tycho 1.1.0
- Use official Orbit

Regenerated pom.xml & target file with generateP2Build task

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>