### PR TITLE
[#506] Removed reflection call.

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -2,7 +2,7 @@
  * Base project version and versions of common dependencies.
  */
 
-version = '2.14.0-SNAPSHOT'
+version = '2.15.0-SNAPSHOT'
 
 ext.versions = [
 	'xtext': version,

--- a/org.eclipse.xtext.ide.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ide.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xtext IDE Tests
 Bundle-SymbolicName: org.eclipse.xtext.ide.tests;singleton:=true
-Bundle-Version: 2.14.0.qualifier
+Bundle-Version: 2.15.0.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xtext IDE Core
 Bundle-SymbolicName: org.eclipse.xtext.ide;singleton:=true
-Bundle-Version: 2.14.0.qualifier
+Bundle-Version: 2.15.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse Xtext

--- a/org.eclipse.xtext.testing/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testing/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xtext Testing Infrastructure
 Bundle-SymbolicName: org.eclipse.xtext.testing;singleton:=true
-Bundle-Version: 2.14.0.qualifier
+Bundle-Version: 2.15.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.xtext.testlanguages.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testlanguages.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Common Xtext Testlanguages for UI and Runtime - IDE Features
 Bundle-SymbolicName: org.eclipse.xtext.testlanguages.ide;singleton:=true
-Bundle-Version: 2.14.0.qualifier
+Bundle-Version: 2.15.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Xtext
 Bundle-ActivationPolicy: lazy
@@ -23,5 +23,5 @@ Require-Bundle: org.eclipse.xtext.ide;visibility:=reexport,
  org.eclipse.xtext.testlanguages,
  org.eclipse.xtext.testing,
  org.antlr.runtime,
- org.eclipse.xtend.lib;bundle-version="2.14.0"
+ org.eclipse.xtend.lib;bundle-version="2.15.0"
 Automatic-Module-Name: org.eclipse.xtext.testlanguages.ide

--- a/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Common Xtext Testlanguages for UI and Runtime - Runtime
 Bundle-Vendor: Eclipse Xtext
-Bundle-Version: 2.14.0.qualifier
+Bundle-Version: 2.15.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.testlanguages; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.emf.ecore;bundle-version="2.10.2",
  org.eclipse.emf.common;bundle-version="2.10.1",
  org.antlr.runtime,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+ org.eclipse.xtext.xbase.lib;bundle-version="2.15.0",
  org.eclipse.xtend.lib,
  org.eclipse.xtext.testing
 Import-Package: org.apache.log4j;version="1.2.15",

--- a/org.eclipse.xtext.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.xtext.tests;singleton:=true
-Bundle-Version: 2.14.0.qualifier
+Bundle-Version: 2.15.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
@@ -20,7 +20,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.xtend.lib,
  org.eclipse.ui.workbench;resolution:=optional,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+ org.eclipse.xtext.xbase.lib;bundle-version="2.15.0",
  org.eclipse.xtext.xtext.generator,
  org.eclipse.xtext.xtext.wizard,
  org.eclipse.emf.mwe.core;bundle-version="1.2.0"

--- a/org.eclipse.xtext.util/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.util/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xtext Utility
 Bundle-SymbolicName: org.eclipse.xtext.util
-Bundle-Version: 2.14.0.qualifier
+Bundle-Version: 2.15.0.qualifier
 Maven-Version: unspecified
 Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.xtext.xtext.generator/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.generator/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.xtext.xtext.generator;singleton:=true
-Bundle-Version: 2.14.0.qualifier
+Bundle-Version: 2.15.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Name: Xtext Generator 2
 Bundle-Vendor: Eclipse Xtext

--- a/org.eclipse.xtext.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xtext Language IDE Support
 Bundle-SymbolicName: org.eclipse.xtext.xtext.ide;singleton:=true
-Bundle-Version: 2.14.0.qualifier
+Bundle-Version: 2.15.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse Xtext

--- a/org.eclipse.xtext.xtext.wizard/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.wizard/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xtext Wizard
 Bundle-SymbolicName: org.eclipse.xtext.xtext.wizard
-Bundle-Version: 2.14.0.qualifier
+Bundle-Version: 2.15.0.qualifier
 Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.xtext.wizard;x-friends:="org.eclipse.xtext.tests,
@@ -10,7 +10,7 @@ Export-Package: org.eclipse.xtext.xtext.wizard;x-friends:="org.eclipse.xtext.tes
   org.eclipse.xtext.xtext.ui.tests",
  org.eclipse.xtext.xtext.wizard.cli;x-friends:="org.eclipse.xtext.tests",
  org.eclipse.xtext.xtext.wizard.ecore2xtext;x-friends:="org.eclipse.xtext.xtext.ui,org.eclipse.xtext.xtext.ui.tests"
-Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.15.0",
  org.eclipse.xtend.lib;resolution:=optional,
  org.eclipse.xtext.util,
  org.eclipse.emf.ecore;bundle-version="2.10.2"

--- a/org.eclipse.xtext/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xtext
 Bundle-SymbolicName: org.eclipse.xtext;singleton:=true
-Bundle-Version: 2.14.0.qualifier
+Bundle-Version: 2.15.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/releng/p2/category.xml
+++ b/releng/p2/category.xml
@@ -1,69 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-	<bundle id="org.eclipse.xtext" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.source" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.source" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.ide" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.ide" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.ide.source" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.ide.source" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.ide.tests" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.ide.tests" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.ide.tests.source" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.ide.tests.source" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.testing" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.testing" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.testing.source" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.testing.source" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.testlanguages" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.testlanguages" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.testlanguages.source" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.testlanguages.source" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.testlanguages.ide" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.testlanguages.ide" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.testlanguages.ide.source" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.testlanguages.ide.source" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.tests" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.tests" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.tests.source" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.tests.source" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.util" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.util" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.util.source" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.util.source" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.xtext.generator" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.xtext.generator" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.xtext.generator.source" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.xtext.generator.source" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.xtext.ide" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.xtext.ide" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.xtext.ide.source" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.xtext.ide.source" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.xtext.wizard" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.xtext.wizard" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
-	<bundle id="org.eclipse.xtext.xtext.wizard.source" version="2.14.0.qualifier">
+	<bundle id="org.eclipse.xtext.xtext.wizard.source" version="2.15.0.qualifier">
 		<category name="xtext-core"/>
 	</bundle>
    <category-def name="xtext-core" label="Xtext-core"/>

--- a/releng/p2/pom.xml
+++ b/releng/p2/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.xtext</groupId>
 		<artifactId>xtext-core.releng</artifactId>
-		<version>2.14.0-SNAPSHOT</version>
+		<version>2.15.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.eclipse.xtext</groupId>
 	<artifactId>xtext-core.releng</artifactId>
-	<version>2.14.0-SNAPSHOT</version>
+	<version>2.15.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>
@@ -38,122 +38,122 @@
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 			<classifier>sources</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.ide</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.ide</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 			<classifier>sources</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.ide.tests</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.ide.tests</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 			<classifier>sources</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.testing</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.testing</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 			<classifier>sources</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.testlanguages</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.testlanguages</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 			<classifier>sources</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.testlanguages.ide</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.testlanguages.ide</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 			<classifier>sources</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.tests</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.tests</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 			<classifier>sources</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.util</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.util</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 			<classifier>sources</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.xtext.generator</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.xtext.generator</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 			<classifier>sources</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.xtext.ide</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.xtext.ide</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 			<classifier>sources</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.xtext.wizard</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.xtext.wizard</artifactId>
-			<version>2.14.0-SNAPSHOT</version>
+			<version>2.15.0-SNAPSHOT</version>
 			<classifier>sources</classifier>
 		</dependency>
 	</dependencies>
@@ -173,11 +173,6 @@
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-versions-plugin</artifactId>
-				<version>${tycho-version}</version>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
@@ -186,7 +181,7 @@
 						<artifact>
 							<groupId>org.eclipse.xtext</groupId>
 							<artifactId>xtext-core.target</artifactId>
-							<version>${project.version}</version>
+							<version>2.15.0-SNAPSHOT</version>
 						</artifact>
 					</target>
 					<environments>

--- a/releng/releng-target/pom.xml
+++ b/releng/releng-target/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.xtext</groupId>
 		<artifactId>xtext-core.releng</artifactId>
-		<version>2.14.0-SNAPSHOT</version>
+		<version>2.15.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 </project>

--- a/releng/releng-target/xtext-core.target.target
+++ b/releng/releng-target/xtext-core.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.8"?>
-<target name="org.eclipse.xtext.core.target" sequenceNumber="0">
+<target name="org.eclipse.xtext.helios.target" sequenceNumber="0">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.13.0"/>


### PR DESCRIPTION
Do not inherit and modify (by reflection) the original
java.util.jar.Manifest but instead C&P and modify the code. Adapt
ManifestMergerTest by importing the new classes.

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>