### PR TITLE
GH-798: Increased the visibility of the stateful incremental builder.

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/build/IncrementalBuilder.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/build/IncrementalBuilder.xtend
@@ -48,10 +48,10 @@ import org.eclipse.xtext.generator.GeneratorContext
 		List<IResourceDescription.Delta> affectedResources
 	}
 	
-	@Log protected static class InternalStatefulIncrementalBuilder {
+	@Log static class InternalStatefulIncrementalBuilder {
 	
-		@Accessors(PROTECTED_SETTER) extension BuildContext context
-		@Accessors(PROTECTED_SETTER) BuildRequest request
+		@Accessors(#[PROTECTED_SETTER, PROTECTED_GETTER]) extension BuildContext context
+		@Accessors(#[PROTECTED_SETTER, PROTECTED_GETTER]) BuildRequest request
 	
 		@Inject Indexer indexer
 		@Inject extension OperationCanceledManager
@@ -219,8 +219,8 @@ import org.eclipse.xtext.generator.GeneratorContext
 									, clusteringPolicy,
 									request.cancelIndicator)
 		val builder = provider.get
-		builder.context = context
-		builder.request = request
+		builder.setContext(context)
+		builder.setRequest(request)
 		try {
 			return builder.launch
 		} catch(Throwable t) {

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/build/IncrementalBuilder.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/build/IncrementalBuilder.java
@@ -140,12 +140,12 @@ public class IncrementalBuilder {
   }
   
   @Log
-  protected static class InternalStatefulIncrementalBuilder {
-    @Accessors(AccessorType.PROTECTED_SETTER)
+  public static class InternalStatefulIncrementalBuilder {
+    @Accessors({ AccessorType.PROTECTED_SETTER, AccessorType.PROTECTED_GETTER })
     @Extension
     private BuildContext context;
     
-    @Accessors(AccessorType.PROTECTED_SETTER)
+    @Accessors({ AccessorType.PROTECTED_SETTER, AccessorType.PROTECTED_GETTER })
     private BuildRequest request;
     
     @Inject
@@ -363,8 +363,18 @@ public class IncrementalBuilder {
     
     private final static Logger LOG = Logger.getLogger(InternalStatefulIncrementalBuilder.class);
     
+    @Pure
+    protected BuildContext getContext() {
+      return this.context;
+    }
+    
     protected void setContext(final BuildContext context) {
       this.context = context;
+    }
+    
+    @Pure
+    protected BuildRequest getRequest() {
+      return this.request;
     }
     
     protected void setRequest(final BuildRequest request) {
@@ -393,8 +403,8 @@ public class IncrementalBuilder {
       CancelIndicator _cancelIndicator = request.getCancelIndicator();
       final BuildContext context = new BuildContext(languages, resourceSet, oldState, clusteringPolicy, _cancelIndicator);
       final IncrementalBuilder.InternalStatefulIncrementalBuilder builder = this.provider.get();
-      builder.context = context;
-      builder.request = request;
+      builder.setContext(context);
+      builder.setRequest(request);
       try {
         return builder.launch();
       } catch (final Throwable _t) {


### PR DESCRIPTION
Added `protected` setters for the build context and the request.
Replaced the context and request assignments with setter calls.

Closes #798.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>