### PR TITLE
startsWith: return false for null argument

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/naming/QualifiedNameTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/naming/QualifiedNameTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,9 @@ import org.eclipse.emf.ecore.resource.impl.BinaryResourceImpl.EObjectOutputStrea
 import org.eclipse.xtext.naming.IQualifiedNameConverter.DefaultImpl;
 import org.eclipse.xtext.scoping.impl.ImportNormalizer;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.google.common.base.Function;
 
@@ -26,7 +28,9 @@ import com.google.common.base.Function;
  * @author Jan Koehnlein - Initial contribution and API
  */
 public class QualifiedNameTest extends Assert {
-	
+    @Rule
+    public ExpectedException thrown= ExpectedException.none();
+    
 	@Test public void testBug354473() {
 		DefaultImpl impl = new IQualifiedNameConverter.DefaultImpl();
 		QualifiedName name = impl.toQualifiedName(".");
@@ -92,8 +96,11 @@ public class QualifiedNameTest extends Assert {
 		assertFalse(qn.startsWith(qn2));
 		assertTrue(qn.startsWithIgnoreCase(qn2));
 		assertFalse(qn2.startsWithIgnoreCase(qn));
+		
+		thrown.expect(IllegalArgumentException.class);
+		qn1.startsWith(null);
 	}
-
+	
 	@Test public void testSkip() throws Exception {
 		QualifiedName qn = QualifiedName.create("foo", "bar", "baz");
 		QualifiedName baz = qn.skipFirst(2);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/naming/QualifiedName.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/naming/QualifiedName.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import org.eclipse.emf.ecore.resource.impl.BinaryResourceImpl.EObjectOutputStrea
 import org.eclipse.xtext.util.Strings;
 
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 
 /**
  * A datatype for dealing with qualified names.
@@ -452,8 +453,11 @@ public class QualifiedName implements Comparable<QualifiedName> {
 	}
 
 	protected boolean startsWith(QualifiedName prefix, boolean ignoreCase) {
-		if (prefix.getSegmentCount() > getSegmentCount())
+		Preconditions.checkArgument(prefix != null, "prefix must not be null");
+		
+		if (prefix.getSegmentCount() > getSegmentCount()) {
 			return false;
+		}
 		if (ignoreCase) {
 			for (int i = 0; i < prefix.getSegmentCount(); ++i) {
 				if (!this.getSegment(i).equalsIgnoreCase(prefix.getSegment(i)))


### PR DESCRIPTION
Avoid NPE when accidently invoked with null

Or shall we throw IllegalArgumentException?