### PR TITLE
[ChangeSerializer] Don't record EObjectDescs if not needed.

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/EObjectSnapshotProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/EObjectSnapshotProvider.java
@@ -148,10 +148,14 @@ public class EObjectSnapshotProvider {
 		protected final Resource resource;
 		protected final URI uri;
 
-		public ResourceSnapshot(EObjectSnapshotProvider strategy, Resource resource) {
+		public ResourceSnapshot(EObjectSnapshotProvider strategy, Resource resource, boolean recordReferences) {
 			this.resource = resource;
 			this.regions = strategy.getTextRegionAccess(resource);
-			this.objects = strategy.createEObjectSnapshots(resource);
+			if (recordReferences) {
+				this.objects = strategy.createEObjectSnapshots(resource);
+			} else {
+				this.objects = Collections.emptyMap();
+			}
 			this.uri = resource.getURI();
 		}
 
@@ -236,8 +240,8 @@ public class EObjectSnapshotProvider {
 
 	}
 
-	public IResourceSnapshot createResourceSnapshot(Resource resource) {
-		return new ResourceSnapshot(this, resource);
+	public IResourceSnapshot createResourceSnapshot(Resource resource, boolean recordReferences) {
+		return new ResourceSnapshot(this, resource, recordReferences);
 	}
 
 	protected EObjectSnapshot getOrCreate(Map<EObject, IEObjectSnapshot> map, EObject obj) {

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/RecordingEmfResourceUpdater.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/RecordingEmfResourceUpdater.java
@@ -40,7 +40,7 @@ public class RecordingEmfResourceUpdater extends RecordingResourceUpdater {
 
 	public void beginRecording(IChangeSerializer serializer, Resource resource) {
 		this.serializer = serializer;
-		this.snapshot = snapshotProvider.createResourceSnapshot(resource);
+		this.snapshot = snapshotProvider.createResourceSnapshot(resource, serializer.isUpdateCrossReferences());
 		EcoreUtil.resolveAll(resource);
 	}
 

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/RecordingXtextResourceUpdater.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/RecordingXtextResourceUpdater.java
@@ -92,7 +92,7 @@ public class RecordingXtextResourceUpdater extends RecordingResourceUpdater {
 
 	public ITextRegionDiffBuilder beginRecording(IChangeSerializer serializer, XtextResource resource) {
 		this.serializer = serializer;
-		this.snapshot = snapshotProvider.createResourceSnapshot(resource);
+		this.snapshot = snapshotProvider.createResourceSnapshot(resource, serializer.isUpdateCrossReferences());
 		this.document = new StringBasedTextRegionAccessDiffBuilder(this.snapshot.getRegions());
 		EcoreUtil.resolveAll(resource);
 		this.recorder = new ChangeRecorder(resource);


### PR DESCRIPTION
When CrossReferences are not updated, recording the descriptions should
not be needed.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>