### PR TITLE
[eclipse/xtext-eclipse#599] Support waiting operation.

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/FileSystemAccessQueue.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/FileSystemAccessQueue.xtend
@@ -40,6 +40,12 @@ class FileSystemAccessQueue extends AdapterImpl {
 			throw new OperationCanceledException
 		}
 	}
+	
+	def void waitForEmptyQueue() {
+		while (!requestQueue.isEmpty) {
+			Thread.yield
+		}
+	}
 
 }
 

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/FileSystemAccessQueue.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/FileSystemAccessQueue.java
@@ -53,4 +53,10 @@ public class FileSystemAccessQueue extends AdapterImpl {
       }
     }
   }
+  
+  public void waitForEmptyQueue() {
+    while ((!this.requestQueue.isEmpty())) {
+      Thread.yield();
+    }
+  }
 }


### PR DESCRIPTION
ActiveAnnotationProcessors might run in parallel. Read operations should
wait until all write operations are ready to avoid race conditions.

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>