### PR TITLE
[eclipse/xtext-eclipse#616] Use more efficient algorithm.

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/contentassist/CompletionPrefixProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/contentassist/CompletionPrefixProvider.java
@@ -9,13 +9,12 @@ package org.eclipse.xtext.ide.editor.contentassist;
 
 import org.eclipse.xtext.AbstractElement;
 import org.eclipse.xtext.ParserRule;
-import org.eclipse.xtext.nodemodel.BidiTreeIterator;
+import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.ILeafNode;
 import org.eclipse.xtext.nodemodel.INode;
 
 /**
- * Small utility to extract the parsable content of a document when 
- * content assist is invoked at a given location.
+ * Small utility to extract the parsable content of a document when content assist is invoked at a given location.
  * 
  * @author Sebastian Zarnekow - Initial contribution and API
  * @since 2.13
@@ -23,31 +22,34 @@ import org.eclipse.xtext.nodemodel.INode;
 public class CompletionPrefixProvider {
 
 	/**
-	 * Standard languages only need to parse the text up to the last hidden token sequence
-	 * in the document. Thus the string from start to the normalized offset is sufficient.
+	 * Standard languages only need to parse the text up to the last hidden token sequence in the document. Thus the
+	 * string from start to the normalized offset is sufficient.
 	 */
 	public String getInputToParse(String completeInput, int offset, int completionOffset) {
 		return completeInput.substring(0, offset);
 	}
-	
+
 	/**
-	 * Returns the last node that appears to be part of the prefix. This will be used to determine
-	 * the current model object that'll be the most special context instance in the proposal provider.
+	 * Returns the last node that appears to be part of the prefix. This will be used to determine the current model
+	 * object that'll be the most special context instance in the proposal provider.
 	 */
-	public INode getLastCompleteNodeByOffset(INode node, int offset, int completionOffset) {
-		BidiTreeIterator<INode> iterator = node.getRootNode().getAsTreeIterable().iterator();
-		INode result = node;
-		while (iterator.hasNext()) {
-			INode candidate = iterator.next();
-			if (candidate.getOffset() >= offset) {
-				break;
-			} else if ((candidate instanceof ILeafNode) && (candidate.getGrammarElement() == null
-					|| candidate.getGrammarElement() instanceof AbstractElement
-					|| candidate.getGrammarElement() instanceof ParserRule)) {
-				result = candidate;
+	public INode getLastCompleteNodeByOffset(INode node, int offsetPosition, int completionOffset) {
+		return internalGetLastCompleteNodeByOffset(node.getRootNode(), offsetPosition);
+	}
+
+	private INode internalGetLastCompleteNodeByOffset(ICompositeNode node, int offsetPosition) {
+		for (INode child : node.getChildren().reverse()) {
+			if (child.getOffset() < offsetPosition) {
+				if (child instanceof ICompositeNode) {
+					return internalGetLastCompleteNodeByOffset((ICompositeNode) child, offsetPosition);
+				} else if ((child instanceof ILeafNode)
+						&& (child.getGrammarElement() == null || child.getGrammarElement() instanceof AbstractElement
+								|| child.getGrammarElement() instanceof ParserRule)) {
+					return child;
+				}
 			}
 		}
-		return result;
+		return node;
 	}
-	
+
 }


### PR DESCRIPTION
Do a depth first traversal the node model in reversed direction and stop
at the first found node before the current offset with specific
properties. This way complete composite nodes can be skipped. This
changes the algorithm complexity from n to log(n) in most cases
(degenerated case ... flat node model).

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>