### PR TITLE
[#1238] Restrict org.antlr.runtime version to 3.2.0

### DIFF
--- a/org.eclipse.xtext.testlanguages.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testlanguages.ide/META-INF/MANIFEST.MF
@@ -22,6 +22,6 @@ Export-Package: org.eclipse.xtext.testlanguages.backtracking.ide.contentassist.a
 Require-Bundle: org.eclipse.xtext.ide;visibility:=reexport,
  org.eclipse.xtext.testlanguages,
  org.eclipse.xtext.testing,
- org.antlr.runtime,
+ org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  org.eclipse.xtend.lib;bundle-version="2.15.0"
 Automatic-Module-Name: org.eclipse.xtext.testlanguages.ide

--- a/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.util,
  org.eclipse.emf.ecore;bundle-version="2.10.2",
  org.eclipse.emf.common;bundle-version="2.10.1",
- org.antlr.runtime,
+ org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  org.eclipse.xtext.xbase.lib;bundle-version="2.15.0",
  org.eclipse.xtend.lib,
  org.eclipse.xtext.testing


### PR DESCRIPTION
Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>