### PR TITLE
[NONE] Fix Typo in AbstractGeneratorFragmentTests.xtend file.

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/AbstractGeneratorFragmentTests.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/AbstractGeneratorFragmentTests.xtend
@@ -46,7 +46,7 @@ abstract class AbstractGeneratorFragmentTests extends AbstractXtextTests {
 	
 	@Before
 	override setUp() {
-		globalStateMemento = globalStateMemento = GlobalRegistries.makeCopyOfGlobalState();
+		globalStateMemento = GlobalRegistries.makeCopyOfGlobalState();
 		super.setUp();
 		EPackage.Registry.INSTANCE.put(XMLTypePackage.eNS_URI, XMLTypePackage.eINSTANCE);
 		with(XtextStandaloneSetup)

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractGeneratorFragmentTests.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractGeneratorFragmentTests.java
@@ -132,7 +132,7 @@ public abstract class AbstractGeneratorFragmentTests extends AbstractXtextTests 
   @Override
   public void setUp() {
     try {
-      this.globalStateMemento = (this.globalStateMemento = GlobalRegistries.makeCopyOfGlobalState());
+      this.globalStateMemento = GlobalRegistries.makeCopyOfGlobalState();
       super.setUp();
       EPackage.Registry.INSTANCE.put(XMLTypePackage.eNS_URI, XMLTypePackage.eINSTANCE);
       this.with(XtextStandaloneSetup.class);


### PR DESCRIPTION
- Avoid double assignment of the globalStateMemento field.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>