### PR TITLE
[#795] Implement Before/AfterEachCallback

### DIFF
--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/extensions/InjectionExtension.java
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/extensions/InjectionExtension.java
@@ -12,8 +12,8 @@ import static org.eclipse.xtext.util.Exceptions.throwUncheckedException;
 import org.eclipse.xtext.testing.IInjectorProvider;
 import org.eclipse.xtext.testing.IRegistryConfigurator;
 import org.eclipse.xtext.testing.InjectWith;
-import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
-import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import com.google.common.annotations.Beta;
@@ -33,18 +33,18 @@ import com.google.inject.Injector;
  * @since 2.14
  */
 @Beta
-public class InjectionExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
+public class InjectionExtension implements BeforeEachCallback, AfterEachCallback {
 	/**
 	 * Maintains a map of injector provider types to their instance.
 	 * <p>
-	 * {@link #getOrCreateInjectorProvider(TestClass)} is used to obtain
-	 * an valid injector provider in the context of a given {@link TestClass}.
+	 * {@link #getOrCreateInjectorProvider(ExtensionContext)} is used to obtain
+	 * an valid injector provider in the context of a given {@link ExtensionContext}.
 	 * </p>
 	 */
 	private static ClassToInstanceMap<IInjectorProvider> injectorProviderClassCache = MutableClassToInstanceMap.create();
 
 	@Override
-	public void beforeTestExecution(ExtensionContext context) throws Exception {
+	public void beforeEach(ExtensionContext context) throws Exception {
 		IInjectorProvider injectorProvider = getOrCreateInjectorProvider(context);
 		if (injectorProvider instanceof IRegistryConfigurator) {
 			final IRegistryConfigurator registryConfigurator = (IRegistryConfigurator) injectorProvider;
@@ -58,7 +58,7 @@ public class InjectionExtension implements BeforeTestExecutionCallback, AfterTes
 	}
 
 	@Override
-	public void afterTestExecution(ExtensionContext context) throws Exception {
+	public void afterEach(ExtensionContext context) throws Exception {
 		IInjectorProvider injectorProvider = getOrCreateInjectorProvider(context);
 		if (injectorProvider instanceof IRegistryConfigurator) {
 			final IRegistryConfigurator registryConfigurator = (IRegistryConfigurator) injectorProvider;

--- a/org.eclipse.xtext.testing/tests/org/eclipse/xtext/testing/tests/InjectionExtensionTest.java
+++ b/org.eclipse.xtext.testing/tests/org/eclipse/xtext/testing/tests/InjectionExtensionTest.java
@@ -7,9 +7,15 @@
  *******************************************************************************/
 package org.eclipse.xtext.testing.tests;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
 
 /**
  * Test for {@link InjectionExtension}.
@@ -20,4 +26,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @InjectWith(InjectionExtensionTest.MyInjectorProvider.class)
 @ExtendWith(InjectionExtension.class)
 public class InjectionExtensionTest extends AbstractJUnitIntegrationTest {
+	@Inject Injector injector;
+	
+	@BeforeEach
+	public void setUp () {
+		assertNotNull(injector);
+	}
 }

--- a/org.eclipse.xtext.testing/tests/org/eclipse/xtext/testing/tests/XtextRunnerTest.java
+++ b/org.eclipse.xtext.testing/tests/org/eclipse/xtext/testing/tests/XtextRunnerTest.java
@@ -7,10 +7,16 @@
  *******************************************************************************/
 package org.eclipse.xtext.testing.tests;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
 
 /**
  * @author Sebastian Benz - Initial contribution and API
@@ -18,6 +24,9 @@ import org.junit.runner.RunWith;
 @InjectWith(XtextRunnerTest.MyInjectorProvider.class)
 @RunWith(XtextRunner.class)
 public class XtextRunnerTest extends AbstractJUnitIntegrationTest {
+	@Inject
+	private Injector injector;
+	
 	/**
 	 * Need to override, otherwise no tests are found in Gradle build
 	 */
@@ -26,4 +35,10 @@ public class XtextRunnerTest extends AbstractJUnitIntegrationTest {
 	public void shouldSaveRegistriesBeforeCreatingAnInjector() {
 		super.shouldSaveRegistriesBeforeCreatingAnInjector();
 	}
+	
+	@Before
+	public void setUp () {
+		assertNotNull(injector);
+	}
+	
 }


### PR DESCRIPTION
Was Before/AfterTestExecutionCallback, which is executed after user
@BeforeEach callbacks. Injected members were not initialized in these
callbacks then.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>