### PR TITLE
Made textRegionTransformer protected in DefaultDocumentHighlightService

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/occurrences/DefaultDocumentHighlightService.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/occurrences/DefaultDocumentHighlightService.java
@@ -74,6 +74,9 @@ public class DefaultDocumentHighlightService implements IDocumentHighlightServic
 	protected ILocationInFileProvider locationInFileProvider;
 
 	@Inject
+	protected ITextRegionTransformer textRegionTransformer;
+
+	@Inject
 	private Provider<TargetURIs> targetURIsProvider;
 
 	@Inject
@@ -81,9 +84,6 @@ public class DefaultDocumentHighlightService implements IDocumentHighlightServic
 
 	@Inject
 	private TargetURICollector uriCollector;
-
-	@Inject
-	private ITextRegionTransformer textRegionTransformer;
 
 	@Inject
 	private DocumentHighlightComparator comparator;


### PR DESCRIPTION
In the default case the ITextRegionTransformer is just a stateless utility class.

However in more complex cases it could need more information needing it to be protected.