### PR TITLE
[eclipse/xtext-eclipse#520] Adjust to latest API

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/codemining/CodeMiningFragment.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/codemining/CodeMiningFragment.xtend
@@ -9,16 +9,17 @@ package org.eclipse.xtext.xtext.generator.ui.codemining
 
 import com.google.common.annotations.Beta
 import com.google.inject.Inject
+import com.google.inject.name.Names
 import org.eclipse.xtext.naming.IQualifiedNameConverter
 import org.eclipse.xtext.naming.QualifiedName
 import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
+import org.eclipse.xtext.xtext.generator.model.TypeReference
 
 import static extension org.eclipse.xtext.GrammarUtil.*
 import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
-import com.google.inject.name.Names
 
 /**
  * This fragment activates code mining functionalities and generates the appropriate stubs.
@@ -42,7 +43,7 @@ class CodeMiningFragment extends AbstractStubGeneratingFragment {
 				try {
 					Class.forName("org.eclipse.jface.text.codemining.ICodeMiningProvider");
 					binder.bind(«'org.eclipse.jface.text.codemining.ICodeMiningProvider'.typeRef».class)
-						.to(«codeMiningProviderClass.toString.typeRef».class);
+						.to(«codeMiningProviderClass».class);
 					binder.bind(«'org.eclipse.xtext.ui.editor.reconciler.IReconcileStrategyFactory'.typeRef».class).annotatedWith(«Names.typeRef».named("codeMinding"))
 						.to(«"org.eclipse.xtext.ui.codemining.XtextCodeMiningReconcileStrategy".typeRef».Factory.class);
 				} catch(«ClassNotFoundException.typeRef» ignore) {
@@ -82,23 +83,43 @@ class CodeMiningFragment extends AbstractStubGeneratingFragment {
 		}
 	}
 	
-	def protected QualifiedName getCodeMiningProviderClass () {
-		(grammar.eclipsePluginBasePackage+".codemining."+grammar.simpleName+"CodeMiningProvider").toQualifiedName
+	def protected TypeReference getCodeMiningProviderClass () {
+		(grammar.eclipsePluginBasePackage+".codemining."+grammar.simpleName+"CodeMiningProvider").toQualifiedName.toString.typeRef
 	}
 	
+	def protected TypeReference getCodeMiningProviderSuperClass() {
+		"org.eclipse.xtext.ui.codemining.AbstractXtextCodeMiningProvider".typeRef
+	}
+	
+	def protected TypeReference getBadLocationException () {
+		"org.eclipse.jface.text.BadLocationException".typeRef
+	}
+	
+	def protected TypeReference getCancelIndicator () {
+		"org.eclipse.xtext.util.CancelIndicator".typeRef
+	}
+	
+	def protected TypeReference getIAcceptor () {
+		"org.eclipse.xtext.util.IAcceptor".typeRef
+	}
+
+	def protected TypeReference getICodeMining () {
+		"org.eclipse.jface.text.codemining.ICodeMining".typeRef
+	}
+
+	def protected TypeReference getIDocument () {
+		"org.eclipse.jface.text.IDocument".typeRef
+	}
+
+	def protected TypeReference getXtextResource () {
+		"org.eclipse.xtext.resource.XtextResource".typeRef
+	}
+
 	def protected generateXtendCodeMiningProvider() {
 		fileAccessFactory.createXtendFile(codeMiningProviderClass.toString.typeRef, '''
-			import org.eclipse.jface.text.BadLocationException
-			import org.eclipse.jface.text.IDocument
-			import org.eclipse.jface.text.codemining.ICodeMining
-			import org.eclipse.xtext.resource.XtextResource
-			import org.eclipse.xtext.ui.codemining.AbstractXtextCodeMiningProvider
-			import org.eclipse.xtext.util.CancelIndicator
-			import org.eclipse.xtext.util.IAcceptor
-			
-			class «codeMiningProviderClass.lastSegment» extends AbstractXtextCodeMiningProvider {
-				override void createCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator,
-					IAcceptor<? super ICodeMining> acceptor) throws BadLocationException {
+			class «codeMiningProviderClass.simpleName» extends «codeMiningProviderSuperClass» {
+				override void createCodeMinings(«getIDocument» document, «getXtextResource» resource, «getCancelIndicator» indicator,
+					«getIAcceptor»<? super «getICodeMining»> acceptor) throws «getBadLocationException» {
 					
 					// TODO: implement me
 					// use acceptor.accept(super.createNewLineHeaderCodeMining(...)) to add a new code mining to the final list
@@ -112,19 +133,11 @@ class CodeMiningFragment extends AbstractStubGeneratingFragment {
 	
 	def protected generateJavaCodeMiningProvider() {
 		fileAccessFactory.createJavaFile(codeMiningProviderClass.toString.typeRef, '''
-			import org.eclipse.jface.text.BadLocationException;
-			import org.eclipse.jface.text.IDocument;
-			import org.eclipse.jface.text.codemining.ICodeMining;
-			import org.eclipse.xtext.resource.XtextResource;
-			import org.eclipse.xtext.ui.codemining.AbstractXtextCodeMiningProvider;
-			import org.eclipse.xtext.util.CancelIndicator;
-			import org.eclipse.xtext.util.IAcceptor;
-			
 			@SuppressWarnings("restriction")
-			public class «codeMiningProviderClass.lastSegment» extends AbstractXtextCodeMiningProvider {
+			public class «codeMiningProviderClass.simpleName» extends «codeMiningProviderSuperClass» {
 				@Override
-				protected void createCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator,
-					IAcceptor<? super ICodeMining> acceptor) throws BadLocationException {
+				protected void createCodeMinings(«getIDocument» document, «getXtextResource» resource, «getCancelIndicator» indicator,
+					«getIAcceptor»<? super «getICodeMining»> acceptor) throws «getBadLocationException» {
 					
 					// TODO: implement me
 					// use acceptor.accept(super.createNewLineHeaderCodeMining(...)) to add a new code mining to the final list

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/codemining/CodeMiningFragment.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/codemining/CodeMiningFragment.xtend
@@ -22,8 +22,10 @@ import com.google.inject.name.Names
 
 /**
  * This fragment activates code mining functionalities and generates the appropriate stubs.
- * @since 2.14
+ * 
  * @author René Purrio - Initial contribution and API
+ * @author Karsten Thoms - Review and improvements on initial implementation
+ * @since 2.14
  */
 @Beta
 class CodeMiningFragment extends AbstractStubGeneratingFragment {
@@ -90,27 +92,19 @@ class CodeMiningFragment extends AbstractStubGeneratingFragment {
 			import org.eclipse.jface.text.IDocument
 			import org.eclipse.jface.text.codemining.ICodeMining
 			import org.eclipse.xtext.resource.XtextResource
-			import org.eclipse.xtext.ui.codemining.XtextCodeMiningProvider
+			import org.eclipse.xtext.ui.codemining.AbstractXtextCodeMiningProvider
 			import org.eclipse.xtext.util.CancelIndicator
 			import org.eclipse.xtext.util.IAcceptor
 			
-			class «codeMiningProviderClass.lastSegment» extends XtextCodeMiningProvider {
-				override void createLineHeaderCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator, IAcceptor<ICodeMining> acceptor) throws BadLocationException{
+			class «codeMiningProviderClass.lastSegment» extends AbstractXtextCodeMiningProvider {
+				override void createCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator,
+					IAcceptor<? super ICodeMining> acceptor) throws BadLocationException {
 					
-					//TODO: implement me
-					//use acceptor.accept(super.createNewLineHeaderCodeMining(...)) to add a new code mining to the final list
+					// TODO: implement me
+					// use acceptor.accept(super.createNewLineHeaderCodeMining(...)) to add a new code mining to the final list
 					
-					//example:
-					//acceptor.accept(createNewLineHeaderCodeMining(1, document, "Header annotation"))
-				}
-				
-				override void createLineContentCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator, IAcceptor<ICodeMining> acceptor)  throws BadLocationException {
-					
-					//TODO: implement me
-					//use acceptor.accept(super.createNewLineContentCodeMining(...)) to add a new code mining to the final list
-					
-					//example:
-					//acceptor.accept(createNewLineContentCodeMining(5, " Inline annotation "))
+					// example:
+					// acceptor.accept(createNewLineHeaderCodeMining(1, document, "Header annotation"))
 				}
 			}
 		''').writeTo(projectConfig.eclipsePlugin.src)
@@ -122,30 +116,21 @@ class CodeMiningFragment extends AbstractStubGeneratingFragment {
 			import org.eclipse.jface.text.IDocument;
 			import org.eclipse.jface.text.codemining.ICodeMining;
 			import org.eclipse.xtext.resource.XtextResource;
-			import org.eclipse.xtext.ui.codemining.XtextCodeMiningProvider;
+			import org.eclipse.xtext.ui.codemining.AbstractXtextCodeMiningProvider;
 			import org.eclipse.xtext.util.CancelIndicator;
 			import org.eclipse.xtext.util.IAcceptor;
 			
 			@SuppressWarnings("restriction")
-			public class «codeMiningProviderClass.lastSegment» extends XtextCodeMiningProvider {
+			public class «codeMiningProviderClass.lastSegment» extends AbstractXtextCodeMiningProvider {
 				@Override
-				protected void createLineHeaderCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator, IAcceptor<ICodeMining> acceptor) throws BadLocationException{
+				protected void createCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator,
+					IAcceptor<? super ICodeMining> acceptor) throws BadLocationException {
 					
-					//TODO: implement me
-					//use acceptor.accept(super.createNewLineHeaderCodeMining(...)) to add a new code mining to the final list
+					// TODO: implement me
+					// use acceptor.accept(super.createNewLineHeaderCodeMining(...)) to add a new code mining to the final list
 					
-					//example:
-					//acceptor.accept(createNewLineHeaderCodeMining(1, document, "Header annotation"));
-				}
-				
-				@Override
-				protected void createLineContentCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator, IAcceptor<ICodeMining> acceptor)  throws BadLocationException {
-					
-					//TODO: implement me
-					//use acceptor.accept(super.createNewLineContentCodeMining(...)) to add a new code mining to the final list
-					
-					//example:
-					//acceptor.accept(createNewLineContentCodeMining(5, " Inline annotation "));
+					// example:
+					// acceptor.accept(createNewLineHeaderCodeMining(1, document, "Header annotation"));
 				}
 			}
 		''').writeTo(projectConfig.eclipsePlugin.src)

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/codemining/CodeMiningFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/codemining/CodeMiningFragment.java
@@ -16,7 +16,6 @@ import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.GrammarUtil;
 import org.eclipse.xtext.naming.IQualifiedNameConverter;
-import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
@@ -75,28 +74,28 @@ public class CodeMiningFragment extends AbstractStubGeneratingFragment {
           _builder.newLineIfNotEmpty();
           _builder.append("\t\t");
           _builder.append(".to(");
-          TypeReference _typeRef_1 = TypeReference.typeRef(CodeMiningFragment.this.getCodeMiningProviderClass().toString());
-          _builder.append(_typeRef_1, "\t\t");
+          TypeReference _codeMiningProviderClass = CodeMiningFragment.this.getCodeMiningProviderClass();
+          _builder.append(_codeMiningProviderClass, "\t\t");
           _builder.append(".class);");
           _builder.newLineIfNotEmpty();
           _builder.append("\t");
           _builder.append("binder.bind(");
-          TypeReference _typeRef_2 = TypeReference.typeRef("org.eclipse.xtext.ui.editor.reconciler.IReconcileStrategyFactory");
-          _builder.append(_typeRef_2, "\t");
+          TypeReference _typeRef_1 = TypeReference.typeRef("org.eclipse.xtext.ui.editor.reconciler.IReconcileStrategyFactory");
+          _builder.append(_typeRef_1, "\t");
           _builder.append(".class).annotatedWith(");
-          TypeReference _typeRef_3 = TypeReference.typeRef(Names.class);
-          _builder.append(_typeRef_3, "\t");
+          TypeReference _typeRef_2 = TypeReference.typeRef(Names.class);
+          _builder.append(_typeRef_2, "\t");
           _builder.append(".named(\"codeMinding\"))");
           _builder.newLineIfNotEmpty();
           _builder.append("\t\t");
           _builder.append(".to(");
-          TypeReference _typeRef_4 = TypeReference.typeRef("org.eclipse.xtext.ui.codemining.XtextCodeMiningReconcileStrategy");
-          _builder.append(_typeRef_4, "\t\t");
+          TypeReference _typeRef_3 = TypeReference.typeRef("org.eclipse.xtext.ui.codemining.XtextCodeMiningReconcileStrategy");
+          _builder.append(_typeRef_3, "\t\t");
           _builder.append(".Factory.class);");
           _builder.newLineIfNotEmpty();
           _builder.append("} catch(");
-          TypeReference _typeRef_5 = TypeReference.typeRef(ClassNotFoundException.class);
-          _builder.append(_typeRef_5);
+          TypeReference _typeRef_4 = TypeReference.typeRef(ClassNotFoundException.class);
+          _builder.append(_typeRef_4);
           _builder.append(" ignore) {");
           _builder.newLineIfNotEmpty();
           _builder.append("\t");
@@ -188,12 +187,40 @@ public class CodeMiningFragment extends AbstractStubGeneratingFragment {
     }
   }
   
-  protected QualifiedName getCodeMiningProviderClass() {
+  protected TypeReference getCodeMiningProviderClass() {
     String _eclipsePluginBasePackage = this._xtextGeneratorNaming.getEclipsePluginBasePackage(this.getGrammar());
     String _plus = (_eclipsePluginBasePackage + ".codemining.");
     String _simpleName = GrammarUtil.getSimpleName(this.getGrammar());
     String _plus_1 = (_plus + _simpleName);
-    return this._iQualifiedNameConverter.toQualifiedName((_plus_1 + "CodeMiningProvider"));
+    return TypeReference.typeRef(this._iQualifiedNameConverter.toQualifiedName((_plus_1 + "CodeMiningProvider")).toString());
+  }
+  
+  protected TypeReference getCodeMiningProviderSuperClass() {
+    return TypeReference.typeRef("org.eclipse.xtext.ui.codemining.AbstractXtextCodeMiningProvider");
+  }
+  
+  protected TypeReference getBadLocationException() {
+    return TypeReference.typeRef("org.eclipse.jface.text.BadLocationException");
+  }
+  
+  protected TypeReference getCancelIndicator() {
+    return TypeReference.typeRef("org.eclipse.xtext.util.CancelIndicator");
+  }
+  
+  protected TypeReference getIAcceptor() {
+    return TypeReference.typeRef("org.eclipse.xtext.util.IAcceptor");
+  }
+  
+  protected TypeReference getICodeMining() {
+    return TypeReference.typeRef("org.eclipse.jface.text.codemining.ICodeMining");
+  }
+  
+  protected TypeReference getIDocument() {
+    return TypeReference.typeRef("org.eclipse.jface.text.IDocument");
+  }
+  
+  protected TypeReference getXtextResource() {
+    return TypeReference.typeRef("org.eclipse.xtext.resource.XtextResource");
   }
   
   protected void generateXtendCodeMiningProvider() {
@@ -201,32 +228,37 @@ public class CodeMiningFragment extends AbstractStubGeneratingFragment {
     StringConcatenationClient _client = new StringConcatenationClient() {
       @Override
       protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-        _builder.append("import org.eclipse.jface.text.BadLocationException");
-        _builder.newLine();
-        _builder.append("import org.eclipse.jface.text.IDocument");
-        _builder.newLine();
-        _builder.append("import org.eclipse.jface.text.codemining.ICodeMining");
-        _builder.newLine();
-        _builder.append("import org.eclipse.xtext.resource.XtextResource");
-        _builder.newLine();
-        _builder.append("import org.eclipse.xtext.ui.codemining.AbstractXtextCodeMiningProvider");
-        _builder.newLine();
-        _builder.append("import org.eclipse.xtext.util.CancelIndicator");
-        _builder.newLine();
-        _builder.append("import org.eclipse.xtext.util.IAcceptor");
-        _builder.newLine();
-        _builder.newLine();
         _builder.append("class ");
-        String _lastSegment = CodeMiningFragment.this.getCodeMiningProviderClass().getLastSegment();
-        _builder.append(_lastSegment);
-        _builder.append(" extends AbstractXtextCodeMiningProvider {");
+        String _simpleName = CodeMiningFragment.this.getCodeMiningProviderClass().getSimpleName();
+        _builder.append(_simpleName);
+        _builder.append(" extends ");
+        TypeReference _codeMiningProviderSuperClass = CodeMiningFragment.this.getCodeMiningProviderSuperClass();
+        _builder.append(_codeMiningProviderSuperClass);
+        _builder.append(" {");
         _builder.newLineIfNotEmpty();
         _builder.append("\t");
-        _builder.append("override void createCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator,");
-        _builder.newLine();
+        _builder.append("override void createCodeMinings(");
+        TypeReference _iDocument = CodeMiningFragment.this.getIDocument();
+        _builder.append(_iDocument, "\t");
+        _builder.append(" document, ");
+        TypeReference _xtextResource = CodeMiningFragment.this.getXtextResource();
+        _builder.append(_xtextResource, "\t");
+        _builder.append(" resource, ");
+        TypeReference _cancelIndicator = CodeMiningFragment.this.getCancelIndicator();
+        _builder.append(_cancelIndicator, "\t");
+        _builder.append(" indicator,");
+        _builder.newLineIfNotEmpty();
         _builder.append("\t\t");
-        _builder.append("IAcceptor<? super ICodeMining> acceptor) throws BadLocationException {");
-        _builder.newLine();
+        TypeReference _iAcceptor = CodeMiningFragment.this.getIAcceptor();
+        _builder.append(_iAcceptor, "\t\t");
+        _builder.append("<? super ");
+        TypeReference _iCodeMining = CodeMiningFragment.this.getICodeMining();
+        _builder.append(_iCodeMining, "\t\t");
+        _builder.append("> acceptor) throws ");
+        TypeReference _badLocationException = CodeMiningFragment.this.getBadLocationException();
+        _builder.append(_badLocationException, "\t\t");
+        _builder.append(" {");
+        _builder.newLineIfNotEmpty();
         _builder.append("\t\t");
         _builder.newLine();
         _builder.append("\t\t");
@@ -258,37 +290,42 @@ public class CodeMiningFragment extends AbstractStubGeneratingFragment {
     StringConcatenationClient _client = new StringConcatenationClient() {
       @Override
       protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-        _builder.append("import org.eclipse.jface.text.BadLocationException;");
-        _builder.newLine();
-        _builder.append("import org.eclipse.jface.text.IDocument;");
-        _builder.newLine();
-        _builder.append("import org.eclipse.jface.text.codemining.ICodeMining;");
-        _builder.newLine();
-        _builder.append("import org.eclipse.xtext.resource.XtextResource;");
-        _builder.newLine();
-        _builder.append("import org.eclipse.xtext.ui.codemining.AbstractXtextCodeMiningProvider;");
-        _builder.newLine();
-        _builder.append("import org.eclipse.xtext.util.CancelIndicator;");
-        _builder.newLine();
-        _builder.append("import org.eclipse.xtext.util.IAcceptor;");
-        _builder.newLine();
-        _builder.newLine();
         _builder.append("@SuppressWarnings(\"restriction\")");
         _builder.newLine();
         _builder.append("public class ");
-        String _lastSegment = CodeMiningFragment.this.getCodeMiningProviderClass().getLastSegment();
-        _builder.append(_lastSegment);
-        _builder.append(" extends AbstractXtextCodeMiningProvider {");
+        String _simpleName = CodeMiningFragment.this.getCodeMiningProviderClass().getSimpleName();
+        _builder.append(_simpleName);
+        _builder.append(" extends ");
+        TypeReference _codeMiningProviderSuperClass = CodeMiningFragment.this.getCodeMiningProviderSuperClass();
+        _builder.append(_codeMiningProviderSuperClass);
+        _builder.append(" {");
         _builder.newLineIfNotEmpty();
         _builder.append("\t");
         _builder.append("@Override");
         _builder.newLine();
         _builder.append("\t");
-        _builder.append("protected void createCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator,");
-        _builder.newLine();
+        _builder.append("protected void createCodeMinings(");
+        TypeReference _iDocument = CodeMiningFragment.this.getIDocument();
+        _builder.append(_iDocument, "\t");
+        _builder.append(" document, ");
+        TypeReference _xtextResource = CodeMiningFragment.this.getXtextResource();
+        _builder.append(_xtextResource, "\t");
+        _builder.append(" resource, ");
+        TypeReference _cancelIndicator = CodeMiningFragment.this.getCancelIndicator();
+        _builder.append(_cancelIndicator, "\t");
+        _builder.append(" indicator,");
+        _builder.newLineIfNotEmpty();
         _builder.append("\t\t");
-        _builder.append("IAcceptor<? super ICodeMining> acceptor) throws BadLocationException {");
-        _builder.newLine();
+        TypeReference _iAcceptor = CodeMiningFragment.this.getIAcceptor();
+        _builder.append(_iAcceptor, "\t\t");
+        _builder.append("<? super ");
+        TypeReference _iCodeMining = CodeMiningFragment.this.getICodeMining();
+        _builder.append(_iCodeMining, "\t\t");
+        _builder.append("> acceptor) throws ");
+        TypeReference _badLocationException = CodeMiningFragment.this.getBadLocationException();
+        _builder.append(_badLocationException, "\t\t");
+        _builder.append(" {");
+        _builder.newLineIfNotEmpty();
         _builder.append("\t\t");
         _builder.newLine();
         _builder.append("\t\t");

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/codemining/CodeMiningFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/codemining/CodeMiningFragment.java
@@ -30,8 +30,10 @@ import org.eclipse.xtext.xtext.generator.model.TypeReference;
 
 /**
  * This fragment activates code mining functionalities and generates the appropriate stubs.
- * @since 2.14
+ * 
  * @author René Purrio - Initial contribution and API
+ * @author Karsten Thoms - Review and improvements on initial implementation
+ * @since 2.14
  */
 @Beta
 @SuppressWarnings("all")
@@ -207,7 +209,7 @@ public class CodeMiningFragment extends AbstractStubGeneratingFragment {
         _builder.newLine();
         _builder.append("import org.eclipse.xtext.resource.XtextResource");
         _builder.newLine();
-        _builder.append("import org.eclipse.xtext.ui.codemining.XtextCodeMiningProvider");
+        _builder.append("import org.eclipse.xtext.ui.codemining.AbstractXtextCodeMiningProvider");
         _builder.newLine();
         _builder.append("import org.eclipse.xtext.util.CancelIndicator");
         _builder.newLine();
@@ -217,50 +219,29 @@ public class CodeMiningFragment extends AbstractStubGeneratingFragment {
         _builder.append("class ");
         String _lastSegment = CodeMiningFragment.this.getCodeMiningProviderClass().getLastSegment();
         _builder.append(_lastSegment);
-        _builder.append(" extends XtextCodeMiningProvider {");
+        _builder.append(" extends AbstractXtextCodeMiningProvider {");
         _builder.newLineIfNotEmpty();
         _builder.append("\t");
-        _builder.append("override void createLineHeaderCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator, IAcceptor<ICodeMining> acceptor) throws BadLocationException{");
+        _builder.append("override void createCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator,");
+        _builder.newLine();
+        _builder.append("\t\t");
+        _builder.append("IAcceptor<? super ICodeMining> acceptor) throws BadLocationException {");
         _builder.newLine();
         _builder.append("\t\t");
         _builder.newLine();
         _builder.append("\t\t");
-        _builder.append("//TODO: implement me");
+        _builder.append("// TODO: implement me");
         _builder.newLine();
         _builder.append("\t\t");
-        _builder.append("//use acceptor.accept(super.createNewLineHeaderCodeMining(...)) to add a new code mining to the final list");
-        _builder.newLine();
-        _builder.append("\t\t");
-        _builder.newLine();
-        _builder.append("\t\t");
-        _builder.append("//example:");
-        _builder.newLine();
-        _builder.append("\t\t");
-        _builder.append("//acceptor.accept(createNewLineHeaderCodeMining(1, document, \"Header annotation\"))");
-        _builder.newLine();
-        _builder.append("\t");
-        _builder.append("}");
-        _builder.newLine();
-        _builder.append("\t");
-        _builder.newLine();
-        _builder.append("\t");
-        _builder.append("override void createLineContentCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator, IAcceptor<ICodeMining> acceptor)  throws BadLocationException {");
+        _builder.append("// use acceptor.accept(super.createNewLineHeaderCodeMining(...)) to add a new code mining to the final list");
         _builder.newLine();
         _builder.append("\t\t");
         _builder.newLine();
         _builder.append("\t\t");
-        _builder.append("//TODO: implement me");
+        _builder.append("// example:");
         _builder.newLine();
         _builder.append("\t\t");
-        _builder.append("//use acceptor.accept(super.createNewLineContentCodeMining(...)) to add a new code mining to the final list");
-        _builder.newLine();
-        _builder.append("\t\t");
-        _builder.newLine();
-        _builder.append("\t\t");
-        _builder.append("//example:");
-        _builder.newLine();
-        _builder.append("\t\t");
-        _builder.append("//acceptor.accept(createNewLineContentCodeMining(5, \" Inline annotation \"))");
+        _builder.append("// acceptor.accept(createNewLineHeaderCodeMining(1, document, \"Header annotation\"))");
         _builder.newLine();
         _builder.append("\t");
         _builder.append("}");
@@ -285,7 +266,7 @@ public class CodeMiningFragment extends AbstractStubGeneratingFragment {
         _builder.newLine();
         _builder.append("import org.eclipse.xtext.resource.XtextResource;");
         _builder.newLine();
-        _builder.append("import org.eclipse.xtext.ui.codemining.XtextCodeMiningProvider;");
+        _builder.append("import org.eclipse.xtext.ui.codemining.AbstractXtextCodeMiningProvider;");
         _builder.newLine();
         _builder.append("import org.eclipse.xtext.util.CancelIndicator;");
         _builder.newLine();
@@ -297,56 +278,32 @@ public class CodeMiningFragment extends AbstractStubGeneratingFragment {
         _builder.append("public class ");
         String _lastSegment = CodeMiningFragment.this.getCodeMiningProviderClass().getLastSegment();
         _builder.append(_lastSegment);
-        _builder.append(" extends XtextCodeMiningProvider {");
+        _builder.append(" extends AbstractXtextCodeMiningProvider {");
         _builder.newLineIfNotEmpty();
         _builder.append("\t");
         _builder.append("@Override");
         _builder.newLine();
         _builder.append("\t");
-        _builder.append("protected void createLineHeaderCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator, IAcceptor<ICodeMining> acceptor) throws BadLocationException{");
+        _builder.append("protected void createCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator,");
+        _builder.newLine();
+        _builder.append("\t\t");
+        _builder.append("IAcceptor<? super ICodeMining> acceptor) throws BadLocationException {");
         _builder.newLine();
         _builder.append("\t\t");
         _builder.newLine();
         _builder.append("\t\t");
-        _builder.append("//TODO: implement me");
+        _builder.append("// TODO: implement me");
         _builder.newLine();
         _builder.append("\t\t");
-        _builder.append("//use acceptor.accept(super.createNewLineHeaderCodeMining(...)) to add a new code mining to the final list");
-        _builder.newLine();
-        _builder.append("\t\t");
-        _builder.newLine();
-        _builder.append("\t\t");
-        _builder.append("//example:");
-        _builder.newLine();
-        _builder.append("\t\t");
-        _builder.append("//acceptor.accept(createNewLineHeaderCodeMining(1, document, \"Header annotation\"));");
-        _builder.newLine();
-        _builder.append("\t");
-        _builder.append("}");
-        _builder.newLine();
-        _builder.append("\t");
-        _builder.newLine();
-        _builder.append("\t");
-        _builder.append("@Override");
-        _builder.newLine();
-        _builder.append("\t");
-        _builder.append("protected void createLineContentCodeMinings(IDocument document, XtextResource resource, CancelIndicator indicator, IAcceptor<ICodeMining> acceptor)  throws BadLocationException {");
+        _builder.append("// use acceptor.accept(super.createNewLineHeaderCodeMining(...)) to add a new code mining to the final list");
         _builder.newLine();
         _builder.append("\t\t");
         _builder.newLine();
         _builder.append("\t\t");
-        _builder.append("//TODO: implement me");
+        _builder.append("// example:");
         _builder.newLine();
         _builder.append("\t\t");
-        _builder.append("//use acceptor.accept(super.createNewLineContentCodeMining(...)) to add a new code mining to the final list");
-        _builder.newLine();
-        _builder.append("\t\t");
-        _builder.newLine();
-        _builder.append("\t\t");
-        _builder.append("//example:");
-        _builder.newLine();
-        _builder.append("\t\t");
-        _builder.append("//acceptor.accept(createNewLineContentCodeMining(5, \" Inline annotation \"));");
+        _builder.append("// acceptor.accept(createNewLineHeaderCodeMining(1, document, \"Header annotation\"));");
         _builder.newLine();
         _builder.append("\t");
         _builder.append("}");


### PR DESCRIPTION
The code mining provider base class has been renamed and only offers one
abstract method to implement by clients.
Also some minor cleanups.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>