### PR TITLE
[#715] Remove test_getCurrent

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/XtextVersionTests.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/XtextVersionTests.java
@@ -9,10 +9,6 @@ package org.eclipse.xtext.util;
 
 import static org.junit.Assert.*;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.jar.Manifest;
-
 import org.junit.Test;
 
 /**
@@ -51,20 +47,4 @@ public class XtextVersionTests {
 		assertFalse(version.isStable());
 		
 	}
-	
-	@Test
-	public void test_getCurrent () throws IOException {
-		XtextVersion current = XtextVersion.getCurrent();
-		try (FileInputStream fis = new FileInputStream("META-INF/MANIFEST.MF")) {
-			assertNotNull(current);
-			Manifest manifest = new Manifest(fis);
-			String bundleVersion = manifest.getMainAttributes().getValue("Bundle-Version");
-			assertNotNull(current);
-			// in development Bundle-Version will have suffix .qualifier
-			if (bundleVersion.endsWith(".qualifier")) {
-				assertEquals(bundleVersion.replace(".qualifier", "-SNAPSHOT"), current.getVersion());
-			}
-		}
-	}
-
 }


### PR DESCRIPTION
This test case was removed since it failed for non-snapshot versions
within a Gradle build. This is typically the case when doing a release.
It was decided to remove this test case.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>