### PR TITLE
[#743] Relax lower bound for JUnit 5 bundles to 5.0.0

### DIFF
--- a/org.eclipse.xtext.testing/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testing/META-INF/MANIFEST.MF
@@ -24,6 +24,6 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtend.lib
 Import-Package: org.apache.log4j;version="1.2.15",
  org.apache.log4j.spi;version="1.2.15",
- org.junit.jupiter.api.extension;version="5.1.0";resolution:=optional
+ org.junit.jupiter.api.extension;version="[5.0.0,6.0.0)";resolution:=optional
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.xtext.testing

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
@@ -58,7 +58,7 @@ abstract class TestProjectDescriptor extends ProjectDescriptor {
 		if (config.junitVersion == JUnitVersion.JUNIT_5) {
 			deps += new ExternalDependency()=>[
 				p2.bundleId = "org.junit.jupiter.api"
-				p2.version = "5.1.0"
+				p2.version = "[5.0.0,6.0.0)"
 				maven.groupId = "org.junit.jupiter"
 				maven.artifactId = "junit-jupiter-api"
 				maven.version = "5.1.0"
@@ -67,7 +67,7 @@ abstract class TestProjectDescriptor extends ProjectDescriptor {
 			if (config.needsGradleBuild) {
 				deps += new ExternalDependency()=>[
 					p2.bundleId = "org.junit.jupiter.engine"
-					p2.version = "5.1.0"
+					p2.version = "[5.0.0,6.0.0)"
 					maven.groupId = "org.junit.jupiter"
 					maven.artifactId = "junit-jupiter-engine"
 					maven.version = "5.1.0"

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
@@ -107,7 +107,7 @@ public abstract class TestProjectDescriptor extends ProjectDescriptor {
         ExternalDependency.P2Coordinates _p2 = it.getP2();
         _p2.setBundleId("org.junit.jupiter.api");
         ExternalDependency.P2Coordinates _p2_1 = it.getP2();
-        _p2_1.setVersion("5.1.0");
+        _p2_1.setVersion("[5.0.0,6.0.0)");
         ExternalDependency.MavenCoordinates _maven = it.getMaven();
         _maven.setGroupId("org.junit.jupiter");
         ExternalDependency.MavenCoordinates _maven_1 = it.getMaven();
@@ -126,7 +126,7 @@ public abstract class TestProjectDescriptor extends ProjectDescriptor {
           ExternalDependency.P2Coordinates _p2 = it.getP2();
           _p2.setBundleId("org.junit.jupiter.engine");
           ExternalDependency.P2Coordinates _p2_1 = it.getP2();
-          _p2_1.setVersion("5.1.0");
+          _p2_1.setVersion("[5.0.0,6.0.0)");
           ExternalDependency.MavenCoordinates _maven = it.getMaven();
           _maven.setGroupId("org.junit.jupiter");
           ExternalDependency.MavenCoordinates _maven_1 = it.getMaven();


### PR DESCRIPTION
Makes bundles work on Oxygen.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>