### PR TITLE
[validation] fix generation of issue code provider

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/ValidatorFragment2Tests.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/ValidatorFragment2Tests.xtend
@@ -166,7 +166,7 @@ class ValidatorFragment2Tests extends AbstractGeneratorFragmentTests {
 			
 			@SuppressWarnings("restriction")
 			public class FooConfigurableIssueCodesProvider extends ConfigurableIssueCodesProvider {
-				protected static final String ISSUE_CODE_PREFIX = "org.xtext.example.mydsl.";
+				protected static final String ISSUE_CODE_PREFIX = grammar.runtimeBasePackage + ".";
 			
 				public static final String DEPRECATED_MODEL_PART = ISSUE_CODE_PREFIX + "deprecatedModelPart";
 			
@@ -245,9 +245,9 @@ class ValidatorFragment2Tests extends AbstractGeneratorFragmentTests {
 				@Override
 				protected IDialogSettings getDialogSettings() {
 					IDialogSettings dialogSettings = super.getDialogSettings();
-					IDialogSettings section = dialogSettings.getSection("MyDsl");
+					IDialogSettings section = dialogSettings.getSection("Foo");
 					if (section == null) {
-						return dialogSettings.addNewSection("MyDsl");
+						return dialogSettings.addNewSection("Foo");
 					}
 					return section;
 				}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/validation/ValidatorFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/validation/ValidatorFragment2.xtend
@@ -226,7 +226,7 @@ class ValidatorFragment2 extends AbstractInheritingFragment {
 		javaFile.content = '''
 			@SuppressWarnings("restriction")
 			public class «configurableIssueCodesProviderClass» extends «superConfigurableIssueCodesProviderClass» {
-				protected static final String ISSUE_CODE_PREFIX = "org.xtext.example.mydsl.";
+				protected static final String ISSUE_CODE_PREFIX = grammar.runtimeBasePackage + ".";
 			
 				public static final String DEPRECATED_MODEL_PART = ISSUE_CODE_PREFIX + "deprecatedModelPart";
 			
@@ -285,9 +285,9 @@ class ValidatorFragment2 extends AbstractInheritingFragment {
 				@Override
 				protected «typeRef('org.eclipse.jface.dialogs.IDialogSettings')» getDialogSettings() {
 					«typeRef('org.eclipse.jface.dialogs.IDialogSettings')» dialogSettings = super.getDialogSettings();
-					«typeRef('org.eclipse.jface.dialogs.IDialogSettings')» section = dialogSettings.getSection("MyDsl");
+					«typeRef('org.eclipse.jface.dialogs.IDialogSettings')» section = dialogSettings.getSection("«grammar.simpleName»");
 					if (section == null) {
-						return dialogSettings.addNewSection("MyDsl");
+						return dialogSettings.addNewSection("«grammar.simpleName»");
 					}
 					return section;
 				}


### PR DESCRIPTION
use grammar info instead of `MyDsl`.

cf. https://github.com/eclipse/xtext-core/pull/680

Signed-off-by: Alex Tugarev <alex.tugarev@typefox.io>