### PR TITLE
added support for junit 4 and junit 5 in testing api

### DIFF
--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
@@ -75,6 +75,7 @@ import org.eclipse.xtext.util.Files
 import org.eclipse.xtext.util.Modules2
 import org.junit.Assert
 import org.junit.Before
+import org.junit.jupiter.api.BeforeEach
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -85,7 +86,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 	@Accessors
 	protected val String fileExtension
 
-	@Before
+	@Before @BeforeEach
 	def void setup() {
 		val injector = Guice.createInjector(getServerModule())
 		injector.injectMembers(this)

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/builder/AbstractIncrementalBuilderTest.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/builder/AbstractIncrementalBuilderTest.xtend
@@ -29,6 +29,7 @@ import org.eclipse.xtext.resource.impl.ProjectDescription
 import org.eclipse.xtext.testing.util.InMemoryURIHandler
 import org.eclipse.xtext.validation.Issue
 import org.junit.Before
+import org.junit.jupiter.api.BeforeEach
 
 /**
  * Abstract base class for testing languages in the incremental builder.
@@ -50,7 +51,7 @@ abstract class AbstractIncrementalBuilderTest {
 	protected List<Issue> issues
 	protected InMemoryURIHandler inMemoryURIHandler
 
-	@Before def void setUp() {
+	@Before @BeforeEach def void setUp() {
 		clean()
 		inMemoryURIHandler = new InMemoryURIHandler()
 	}

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
@@ -111,6 +111,7 @@ import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -172,6 +173,7 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
   protected final String fileExtension;
   
   @Before
+  @BeforeEach
   public void setup() {
     try {
       final Injector injector = Guice.createInjector(this.getServerModule());

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/builder/AbstractIncrementalBuilderTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/builder/AbstractIncrementalBuilderTest.java
@@ -48,6 +48,7 @@ import org.eclipse.xtext.xbase.lib.Pair;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure2;
 import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Abstract base class for testing languages in the incremental builder.
@@ -83,6 +84,7 @@ public abstract class AbstractIncrementalBuilderTest {
   protected InMemoryURIHandler inMemoryURIHandler;
   
   @Before
+  @BeforeEach
   public void setUp() {
     this.clean();
     InMemoryURIHandler _inMemoryURIHandler = new InMemoryURIHandler();


### PR DESCRIPTION
[eclipse/xtext#1236]
added support for junit 4 and junit 5 in testing api
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>