### PR TITLE
Updated to LSP4J 0.4.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -9,7 +9,7 @@ ext.versions = [
 	'xtext_bootstrap': '2.13.0',
 	'gradle_plugins': '0.1.0',
 	'xtext_gradle_plugin': '1.0.20',
-	'lsp4j': '[0.3.0,0.4)',
+	'lsp4j': '0.4.0-SNAPSHOT',
 	'log4j': '1.2.16',
 	'equinoxCommon' : '3.8.0',
 	'equinoxRegistry' : '3.6.100',

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/UnknownProjectConfigTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/UnknownProjectConfigTest.xtend
@@ -7,11 +7,11 @@
  *******************************************************************************/
 package org.eclipse.xtext.ide.tests.server
 
+import org.eclipse.lsp4j.CompletionParams
 import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentItem
-import org.eclipse.lsp4j.TextDocumentPositionParams
 import org.junit.Test
 
 class UnknownProjectConfigTest extends AbstractTestLangLanguageServerTest {
@@ -77,7 +77,7 @@ class UnknownProjectConfigTest extends AbstractTestLangLanguageServerTest {
 	}
 	
 	protected def checkCompletion(String uri) {
-		val completionItems = languageServer.completion(new TextDocumentPositionParams => [
+		val completionItems = languageServer.completion(new CompletionParams => [
 			textDocument = new TextDocumentIdentifier(uri)
 			position = new Position(0, 10)
 		])

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/commands/CommandRegistryTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/commands/CommandRegistryTest.java
@@ -16,6 +16,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.ApplyWorkspaceEditResponse;
 import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.ConfigurationParams;
 import org.eclipse.lsp4j.ExecuteCommandCapabilities;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.MessageActionItem;
@@ -27,6 +28,7 @@ import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.Unregistration;
 import org.eclipse.lsp4j.UnregistrationParams;
 import org.eclipse.lsp4j.WorkspaceClientCapabilities;
+import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.xtend.lib.annotations.Delegate;
 import org.eclipse.xtext.ide.server.ILanguageServerAccess;
@@ -175,6 +177,10 @@ public class CommandRegistryTest implements IResourceServiceProvider, IExecutabl
     return this.noImpl3.applyEdit(params);
   }
   
+  public CompletableFuture<List<Object>> configuration(final ConfigurationParams configurationParams) {
+    return this.noImpl3.configuration(configurationParams);
+  }
+  
   public void logMessage(final MessageParams message) {
     this.noImpl3.logMessage(message);
   }
@@ -193,5 +199,9 @@ public class CommandRegistryTest implements IResourceServiceProvider, IExecutabl
   
   public void telemetryEvent(final Object object) {
     this.noImpl3.telemetryEvent(object);
+  }
+  
+  public CompletableFuture<List<WorkspaceFolder>> workspaceFolders() {
+    return this.noImpl3.workspaceFolders();
   }
 }

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/UnknownProjectConfigTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/UnknownProjectConfigTest.java
@@ -11,12 +11,12 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
-import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
@@ -123,14 +123,14 @@ public class UnknownProjectConfigTest extends AbstractTestLangLanguageServerTest
   
   protected void checkCompletion(final String uri) {
     try {
-      TextDocumentPositionParams _textDocumentPositionParams = new TextDocumentPositionParams();
-      final Procedure1<TextDocumentPositionParams> _function = (TextDocumentPositionParams it) -> {
+      CompletionParams _completionParams = new CompletionParams();
+      final Procedure1<CompletionParams> _function = (CompletionParams it) -> {
         TextDocumentIdentifier _textDocumentIdentifier = new TextDocumentIdentifier(uri);
         it.setTextDocument(_textDocumentIdentifier);
         Position _position = new Position(0, 10);
         it.setPosition(_position);
       };
-      TextDocumentPositionParams _doubleArrow = ObjectExtensions.<TextDocumentPositionParams>operator_doubleArrow(_textDocumentPositionParams, _function);
+      CompletionParams _doubleArrow = ObjectExtensions.<CompletionParams>operator_doubleArrow(_completionParams, _function);
       final CompletableFuture<Either<List<CompletionItem>, CompletionList>> completionItems = this.languageServer.completion(_doubleArrow);
       final Either<List<CompletionItem>, CompletionList> result = completionItems.get();
       List<CompletionItem> _xifexpression = null;

--- a/org.eclipse.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ide/META-INF/MANIFEST.MF
@@ -10,8 +10,8 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtend.lib,
  org.eclipse.core.runtime;bundle-version="3.6.0";resolution:=optional;x-installation:=greedy,
  org.eclipse.equinox.common;bundle-version="3.5.0",
- org.eclipse.lsp4j;bundle-version="[0.3.0,0.4.0)";resolution:=optional,
- org.eclipse.lsp4j.jsonrpc;bundle-version="[0.3.0,0.4.0)";resolution:=optional,
+ org.eclipse.lsp4j;bundle-version="[0.4.0,0.5.0)";resolution:=optional,
+ org.eclipse.lsp4j.jsonrpc;bundle-version="[0.4.0,0.5.0)";resolution:=optional,
  org.eclipse.emf.ecore.change;bundle-version="[2.10.0,3)"
 Import-Package: org.apache.log4j;version="1.2.15"
 Export-Package: org.eclipse.xtext.ide;x-friends:="org.eclipse.xtend.ide,

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/LanguageServerImpl.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/LanguageServerImpl.java
@@ -36,6 +36,7 @@ import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionOptions;
+import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
@@ -372,7 +373,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
         String _text = event.getText();
         return new TextEdit(_range, _text);
       };
-      return this.workspaceManager.didChange(this._uriExtensions.toUri(params.getTextDocument().getUri()), params.getTextDocument().getVersion(), ListExtensions.<TextDocumentContentChangeEvent, TextEdit>map(params.getContentChanges(), _function_1));
+      return this.workspaceManager.didChange(this._uriExtensions.toUri(params.getTextDocument().getUri()), (params.getTextDocument().getVersion()).intValue(), ListExtensions.<TextDocumentContentChangeEvent, TextEdit>map(params.getContentChanges(), _function_1));
     };
     final Function2<CancelIndicator, BuildManager.Buildable, List<IResourceDescription.Delta>> _function_1 = (CancelIndicator cancelIndicator, BuildManager.Buildable buildable) -> {
       return buildable.build(cancelIndicator);
@@ -516,15 +517,15 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
   }
   
   @Override
-  public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(final TextDocumentPositionParams params) {
-    final Function1<CancelIndicator, Either<List<CompletionItem>, CompletionList>> _function = (CancelIndicator origialCancelIndicator) -> {
-      return this.completion(origialCancelIndicator, params);
+  public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(final CompletionParams params) {
+    final Function1<CancelIndicator, Either<List<CompletionItem>, CompletionList>> _function = (CancelIndicator cancelIndicator) -> {
+      return this.completion(cancelIndicator, params);
     };
     return this.requestManager.<Either<List<CompletionItem>, CompletionList>>runRead(_function);
   }
   
-  protected Either<List<CompletionItem>, CompletionList> completion(final CancelIndicator origialCancelIndicator, final TextDocumentPositionParams params) {
-    final LanguageServerImpl.BufferedCancelIndicator cancelIndicator = new LanguageServerImpl.BufferedCancelIndicator(origialCancelIndicator);
+  protected Either<List<CompletionItem>, CompletionList> completion(final CancelIndicator originalCancelIndicator, final CompletionParams params) {
+    final LanguageServerImpl.BufferedCancelIndicator cancelIndicator = new LanguageServerImpl.BufferedCancelIndicator(originalCancelIndicator);
     final URI uri = this._uriExtensions.toUri(params.getTextDocument().getUri());
     final IResourceServiceProvider resourceServiceProvider = this.languagesRegistry.getResourceServiceProvider(uri);
     ContentAssistService _get = null;

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
@@ -9,6 +9,7 @@ package org.eclipse.xtext.testing
 
 import com.google.inject.Guice
 import com.google.inject.Inject
+import com.google.inject.Module
 import java.io.File
 import java.io.FileWriter
 import java.net.URI
@@ -26,6 +27,7 @@ import org.eclipse.lsp4j.ColoringParams
 import org.eclipse.lsp4j.Command
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
+import org.eclipse.lsp4j.CompletionParams
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams
 import org.eclipse.lsp4j.DidCloseTextDocumentParams
@@ -66,14 +68,13 @@ import org.eclipse.xtext.ide.server.Document
 import org.eclipse.xtext.ide.server.LanguageServerImpl
 import org.eclipse.xtext.ide.server.ServerModule
 import org.eclipse.xtext.ide.server.UriExtensions
+import org.eclipse.xtext.ide.server.concurrent.RequestManager
 import org.eclipse.xtext.resource.IResourceServiceProvider
+import org.eclipse.xtext.util.CancelIndicator
 import org.eclipse.xtext.util.Files
+import org.eclipse.xtext.util.Modules2
 import org.junit.Assert
 import org.junit.Before
-import org.eclipse.xtext.util.Modules2
-import com.google.inject.Module
-import org.eclipse.xtext.ide.server.concurrent.RequestManager
-import org.eclipse.xtext.util.CancelIndicator
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -381,7 +382,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		configuration.filePath = 'MyModel.' + fileExtension
 		configurator.apply(configuration)
 		val filePath = initializeContext(configuration).uri
-		val completionItems = languageServer.completion(new TextDocumentPositionParams => [
+		val completionItems = languageServer.completion(new CompletionParams => [
 			textDocument = new TextDocumentIdentifier(filePath)
 			position = new Position(line, column)
 		])

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
@@ -13,6 +13,7 @@ import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
+import com.google.inject.Module;
 import com.google.inject.binder.AnnotatedBindingBuilder;
 import java.io.File;
 import java.io.FileWriter;
@@ -35,6 +36,7 @@ import org.eclipse.lsp4j.ColoringParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
@@ -195,9 +197,9 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
     }
   }
   
-  protected com.google.inject.Module getServerModule() {
+  protected Module getServerModule() {
     ServerModule _serverModule = new ServerModule();
-    final com.google.inject.Module _function = (Binder it) -> {
+    final Module _function = (Binder it) -> {
       AnnotatedBindingBuilder<RequestManager> _bind = it.<RequestManager>bind(RequestManager.class);
       _bind.toInstance(new RequestManager() {
         @Override
@@ -768,8 +770,8 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
       configuration.setFilePath(("MyModel." + this.fileExtension));
       configurator.apply(configuration);
       final String filePath = this.initializeContext(configuration).getUri();
-      TextDocumentPositionParams _textDocumentPositionParams = new TextDocumentPositionParams();
-      final Procedure1<TextDocumentPositionParams> _function = (TextDocumentPositionParams it) -> {
+      CompletionParams _completionParams = new CompletionParams();
+      final Procedure1<CompletionParams> _function = (CompletionParams it) -> {
         TextDocumentIdentifier _textDocumentIdentifier = new TextDocumentIdentifier(filePath);
         it.setTextDocument(_textDocumentIdentifier);
         int _line = configuration.getLine();
@@ -777,7 +779,7 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
         Position _position = new Position(_line, _column);
         it.setPosition(_position);
       };
-      TextDocumentPositionParams _doubleArrow = ObjectExtensions.<TextDocumentPositionParams>operator_doubleArrow(_textDocumentPositionParams, _function);
+      CompletionParams _doubleArrow = ObjectExtensions.<CompletionParams>operator_doubleArrow(_completionParams, _function);
       final CompletableFuture<Either<List<CompletionItem>, CompletionList>> completionItems = this.languageServer.completion(_doubleArrow);
       final Either<List<CompletionItem>, CompletionList> result = completionItems.get();
       List<CompletionItem> _xifexpression = null;


### PR DESCRIPTION
Fixes #694.

In LSP 3.6 the parameter type of `textDocument/completion` has changed from `TextDocumentPositionParams` to `CompletionParams`. While this is compatible in TypeScript (the new type adds only optional properties), it is a breaking change in Java :-/

LSP4J 0.4.0 is released next week. I set the dependency to the snapshot version here so we can include the update in the first RC. I'll change it to the released version as soon as it's available.