### PR TITLE
[eclipse/xtext-web#53] updated to a newer jetty version that works better with asm 6.1

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.web/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.web/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 	compile "org.webjars:requirejs:2.3.2"
 	compile "org.webjars:jquery:2.2.4"
 	compile "org.webjars:ace:1.2.3"
-	providedCompile "org.eclipse.jetty:jetty-annotations:9.3.8.v20160314"
+	providedCompile "org.eclipse.jetty:jetty-annotations:9.4.9.v20180320"
 	providedCompile "org.slf4j:slf4j-simple:1.7.21"
 }
 task jettyRun(type:JavaExec) {

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.gradle/org.xtext.example.gradle.parent/org.xtext.example.gradle.web/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.gradle/org.xtext.example.gradle.parent/org.xtext.example.gradle.web/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 	compile "org.webjars:requirejs:2.3.2"
 	compile "org.webjars:jquery:2.2.4"
 	compile "org.webjars:ace:1.2.3"
-	providedCompile "org.eclipse.jetty:jetty-annotations:9.3.8.v20160314"
+	providedCompile "org.eclipse.jetty:jetty-annotations:9.4.9.v20180320"
 	providedCompile "org.slf4j:slf4j-simple:1.7.21"
 }
 task jettyRun(type:JavaExec) {

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.web/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.web/pom.xml
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.2.13.v20150730</version>
+				<version>9.4.9.v20180320</version>
 				<configuration>
 					<webAppSourceDirectory>WebRoot</webAppSourceDirectory>
 				</configuration>
@@ -116,7 +116,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-annotations</artifactId>
-			<version>9.3.8.v20160314</version>
+			<version>9.4.9.v20180320</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9.web/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9.web/pom.xml
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.2.13.v20150730</version>
+				<version>9.4.9.v20180320</version>
 				<configuration>
 					<webAppSourceDirectory>WebRoot</webAppSourceDirectory>
 				</configuration>
@@ -116,7 +116,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-annotations</artifactId>
-			<version>9.3.8.v20160314</version>
+			<version>9.4.9.v20180320</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.web/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.web/pom.xml
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.2.13.v20150730</version>
+				<version>9.4.9.v20180320</version>
 				<configuration>
 					<webAppSourceDirectory>WebRoot</webAppSourceDirectory>
 				</configuration>
@@ -116,7 +116,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-annotations</artifactId>
-			<version>9.3.8.v20160314</version>
+			<version>9.4.9.v20180320</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/org.xtext.example.plainMaven.web/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/org.xtext.example.plainMaven.web/pom.xml
@@ -26,7 +26,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.2.13.v20150730</version>
+				<version>9.4.9.v20180320</version>
 				<configuration>
 					<webAppSourceDirectory>src/main/webapp</webAppSourceDirectory>
 				</configuration>
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-annotations</artifactId>
-			<version>9.3.8.v20160314</version>
+			<version>9.4.9.v20180320</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/WebProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/WebProjectDescriptor.xtend
@@ -17,7 +17,7 @@ class WebProjectDescriptor extends ProjectDescriptor {
 	static val REQUIREJS_VERSION = '2.3.2'
 //	static val REQUIREJS_TEXT_VERSION = '2.0.15'
 	static val JQUERY_VERSION = '2.2.4'
-	static val JETTY_VERSION = '9.3.8.v20160314'
+	static val JETTY_VERSION = '9.4.9.v20180320'
 	static val SLF4J_VERSION = '1.7.21'
 	static val ACE_VERSION = '1.2.3'
 	
@@ -110,7 +110,7 @@ class WebProjectDescriptor extends ProjectDescriptor {
 						<plugin>
 							<groupId>org.eclipse.jetty</groupId>
 							<artifactId>jetty-maven-plugin</artifactId>
-							<version>9.2.13.v20150730</version>
+							<version>«JETTY_VERSION»</version>
 							<configuration>
 								<webAppSourceDirectory>«Outlet.WEBAPP.sourceFolder»</webAppSourceDirectory>
 							</configuration>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/WebProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/WebProjectDescriptor.java
@@ -33,7 +33,7 @@ public class WebProjectDescriptor extends ProjectDescriptor {
   
   private final static String JQUERY_VERSION = "2.2.4";
   
-  private final static String JETTY_VERSION = "9.3.8.v20160314";
+  private final static String JETTY_VERSION = "9.4.9.v20180320";
   
   private final static String SLF4J_VERSION = "1.7.21";
   
@@ -253,8 +253,10 @@ public class WebProjectDescriptor extends ProjectDescriptor {
       _builder.append("<artifactId>jetty-maven-plugin</artifactId>");
       _builder.newLine();
       _builder.append("\t\t\t");
-      _builder.append("<version>9.2.13.v20150730</version>");
-      _builder.newLine();
+      _builder.append("<version>");
+      _builder.append(WebProjectDescriptor.JETTY_VERSION, "\t\t\t");
+      _builder.append("</version>");
+      _builder.newLineIfNotEmpty();
       _builder.append("\t\t\t");
       _builder.append("<configuration>");
       _builder.newLine();


### PR DESCRIPTION
[eclipse/xtext-web#53] updated to a newer jetty version that works better with asm 6.1

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>