### PR TITLE
[eclipse/xtext#1224] Detect local Jenkins environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node {
 	}
 	
 	stage('Gradle Build') {
-		sh "./gradlew clean cleanGenerateXtext build createLocalMavenRepo -PuseJenkinsSnapshots=true -PcompileXtend=true -PignoreTestFailures=true --refresh-dependencies --continue"
+		sh "./gradlew clean cleanGenerateXtext build createLocalMavenRepo -PuseJenkinsSnapshots=true -PJENKINS_URL=$JENKINS_URL -PcompileXtend=true -PignoreTestFailures=true --refresh-dependencies --continue"
 		step([$class: 'JUnitResultArchiver', testResults: '**/build/test-results/test/*.xml'])
 	}
 	
@@ -16,7 +16,7 @@ node {
 		def mvnHome = tool 'M3'
 		env.M2_HOME = "${mvnHome}"
 		dir('.m2/repository/org/eclipse/xtext') { deleteDir() }
-		sh "${mvnHome}/bin/mvn -f releng --batch-mode --update-snapshots -Dmaven.repo.local=.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install"
+		sh "${mvnHome}/bin/mvn -f releng --batch-mode --update-snapshots -Dmaven.repo.local=.m2/repository -DJENKINS_URL=$JENKINS_URL -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install"
 	}
 	
 	archive 'build/**'

--- a/gradle/bootstrap-setup.gradle
+++ b/gradle/bootstrap-setup.gradle
@@ -1,13 +1,16 @@
 /*
  * Root project configuration that is reused by subprojects to apply the Xtend compiler.
  */
+if (!hasProperty('JENKINS_URL')) {
+	ext.JENKINS_URL = 'http://services.typefox.io/open-source/jenkins'
+}
 
 // The repositories to query when constructing the Xtend compiler classpath
 repositories {
 	jcenter()
 	maven {
 		name 'xtend-bootstrap'
-		url 'http://services.typefox.io/open-source/jenkins/job/xtend-bootstrap/lastStableBuild/artifact/build-result/maven-repository/'
+		url "$JENKINS_URL/job/xtend-bootstrap/lastStableBuild/artifact/build-result/maven-repository/"
 	}
 }
 

--- a/gradle/upstream-repositories.gradle
+++ b/gradle/upstream-repositories.gradle
@@ -6,6 +6,10 @@
  * upstream branch is selected automatically based on the version string.
  */
 
+if (!hasProperty('JENKINS_URL')) {
+	ext.JENKINS_URL = 'http://services.typefox.io/open-source/jenkins'
+}
+
 if (!hasProperty('upstreamBranch')) {
 	def versionSplit = version.split('\\.')
 	if (versionSplit.length == 4)
@@ -18,13 +22,13 @@ if (!hasProperty('upstreamBranch')) {
 		ext.upstreamBranch = 'release_' + version
 }
 
-def jenkinsPipelineRepo = { jobName -> "http://services.typefox.io/open-source/jenkins/job/$jobName/job/$upstreamBranch/lastStableBuild/artifact/build/maven-repository/" }
+def jenkinsPipelineRepo = { jobName, upstreamBranch -> "$JENKINS_URL/job/$jobName/job/$upstreamBranch/lastStableBuild/artifact/build/maven-repository/" }
 
 repositories {
 	jcenter()
 	if (findProperty('useJenkinsSnapshots') == 'true') {
 		maven { url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/" }
-		maven { url jenkinsPipelineRepo('xtext-lib') }
+		maven { url jenkinsPipelineRepo('xtext-lib','master') }
 	} else {
 		mavenLocal()
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -10,6 +10,7 @@
 	<properties>
 		<tycho-version>1.2.0</tycho-version>
 		<root-dir>${basedir}/..</root-dir>
+		<JENKINS_URL>http://services.typefox.io/open-source/jenkins</JENKINS_URL>
 	</properties>
 
 	<repositories>
@@ -26,11 +27,11 @@
 		</repository>
 		<repository>
 			<id>maven</id>
-			<url>http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository</url>
 		</repository>
 		<repository>
 			<id>maven2</id>
-			<url>http://services.typefox.io/open-source/jenkins/job/xtext-lib/job/master/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-lib/job/master/lastStableBuild/artifact/build/maven-repository</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Build steps defined in Jenkinsfile pass the built-in environment
variable 'JENKINS_URL' to the Gradle/Maven executions. This is evaluated
in the build scripts for upstream repository URLs. On Xtext JIPP this
will use upstream repos from JIPP. In local builds outside of Jenkins
the property defaults to Typefox CI like before.

https://ci.eclipse.org/xtext/job/xtext-core/job/kth_issue1224/1/console:
```
+ ./gradlew clean cleanGenerateXtext build createLocalMavenRepo -PuseJenkinsSnapshots=true -PJENKINS_URL=https://ci.eclipse.org/xtext/ -PcompileXtend=true -PignoreTestFailures=true --refresh-dependencies --continue
...
:org.eclipse.xtext.util:generateXtext
Download https://ci.eclipse.org/xtext//job/xtext-lib/job/master/lastStableBuild/artifact/build/maven-repository/org/eclipse/xtend/org.eclipse.xtend.lib/2.15.0-SNAPSHOT/org.eclipse.xtend.lib-2.15.0-20180526.141909-1.jar
```

http://services.typefox.io/open-source/jenkins/job/xtext-core/job/kth_issue1224/1:
```
+ ./gradlew clean cleanGenerateXtext build createLocalMavenRepo -PuseJenkinsSnapshots=true -PJENKINS_URL=http://services.typefox.io/open-source/jenkins/ -PcompileXtend=true -PignoreTestFailures=true --refresh-dependencies --continue

```



Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>