### PR TITLE
[479833] Formatter2Fragment2 stub improvements.

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/AbstractGeneratorFragmentTests.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/AbstractGeneratorFragmentTests.xtend
@@ -42,6 +42,7 @@ import org.junit.Before
 abstract class AbstractGeneratorFragmentTests extends AbstractXtextTests {
 	
 	GlobalStateMemento globalStateMemento;
+	var static StandardLanguage lang
 	
 	@Before
 	override setUp() {
@@ -73,7 +74,7 @@ abstract class AbstractGeneratorFragmentTests extends AbstractXtextTests {
 		}
 
 		override configureXtextProjectConfig(Binder binder) {
-			val lang = new StandardLanguage
+			lang = new StandardLanguage
 			lang.initialize(grammar)
 			binder.bind(IXtextGeneratorLanguage).toInstance(lang)
 		}
@@ -134,6 +135,7 @@ abstract class AbstractGeneratorFragmentTests extends AbstractXtextTests {
 		emfGeneratorFragment.initialize(generatorInjector)
 		// Create GenModel out of generated EPackages
 		emfGeneratorFragment.getSaveAndReconcileGenModel(grammar, transformer.generatedPackages, resource.resourceSet)
+		lang.resourceSet = resource.resourceSet
 		return generatorInjector.getInstance(fragmentClass);
 	}
 	

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractGeneratorFragmentTests.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractGeneratorFragmentTests.java
@@ -70,9 +70,10 @@ public abstract class AbstractGeneratorFragmentTests extends AbstractXtextTests 
     
     @Override
     public void configureXtextProjectConfig(final Binder binder) {
-      final StandardLanguage lang = new StandardLanguage();
-      lang.initialize(this.grammar);
-      binder.<IXtextGeneratorLanguage>bind(IXtextGeneratorLanguage.class).toInstance(lang);
+      StandardLanguage _standardLanguage = new StandardLanguage();
+      AbstractGeneratorFragmentTests.lang = _standardLanguage;
+      AbstractGeneratorFragmentTests.lang.initialize(this.grammar);
+      binder.<IXtextGeneratorLanguage>bind(IXtextGeneratorLanguage.class).toInstance(AbstractGeneratorFragmentTests.lang);
     }
     
     public void configureIXtextProjectConfig(final Binder binder) {
@@ -125,6 +126,8 @@ public abstract class AbstractGeneratorFragmentTests extends AbstractXtextTests 
   
   private GlobalRegistries.GlobalStateMemento globalStateMemento;
   
+  private static StandardLanguage lang;
+  
   @Before
   @Override
   public void setUp() {
@@ -163,6 +166,7 @@ public abstract class AbstractGeneratorFragmentTests extends AbstractXtextTests 
       final AbstractGeneratorFragmentTests.FakeEMFGeneratorFragment2 emfGeneratorFragment = generatorInjector.<AbstractGeneratorFragmentTests.FakeEMFGeneratorFragment2>getInstance(AbstractGeneratorFragmentTests.FakeEMFGeneratorFragment2.class);
       emfGeneratorFragment.initialize(generatorInjector);
       emfGeneratorFragment.getSaveAndReconcileGenModel(grammar, transformer.getGeneratedPackages(), resource.getResourceSet());
+      AbstractGeneratorFragmentTests.lang.setResourceSet(resource.getResourceSet());
       return generatorInjector.<T>getInstance(fragmentClass);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/Formatter2Fragment2Test.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/Formatter2Fragment2Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,9 +11,12 @@ import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.ENamedElement;
 import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.eclipse.xtext.xtext.generator.AbstractGeneratorFragmentTests;
 import org.eclipse.xtext.xtext.generator.formatting.Formatter2Fragment2;
+import org.eclipse.xtext.xtext.generator.model.XtendFileAccess;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -21,11 +24,16 @@ import org.junit.Test;
  * @author Lorenzo Bettini - Initial contribution and API
  */
 @SuppressWarnings("all")
-public class Formatter2Fragment2Test {
+public class Formatter2Fragment2Test extends AbstractGeneratorFragmentTests {
   public static class TestableFormatter2Fragment2 extends Formatter2Fragment2 {
     @Override
     public String toVarName(final ENamedElement element, final String... reservedNames) {
       return super.toVarName(element, reservedNames);
+    }
+    
+    @Override
+    public XtendFileAccess doGetXtendStubFile() {
+      return super.doGetXtendStubFile();
     }
   }
   
@@ -64,5 +72,178 @@ public class Formatter2Fragment2Test {
   @Test
   public void testVarNameConflictingWithXtendKeywordAndParam() {
     Assert.assertEquals("__abstract", this.fragment.toVarName(EcorePackage.eINSTANCE.getEClass_Abstract(), "_abstract"));
+  }
+  
+  @Test
+  public void testFormatMethodGeneration01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder.newLine();
+    _builder.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder.newLine();
+    _builder.append("Model:");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("greetings+=Greeting*;");
+    _builder.newLine();
+    _builder.append("Greeting:");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("\'Hello\' name=ID \'!\';");
+    _builder.newLine();
+    this.fragment = this.<Formatter2Fragment2Test.TestableFormatter2Fragment2>initializeFragmentWithGrammarFromString(Formatter2Fragment2Test.TestableFormatter2Fragment2.class, _builder.toString());
+    final String actual = this.concatenationClientToString(this.fragment.doGetXtendStubFile());
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package org.xtext.example.mydsl.formatting2");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("import com.google.inject.Inject");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.formatting2.AbstractFormatter2");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.formatting2.IFormattableDocument");
+    _builder_1.newLine();
+    _builder_1.append("import org.xtext.example.mydsl.myDsl.Model");
+    _builder_1.newLine();
+    _builder_1.append("import org.xtext.example.mydsl.services.MyDslGrammarAccess");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("class MyDslFormatter extends AbstractFormatter2 {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("@Inject extension MyDslGrammarAccess");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def dispatch void format(Model model, extension IFormattableDocument document) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("// TODO: format HiddenRegions around keywords, attributes, cross references, etc. ");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("for (greeting : model.greetings) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("greeting.format");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("// TODO: implement for ");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    final String expected = _builder_1.toString();
+    Assert.assertEquals(expected, actual);
+  }
+  
+  @Test
+  public void testFormatMethodGeneration02() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder.newLine();
+    _builder.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder.newLine();
+    _builder.append("Model:");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("greetings+=Greeting*");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("description=Description;");
+    _builder.newLine();
+    _builder.append("Greeting:");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("\'Hello\' person=Person \'!\';");
+    _builder.newLine();
+    _builder.append("Person:");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("firstname=ID lastname=ID;");
+    _builder.newLine();
+    _builder.append("Description:");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("text=STRING;");
+    _builder.newLine();
+    this.fragment = this.<Formatter2Fragment2Test.TestableFormatter2Fragment2>initializeFragmentWithGrammarFromString(Formatter2Fragment2Test.TestableFormatter2Fragment2.class, _builder.toString());
+    final String actual = this.concatenationClientToString(this.fragment.doGetXtendStubFile());
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package org.xtext.example.mydsl.formatting2");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("import com.google.inject.Inject");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.formatting2.AbstractFormatter2");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.formatting2.IFormattableDocument");
+    _builder_1.newLine();
+    _builder_1.append("import org.xtext.example.mydsl.myDsl.Greeting");
+    _builder_1.newLine();
+    _builder_1.append("import org.xtext.example.mydsl.myDsl.Model");
+    _builder_1.newLine();
+    _builder_1.append("import org.xtext.example.mydsl.services.MyDslGrammarAccess");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("class MyDslFormatter extends AbstractFormatter2 {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("@Inject extension MyDslGrammarAccess");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def dispatch void format(Model model, extension IFormattableDocument document) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("// TODO: format HiddenRegions around keywords, attributes, cross references, etc. ");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("for (greeting : model.greetings) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("greeting.format");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("model.description.format");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def dispatch void format(Greeting greeting, extension IFormattableDocument document) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("// TODO: format HiddenRegions around keywords, attributes, cross references, etc. ");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("greeting.person.format");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("// TODO: implement for ");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    final String expected = _builder_1.toString();
+    Assert.assertEquals(expected, actual);
   }
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -69,8 +69,13 @@ import org.eclipse.xtext.util.internal.Log
 	}
 
 	protected def doGenerateStubFile() {
+		val xtendFile = doGetXtendStubFile
+		xtendFile?.writeTo(projectConfig.runtime.src)
+	}
+
+	protected def doGetXtendStubFile() {
 		if(!isGenerateStub)
-			return;
+			return null
 			
 		if(isGenerateXtendStub) {
 			val xtendFile = fileAccessFactory.createXtendFile(grammar.formatter2Stub)
@@ -94,10 +99,12 @@ import org.eclipse.xtext.util.internal.Log
 					// TODO: implement for «types.drop(2).map[name].join(", ")»
 				}
 			'''
-			xtendFile.writeTo(projectConfig.runtime.src) 
+			return xtendFile
 		} else {
 			LOG.error(this.class.name + " has been configured to generate a Java stub, but that's not yet supported. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=481563")	
 		}
+		
+		null
 	}
 	
 	protected def StringConcatenationClient generateFormatMethod(EClass clazz, Collection<EReference> containmentRefs, boolean isOverriding) '''
@@ -105,11 +112,11 @@ import org.eclipse.xtext.util.internal.Log
 			// TODO: format HiddenRegions around keywords, attributes, cross references, etc. 
 			«FOR ref:containmentRefs»
 				«IF ref.isMany»
-					for («ref.EReferenceType» «ref.toVarName(clazz.toVarName, "document")» : «clazz.toVarName».«ref.getGetAccessor()»()) {
-						«ref.toVarName(clazz.toVarName, "document")».format;
+					for («ref.toVarName(clazz.toVarName, "document")» : «clazz.toVarName».«ref.getGetAccessor()») {
+						«ref.toVarName(clazz.toVarName, "document")».format
 					}
 				«ELSE»
-					«clazz.toVarName».«ref.getGetAccessor()».format;
+					«clazz.toVarName».«ref.getGetAccessor()».format
 				«ENDIF»
 			«ENDFOR»
 		}
@@ -172,7 +179,7 @@ import org.eclipse.xtext.util.internal.Log
 	}
 	
 	protected def String getGetAccessor(EStructuralFeature feature) {
-		GenModelUtil2.getGenFeature(feature, language.resourceSet).getAccessor
+		GenModelUtil2.getGenFeature(feature, language.resourceSet).name
 	}
 	
 }

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -107,71 +107,83 @@ public class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
   }
   
   protected void doGenerateStubFile() {
-    boolean _isGenerateStub = this.isGenerateStub();
-    boolean _not = (!_isGenerateStub);
-    if (_not) {
-      return;
-    }
-    boolean _isGenerateXtendStub = this.isGenerateXtendStub();
-    if (_isGenerateXtendStub) {
-      final XtendFileAccess xtendFile = this.fileAccessFactory.createXtendFile(this.getFormatter2Stub(this.getGrammar()));
-      xtendFile.setResourceSet(this.getLanguage().getResourceSet());
-      final LinkedHashMultimap<EClass, EReference> type2ref = LinkedHashMultimap.<EClass, EReference>create();
-      this.getLocallyAssignedContainmentReferences(this.getLanguage().getGrammar(), type2ref);
-      final LinkedHashMultimap<EClass, EReference> inheritedTypes = LinkedHashMultimap.<EClass, EReference>create();
-      this.getInheritedContainmentReferences(this.getLanguage().getGrammar(), inheritedTypes, CollectionLiterals.<Grammar>newHashSet());
-      final Set<EClass> types = type2ref.keySet();
-      StringConcatenationClient _client = new StringConcatenationClient() {
-        @Override
-        protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-          _builder.append("class ");
-          String _simpleName = Formatter2Fragment2.this.getFormatter2Stub(Formatter2Fragment2.this.getGrammar()).getSimpleName();
-          _builder.append(_simpleName);
-          _builder.append(" extends ");
-          TypeReference _stubSuperClass = Formatter2Fragment2.this.getStubSuperClass();
-          _builder.append(_stubSuperClass);
-          _builder.append(" {");
-          _builder.newLineIfNotEmpty();
-          _builder.append("\t");
-          _builder.newLine();
-          _builder.append("\t");
-          _builder.append("@");
-          _builder.append(Inject.class, "\t");
-          _builder.append(" extension ");
-          TypeReference _grammarAccess = Formatter2Fragment2.this._grammarAccessExtensions.getGrammarAccess(Formatter2Fragment2.this.getGrammar());
-          _builder.append(_grammarAccess, "\t");
-          _builder.newLineIfNotEmpty();
-          {
-            Iterable<EClass> _take = IterableExtensions.<EClass>take(types, 2);
-            for(final EClass type : _take) {
-              _builder.newLine();
-              _builder.append("\t");
-              StringConcatenationClient _generateFormatMethod = Formatter2Fragment2.this.generateFormatMethod(type, type2ref.get(type), inheritedTypes.containsKey(type));
-              _builder.append(_generateFormatMethod, "\t");
-              _builder.newLineIfNotEmpty();
-            }
-          }
-          _builder.append("\t");
-          _builder.newLine();
-          _builder.append("\t");
-          _builder.append("// TODO: implement for ");
-          final Function1<EClass, String> _function = (EClass it) -> {
-            return it.getName();
-          };
-          String _join = IterableExtensions.join(IterableExtensions.<EClass, String>map(IterableExtensions.<EClass>drop(types, 2), _function), ", ");
-          _builder.append(_join, "\t");
-          _builder.newLineIfNotEmpty();
-          _builder.append("}");
-          _builder.newLine();
-        }
-      };
-      xtendFile.setContent(_client);
+    final XtendFileAccess xtendFile = this.doGetXtendStubFile();
+    if (xtendFile!=null) {
       xtendFile.writeTo(this.getProjectConfig().getRuntime().getSrc());
-    } else {
-      String _name = this.getClass().getName();
-      String _plus = (_name + " has been configured to generate a Java stub, but that\'s not yet supported. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=481563");
-      Formatter2Fragment2.LOG.error(_plus);
     }
+  }
+  
+  protected XtendFileAccess doGetXtendStubFile() {
+    Object _xblockexpression = null;
+    {
+      boolean _isGenerateStub = this.isGenerateStub();
+      boolean _not = (!_isGenerateStub);
+      if (_not) {
+        return null;
+      }
+      boolean _isGenerateXtendStub = this.isGenerateXtendStub();
+      if (_isGenerateXtendStub) {
+        final XtendFileAccess xtendFile = this.fileAccessFactory.createXtendFile(this.getFormatter2Stub(this.getGrammar()));
+        xtendFile.setResourceSet(this.getLanguage().getResourceSet());
+        final LinkedHashMultimap<EClass, EReference> type2ref = LinkedHashMultimap.<EClass, EReference>create();
+        this.getLocallyAssignedContainmentReferences(this.getLanguage().getGrammar(), type2ref);
+        final LinkedHashMultimap<EClass, EReference> inheritedTypes = LinkedHashMultimap.<EClass, EReference>create();
+        this.getInheritedContainmentReferences(this.getLanguage().getGrammar(), inheritedTypes, CollectionLiterals.<Grammar>newHashSet());
+        final Set<EClass> types = type2ref.keySet();
+        StringConcatenationClient _client = new StringConcatenationClient() {
+          @Override
+          protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
+            _builder.append("class ");
+            String _simpleName = Formatter2Fragment2.this.getFormatter2Stub(Formatter2Fragment2.this.getGrammar()).getSimpleName();
+            _builder.append(_simpleName);
+            _builder.append(" extends ");
+            TypeReference _stubSuperClass = Formatter2Fragment2.this.getStubSuperClass();
+            _builder.append(_stubSuperClass);
+            _builder.append(" {");
+            _builder.newLineIfNotEmpty();
+            _builder.append("\t");
+            _builder.newLine();
+            _builder.append("\t");
+            _builder.append("@");
+            _builder.append(Inject.class, "\t");
+            _builder.append(" extension ");
+            TypeReference _grammarAccess = Formatter2Fragment2.this._grammarAccessExtensions.getGrammarAccess(Formatter2Fragment2.this.getGrammar());
+            _builder.append(_grammarAccess, "\t");
+            _builder.newLineIfNotEmpty();
+            {
+              Iterable<EClass> _take = IterableExtensions.<EClass>take(types, 2);
+              for(final EClass type : _take) {
+                _builder.newLine();
+                _builder.append("\t");
+                StringConcatenationClient _generateFormatMethod = Formatter2Fragment2.this.generateFormatMethod(type, type2ref.get(type), inheritedTypes.containsKey(type));
+                _builder.append(_generateFormatMethod, "\t");
+                _builder.newLineIfNotEmpty();
+              }
+            }
+            _builder.append("\t");
+            _builder.newLine();
+            _builder.append("\t");
+            _builder.append("// TODO: implement for ");
+            final Function1<EClass, String> _function = (EClass it) -> {
+              return it.getName();
+            };
+            String _join = IterableExtensions.join(IterableExtensions.<EClass, String>map(IterableExtensions.<EClass>drop(types, 2), _function), ", ");
+            _builder.append(_join, "\t");
+            _builder.newLineIfNotEmpty();
+            _builder.append("}");
+            _builder.newLine();
+          }
+        };
+        xtendFile.setContent(_client);
+        return xtendFile;
+      } else {
+        String _name = this.getClass().getName();
+        String _plus = (_name + " has been configured to generate a Java stub, but that\'s not yet supported. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=481563");
+        Formatter2Fragment2.LOG.error(_plus);
+      }
+      _xblockexpression = null;
+    }
+    return ((XtendFileAccess)_xblockexpression);
   }
   
   protected StringConcatenationClient generateFormatMethod(final EClass clazz, final Collection<EReference> containmentRefs, final boolean isOverriding) {
@@ -204,9 +216,6 @@ public class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
               if (_isMany) {
                 _builder.append("\t");
                 _builder.append("for (");
-                EClass _eReferenceType = ref.getEReferenceType();
-                _builder.append(_eReferenceType, "\t");
-                _builder.append(" ");
                 String _varName_1 = Formatter2Fragment2.this.toVarName(ref, Formatter2Fragment2.this.toVarName(clazz), "document");
                 _builder.append(_varName_1, "\t");
                 _builder.append(" : ");
@@ -215,13 +224,13 @@ public class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
                 _builder.append(".");
                 String _getAccessor = Formatter2Fragment2.this.getGetAccessor(ref);
                 _builder.append(_getAccessor, "\t");
-                _builder.append("()) {");
+                _builder.append(") {");
                 _builder.newLineIfNotEmpty();
                 _builder.append("\t");
                 _builder.append("\t");
                 String _varName_3 = Formatter2Fragment2.this.toVarName(ref, Formatter2Fragment2.this.toVarName(clazz), "document");
                 _builder.append(_varName_3, "\t\t");
-                _builder.append(".format;");
+                _builder.append(".format");
                 _builder.newLineIfNotEmpty();
                 _builder.append("\t");
                 _builder.append("}");
@@ -233,7 +242,7 @@ public class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
                 _builder.append(".");
                 String _getAccessor_1 = Formatter2Fragment2.this.getGetAccessor(ref);
                 _builder.append(_getAccessor_1, "\t");
-                _builder.append(".format;");
+                _builder.append(".format");
                 _builder.newLineIfNotEmpty();
               }
             }
@@ -319,7 +328,7 @@ public class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
   }
   
   protected String getGetAccessor(final EStructuralFeature feature) {
-    return GenModelUtil2.getGenFeature(feature, this.getLanguage().getResourceSet()).getGetAccessor();
+    return GenModelUtil2.getGenFeature(feature, this.getLanguage().getResourceSet()).getName();
   }
   
   private final static Logger LOG = Logger.getLogger(Formatter2Fragment2.class);


### PR DESCRIPTION
- Make the generated Formatter.xtend stub more concise by eliminating
unnecessary semicolons, by eliminating explicit type before the for loop
variable and by using the EReference feature name (instead of its getter
accessor name) in the for loop collection.
- Refactor the Formatter2Fragment2 class to make it more testable.
- Modify the AbstractGeneratorFragmentTests to set the resourceSet into
the used StandardLanguage (needed by the Formatter2Fragment2).
- Implement corresponding Formatter2Fragment2 test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>