### PR TITLE
[474468][eclipse/xtext-core#778] Fix bogus validation in MaxLineWidthDocument

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/MaxLineWidthDocument.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/MaxLineWidthDocument.java
@@ -51,7 +51,7 @@ public class MaxLineWidthDocument extends SubDocument {
 	protected void validate(HiddenRegionReplacer replacer) throws FormattingNotApplicableException {
 		IHiddenRegionFormatting formatting = replacer.getFormatting();
 		Integer newLineMin = formatting.getNewLineMin();
-		if (newLineMin != null && newLineMin > 0)
+		if (newLineMin != null && newLineMin < 0)
 			throw new FormattingNotApplicableException();
 	}
 


### PR DESCRIPTION
[474468][eclipse/xtext-core#778] Fix bogus validation in MaxLineWidthDocument

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>