### PR TITLE
GH-812: Implemented the semantic highlighting for the Xtext LS.

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -9,7 +9,11 @@ ext.versions = [
 	'xtext_bootstrap': '2.14.0',
 	'gradle_plugins': '0.1.0',
 	'xtext_gradle_plugin': '2.0.1',
-	'lsp4j': '0.4.0', // dont forget to adapt IdeProjectDescriptor + Tests
+	// When adjusting the `lsp4j` version here, do not forget to do the followings:
+	// - Update the version in `IdeProjectDescriptor#pom`.
+	// - Update the test expectations by running `CliWizardIntegrationTest#main`.
+	// - Update the versions in the `/org.eclipse.xtext.ide/META-INF/MANIFEST.MF` and `/org.eclipse.xtext.ide.tests/META-INF/MANIFEST.MF` files.
+	'lsp4j': '0.5.0.M1',
 	'log4j': '1.2.16',
 	'equinoxCommon' : '3.9.0',
 	'equinoxRegistry' : '3.7.0',

--- a/org.eclipse.xtext.ide.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ide.tests/META-INF/MANIFEST.MF
@@ -14,8 +14,8 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.xtext.ide,
  org.junit;bundle-version="4.12.0",
- org.eclipse.lsp4j;resolution:=optional,
- org.eclipse.lsp4j.jsonrpc;resolution:=optional,
+ org.eclipse.lsp4j;bundle-version="[0.5.0,0.6.0)";resolution:=optional,
+ org.eclipse.lsp4j.jsonrpc;bundle-version="[0.5.0,0.6.0)";resolution:=optional,
  org.eclipse.xtext.testlanguages,
  org.eclipse.xtext.testlanguages.ide
 Import-Package: org.apache.log4j;version="1.2.15"

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/DocumentTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/DocumentTest.xtend
@@ -107,6 +107,43 @@ class DocumentTest {
         ]
     }
     
+    @Test(expected=IndexOutOfBoundsException) def void testGetLineContent_negative() {
+        new Document(1, '').getLineContent(-1);
+    }
+
+    @Test(expected=IndexOutOfBoundsException) def void testGetLineContent_exceeds() {
+        new Document(1, '''
+        aaa
+        bbb
+        ccc''').getLineContent(3);
+    }
+
+    @Test def void testGetLineContent_empty() {
+        assertEquals('', new Document(1, '').getLineContent(0));
+    }
+
+    @Test def void testGetLineContent() {
+        assertEquals('bbb', new Document(1, '''
+        aaa
+        bbb
+        ccc''').getLineContent(1));
+    }
+
+    @Test def void testGetLineCount_empty() {
+        assertEquals(1, new Document(1, '').lineCount);
+    }
+
+    @Test def void testGetLineCount_single() {
+        assertEquals(1, new Document(1, 'aaa bbb ccc').lineCount);
+    }
+
+    @Test def void testGetLineCount_multi() {
+        assertEquals(3, new Document(1, '''
+        aaa
+        bbb
+        ccc''').lineCount);
+    }
+
     private def change(Position startPos, Position endPos, String newText) {
         new TextEdit => [
               if (startPos !== null) {

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/SemanticHighlightingTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/SemanticHighlightingTest.xtend
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.server
+
+import com.google.inject.Inject
+import java.util.List
+import org.eclipse.lsp4j.ClientCapabilities
+import org.eclipse.lsp4j.DidChangeTextDocumentParams
+import org.eclipse.lsp4j.SemanticHighlightingCapabilities
+import org.eclipse.lsp4j.TextDocumentClientCapabilities
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
+import org.eclipse.xtext.ide.server.UriExtensions
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+class SemanticHighlightingTest extends AbstractTestLangLanguageServerTest {
+
+	@Inject
+	extension UriExtensions;
+
+	List<List<String>> scopes;
+
+	@Before
+	def void before() {
+		scopes = initialize[
+			capabilities = new ClientCapabilities() => [
+				textDocument = new TextDocumentClientCapabilities() => [
+					semanticHighlightingCapabilities = new SemanticHighlightingCapabilities() => [
+						semanticHighlighting = true;
+					];
+				];
+			];
+		].capabilities.semanticHighlighting.scopes;
+	}
+
+	@Test
+	def void testDidOpen() {
+		val file = root.toPath.resolve('''MyModel.«fileExtension»''').toFile;
+		val uri = file.toURI.toUriString;
+		uri.open('''
+			type A {
+			  int a
+			  op foo() {}
+			  op foo(a: A): string {}
+			}''');
+		uri.assertInfos('''0 : [5:1:[typeDeclaration]]
+1 : [2:3:[primitiveType], 6:1:[identifier]]
+2 : [5:3:[identifier]]
+3 : [5:3:[identifier], 9:1:[parameterName], 12:1:[type], 16:6:[primitiveType]]
+4 : []''');
+	}
+	
+	@Test
+	def void testDidOpen_multiLine() {
+		val file = root.toPath.resolve('''MyModel.«fileExtension»''').toFile;
+		val uri = file.toURI.toUriString;
+		uri.open('''
+			type A {
+			  op foo() { 
+			  
+			    
+			  }
+			}''');
+		uri.assertInfos('''0 : [5:1:[typeDeclaration]]
+1 : [5:3:[identifier], 12:1:[opBody]]
+2 : [0:2:[opBody]]
+3 : [0:4:[opBody]]
+4 : [0:2:[opBody]]
+5 : []''');
+	}
+
+	@Test
+	def void testChange() {
+		val file = root.toPath.resolve('''MyModel.«fileExtension»''').toFile;
+		val fileUri = file.toURI.toUriString;
+		fileUri.open('''
+			type A {
+			  int a
+			  op foo() {}
+			  op foo(a: A): string {}
+			}''');
+		notifications.clear;
+		// Delete line: `  op foo() { }`
+		languageServer.didChange(new DidChangeTextDocumentParams => [
+			textDocument = new VersionedTextDocumentIdentifier => [
+				uri = fileUri;
+				version = 2;
+			];
+			contentChanges = #[
+				new TextDocumentContentChangeEvent => [
+					text = '''
+					type A {
+					  int a
+					  op foo(a: A): string {}
+					}'''
+				]
+			];
+		]);
+
+		fileUri.assertInfos('''0 : [5:1:[typeDeclaration]]
+1 : [2:3:[primitiveType], 6:1:[identifier]]
+2 : [5:3:[identifier], 9:1:[parameterName], 12:1:[type], 16:6:[primitiveType]]
+3 : []''');
+
+		notifications.clear;
+		// Delete line: `  op foo(a: A): string { }`
+		languageServer.didChange(new DidChangeTextDocumentParams => [
+			textDocument = new VersionedTextDocumentIdentifier => [
+				uri = fileUri;
+				version = 3;
+			];
+			contentChanges = #[
+				new TextDocumentContentChangeEvent => [
+					text = '''
+					type A {
+					  int a
+					}'''
+				]
+			];
+		]);
+		fileUri.assertInfos('''0 : [5:1:[typeDeclaration]]
+1 : [2:3:[primitiveType], 6:1:[identifier]]
+2 : []''');
+
+		notifications.clear;
+		// Restore the original state.
+		languageServer.didChange(new DidChangeTextDocumentParams => [
+			textDocument = new VersionedTextDocumentIdentifier => [
+				uri = fileUri;
+				version = 3;
+			];
+			contentChanges = #[
+				new TextDocumentContentChangeEvent => [
+					text = '''
+					type A {
+					  int a
+					  op foo() {}
+					  op foo(a: A): string {}
+					}'''
+				]
+			];
+		]);
+		fileUri.assertInfos('''0 : [5:1:[typeDeclaration]]
+1 : [2:3:[primitiveType], 6:1:[identifier]]
+2 : [5:3:[identifier]]
+3 : [5:3:[identifier], 9:1:[parameterName], 12:1:[type], 16:6:[primitiveType]]
+4 : []''');
+
+	}
+
+	protected def void assertInfos(String uri, String expected) {
+		val params = semanticHighlightingParams;
+		assertEquals(1, params.size);
+		val entry = params.entrySet.findFirst[key.uri == uri];
+		assertNotNull(entry);
+		val actual = entry.value.sortWith[left, right|left.line - right.line].map[it -> scopes].map [
+			toExpectation
+		].join('\n');
+		assertEquals(expected, actual);
+	}
+
+}

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/TestLanguageRuntimeModule.xtend
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/TestLanguageRuntimeModule.xtend
@@ -8,9 +8,13 @@
 package org.eclipse.xtext.ide.tests.testlanguage
 
 import org.eclipse.xtext.formatting2.IFormatter2
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator
 import org.eclipse.xtext.ide.server.coloring.IColoringService
+import org.eclipse.xtext.ide.server.semanticHighlight.ISemanticHighlightingStyleToTokenMapper
 import org.eclipse.xtext.ide.server.signatureHelp.ISignatureHelpService
 import org.eclipse.xtext.ide.tests.testlanguage.coloring.ColoringServiceImpl
+import org.eclipse.xtext.ide.tests.testlanguage.editor.syntaxcoloring.SemanticHighlightingCalculatorImpl
+import org.eclipse.xtext.ide.tests.testlanguage.editor.syntaxcoloring.SemanticHighlightingStyleToTokenMapper
 import org.eclipse.xtext.ide.tests.testlanguage.formatting2.TestLanguageFormatter
 import org.eclipse.xtext.ide.tests.testlanguage.signatureHelp.SignatureHelpServiceImpl
 
@@ -23,12 +27,20 @@ class TestLanguageRuntimeModule extends AbstractTestLanguageRuntimeModule {
 		return TestLanguageFormatter;
 	}
 	
-    def Class<? extends ISignatureHelpService> bindSignatureHelpService() {
-        return SignatureHelpServiceImpl;
-    }
-    
-    def Class<? extends IColoringService> bindIColoringService() {
-    	return ColoringServiceImpl;
-    }
+	def Class<? extends ISignatureHelpService> bindSignatureHelpService() {
+		return SignatureHelpServiceImpl;
+	}
+
+	def Class<? extends IColoringService> bindIColoringService() {
+		return ColoringServiceImpl;
+	}
+
+	def Class<? extends ISemanticHighlightingCalculator> bindISemanticHighlightingCalculator() {
+		return SemanticHighlightingCalculatorImpl;
+	}
+
+	def Class<? extends ISemanticHighlightingStyleToTokenMapper> bindISemanticHighlightingStyleToTokenMapper() {
+		return SemanticHighlightingStyleToTokenMapper;
+	}
 
 }

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/editor/syntaxcoloring/SemanticHighlightingCalculatorImpl.xtend
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/editor/syntaxcoloring/SemanticHighlightingCalculatorImpl.xtend
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.testlanguage.editor.syntaxcoloring
+
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.EStructuralFeature
+import org.eclipse.xtext.ide.editor.syntaxcoloring.DefaultSemanticHighlightingCalculator
+import org.eclipse.xtext.ide.editor.syntaxcoloring.IHighlightedPositionAcceptor
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.Operation
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.Parameter
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.PrimitiveType
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.Property
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.TypeDeclaration
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.TypeReference
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils
+import org.eclipse.xtext.util.CancelIndicator
+
+import static org.eclipse.xtext.ide.tests.testlanguage.testLanguage.TestLanguagePackage.Literals.*
+
+class SemanticHighlightingCalculatorImpl extends DefaultSemanticHighlightingCalculator {
+
+	static val IDENTIFIER_STYLE = 'identifier';
+	static val PRIMITIVE_TYPE_STYLE = 'primitiveType';
+	static val TYPE_STYLE = 'type';
+	static val TYPE_DECLARATION_STYLE = 'typeDeclaration';
+	static val PARAMETER_NAME_STYLE = 'parameterName';
+	static val OP_BODY_STYLE = 'opBody';
+
+	public static val STYLES = #{
+		IDENTIFIER_STYLE,
+		PRIMITIVE_TYPE_STYLE,
+		TYPE_STYLE,
+		TYPE_DECLARATION_STYLE,
+		PARAMETER_NAME_STYLE,
+		OP_BODY_STYLE
+	};
+
+	override protected highlightElement(EObject object, IHighlightedPositionAcceptor acceptor,
+		CancelIndicator cancelIndicator) {
+
+		return object.doHighlightElement(acceptor);
+	}
+
+	def dispatch boolean doHighlightElement(EObject it, IHighlightedPositionAcceptor acceptor) {
+		return false;
+	}
+
+	def dispatch boolean doHighlightElement(Property it, IHighlightedPositionAcceptor acceptor) {
+		return acceptor.doHighlightNode(it, MEMBER__NAME, IDENTIFIER_STYLE);
+	}
+
+	def dispatch boolean doHighlightElement(Operation it, IHighlightedPositionAcceptor acceptor) {
+		val canStop = acceptor.doHighlightNode(it, MEMBER__NAME, IDENTIFIER_STYLE);
+		// Besides highlighting the name of the operation, we highlight the body between the braces (exclusive)
+		// to ensure, we can map a single multi-line range into several corresponding highlighting tokens.
+		val opNode = NodeModelUtils.findActualNodeFor(it)
+		if (opNode !== null) {
+			val inverseChildren = opNode.leafNodes.filter[!hidden].toList.reverse;
+			var endOffset = -1;
+			var startOffset = -1;
+			if (inverseChildren.head?.text == '}') {
+				endOffset = inverseChildren.head.endOffset - 1; // exclusive
+			}
+			if (endOffset !== -1) {
+				val opStartNode = inverseChildren.findFirst[text.trim == '{'];
+				if (opStartNode !== null) {
+					startOffset = opStartNode.offset + 1; // exclusive
+				}
+			}
+			if (startOffset >= 0 && endOffset >= 0) {
+				acceptor.addPosition(startOffset, endOffset - startOffset, OP_BODY_STYLE);
+			}
+		}
+		return canStop;
+	}
+
+	def dispatch boolean doHighlightElement(TypeDeclaration it, IHighlightedPositionAcceptor acceptor) {
+		return acceptor.doHighlightNode(it, TYPE_DECLARATION__NAME, TYPE_DECLARATION_STYLE);
+	}
+
+	def dispatch boolean doHighlightElement(PrimitiveType it, IHighlightedPositionAcceptor acceptor) {
+		return acceptor.doHighlightNode(it, PRIMITIVE_TYPE__NAME, PRIMITIVE_TYPE_STYLE);
+	}
+
+	def dispatch boolean doHighlightElement(TypeReference it, IHighlightedPositionAcceptor acceptor) {
+		return acceptor.doHighlightNode(it, TYPE_REFERENCE__TYPE_REF, TYPE_STYLE);
+	}
+
+	def dispatch boolean doHighlightElement(Parameter it, IHighlightedPositionAcceptor acceptor) {
+		return acceptor.doHighlightNode(it, PARAMETER__NAME, PARAMETER_NAME_STYLE);
+	}
+
+	def doHighlightNode(IHighlightedPositionAcceptor acceptor, EObject object, EStructuralFeature feature,
+		String style) {
+
+		NodeModelUtils.findNodesForFeature(object, feature).forEach [
+			acceptor.addPosition(offset, length, style)
+		];
+		return false;
+	}
+
+}

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/editor/syntaxcoloring/SemanticHighlightingStyleToTokenMapper.xtend
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/editor/syntaxcoloring/SemanticHighlightingStyleToTokenMapper.xtend
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.testlanguage.editor.syntaxcoloring
+
+import org.eclipse.xtext.ide.server.semanticHighlight.ISemanticHighlightingStyleToTokenMapper
+
+class SemanticHighlightingStyleToTokenMapper implements ISemanticHighlightingStyleToTokenMapper {
+
+	override toScopes(String styleId) {
+		return #[styleId];
+	}
+
+	override getAllStyleIds() {
+		return SemanticHighlightingCalculatorImpl.STYLES;
+	}
+
+}

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/server/CodeActionService.xtend
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/server/CodeActionService.xtend
@@ -29,6 +29,7 @@ import org.eclipse.xtext.util.CollectionBasedAcceptor
 import org.eclipse.xtext.util.StringInputStream
 
 import static org.eclipse.xtext.ide.tests.testlanguage.validation.TestLanguageValidator.*
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -46,7 +47,7 @@ class CodeActionService implements ICodeActionService {
 				case UNSORTED_MEMBERS: commands += d.fixUnsortedMembers(document, resource, params)
 			}
 		}
-		return commands
+		return commands.map[Either.forLeft(it)];
 	}
 
 	def private Command fixInvalidName(Diagnostic d, Document doc, XtextResource res, CodeActionParams params) {

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/commands/CommandRegistryTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/commands/CommandRegistryTest.java
@@ -24,6 +24,7 @@ import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.SemanticHighlightingParams;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.Unregistration;
 import org.eclipse.lsp4j.UnregistrationParams;
@@ -187,6 +188,10 @@ public class CommandRegistryTest implements IResourceServiceProvider, IExecutabl
   
   public void publishDiagnostics(final PublishDiagnosticsParams diagnostics) {
     this.noImpl3.publishDiagnostics(diagnostics);
+  }
+  
+  public void semanticHighlighting(final SemanticHighlightingParams params) {
+    this.noImpl3.semanticHighlighting(params);
   }
   
   public void showMessage(final MessageParams messageParams) {

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/DocumentTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/DocumentTest.java
@@ -161,6 +161,59 @@ public class DocumentTest {
     ObjectExtensions.<Document>operator_doubleArrow(_document, _function);
   }
   
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testGetLineContent_negative() {
+    new Document(Integer.valueOf(1), "").getLineContent((-1));
+  }
+  
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testGetLineContent_exceeds() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("aaa");
+    _builder.newLine();
+    _builder.append("bbb");
+    _builder.newLine();
+    _builder.append("ccc");
+    new Document(Integer.valueOf(1), _builder.toString()).getLineContent(3);
+  }
+  
+  @Test
+  public void testGetLineContent_empty() {
+    Assert.assertEquals("", new Document(Integer.valueOf(1), "").getLineContent(0));
+  }
+  
+  @Test
+  public void testGetLineContent() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("aaa");
+    _builder.newLine();
+    _builder.append("bbb");
+    _builder.newLine();
+    _builder.append("ccc");
+    Assert.assertEquals("bbb", new Document(Integer.valueOf(1), _builder.toString()).getLineContent(1));
+  }
+  
+  @Test
+  public void testGetLineCount_empty() {
+    Assert.assertEquals(1, new Document(Integer.valueOf(1), "").getLineCount());
+  }
+  
+  @Test
+  public void testGetLineCount_single() {
+    Assert.assertEquals(1, new Document(Integer.valueOf(1), "aaa bbb ccc").getLineCount());
+  }
+  
+  @Test
+  public void testGetLineCount_multi() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("aaa");
+    _builder.newLine();
+    _builder.append("bbb");
+    _builder.newLine();
+    _builder.append("ccc");
+    Assert.assertEquals(3, new Document(Integer.valueOf(1), _builder.toString()).getLineCount());
+  }
+  
   private TextEdit change(final Position startPos, final Position endPos, final String newText) {
     TextEdit _textEdit = new TextEdit();
     final Procedure1<TextEdit> _function = (TextEdit it) -> {

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/SemanticHighlightingTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/SemanticHighlightingTest.java
@@ -1,0 +1,306 @@
+/**
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.tests.server;
+
+import com.google.common.base.Objects;
+import com.google.inject.Inject;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.SemanticHighlightingCapabilities;
+import org.eclipse.lsp4j.SemanticHighlightingInformation;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.ide.server.UriExtensions;
+import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ListExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Pair;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@SuppressWarnings("all")
+public class SemanticHighlightingTest extends AbstractTestLangLanguageServerTest {
+  @Inject
+  @Extension
+  private UriExtensions _uriExtensions;
+  
+  private List<List<String>> scopes;
+  
+  @Before
+  public void before() {
+    final Procedure1<InitializeParams> _function = (InitializeParams it) -> {
+      ClientCapabilities _clientCapabilities = new ClientCapabilities();
+      final Procedure1<ClientCapabilities> _function_1 = (ClientCapabilities it_1) -> {
+        TextDocumentClientCapabilities _textDocumentClientCapabilities = new TextDocumentClientCapabilities();
+        final Procedure1<TextDocumentClientCapabilities> _function_2 = (TextDocumentClientCapabilities it_2) -> {
+          SemanticHighlightingCapabilities _semanticHighlightingCapabilities = new SemanticHighlightingCapabilities();
+          final Procedure1<SemanticHighlightingCapabilities> _function_3 = (SemanticHighlightingCapabilities it_3) -> {
+            it_3.setSemanticHighlighting(Boolean.valueOf(true));
+          };
+          SemanticHighlightingCapabilities _doubleArrow = ObjectExtensions.<SemanticHighlightingCapabilities>operator_doubleArrow(_semanticHighlightingCapabilities, _function_3);
+          it_2.setSemanticHighlightingCapabilities(_doubleArrow);
+        };
+        TextDocumentClientCapabilities _doubleArrow = ObjectExtensions.<TextDocumentClientCapabilities>operator_doubleArrow(_textDocumentClientCapabilities, _function_2);
+        it_1.setTextDocument(_doubleArrow);
+      };
+      ClientCapabilities _doubleArrow = ObjectExtensions.<ClientCapabilities>operator_doubleArrow(_clientCapabilities, _function_1);
+      it.setCapabilities(_doubleArrow);
+    };
+    this.scopes = this.initialize(_function).getCapabilities().getSemanticHighlighting().getScopes();
+  }
+  
+  @Test
+  public void testDidOpen() {
+    Path _path = this.root.toPath();
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("MyModel.");
+    _builder.append(this.fileExtension);
+    final File file = _path.resolve(_builder.toString()).toFile();
+    final String uri = this._uriExtensions.toUriString(file.toURI());
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("type A {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("int a");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("op foo() {}");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("op foo(a: A): string {}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    this.open(uri, _builder_1.toString());
+    StringConcatenation _builder_2 = new StringConcatenation();
+    _builder_2.append("0 : [5:1:[typeDeclaration]]");
+    _builder_2.newLine();
+    _builder_2.append("1 : [2:3:[primitiveType], 6:1:[identifier]]");
+    _builder_2.newLine();
+    _builder_2.append("2 : [5:3:[identifier]]");
+    _builder_2.newLine();
+    _builder_2.append("3 : [5:3:[identifier], 9:1:[parameterName], 12:1:[type], 16:6:[primitiveType]]");
+    _builder_2.newLine();
+    _builder_2.append("4 : []");
+    this.assertInfos(uri, _builder_2.toString());
+  }
+  
+  @Test
+  public void testDidOpen_multiLine() {
+    Path _path = this.root.toPath();
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("MyModel.");
+    _builder.append(this.fileExtension);
+    final File file = _path.resolve(_builder.toString()).toFile();
+    final String uri = this._uriExtensions.toUriString(file.toURI());
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("type A {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("op foo() { ");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    this.open(uri, _builder_1.toString());
+    StringConcatenation _builder_2 = new StringConcatenation();
+    _builder_2.append("0 : [5:1:[typeDeclaration]]");
+    _builder_2.newLine();
+    _builder_2.append("1 : [5:3:[identifier], 12:1:[opBody]]");
+    _builder_2.newLine();
+    _builder_2.append("2 : [0:2:[opBody]]");
+    _builder_2.newLine();
+    _builder_2.append("3 : [0:4:[opBody]]");
+    _builder_2.newLine();
+    _builder_2.append("4 : [0:2:[opBody]]");
+    _builder_2.newLine();
+    _builder_2.append("5 : []");
+    this.assertInfos(uri, _builder_2.toString());
+  }
+  
+  @Test
+  public void testChange() {
+    Path _path = this.root.toPath();
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("MyModel.");
+    _builder.append(this.fileExtension);
+    final File file = _path.resolve(_builder.toString()).toFile();
+    final String fileUri = this._uriExtensions.toUriString(file.toURI());
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("type A {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("int a");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("op foo() {}");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("op foo(a: A): string {}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    this.open(fileUri, _builder_1.toString());
+    this.notifications.clear();
+    DidChangeTextDocumentParams _didChangeTextDocumentParams = new DidChangeTextDocumentParams();
+    final Procedure1<DidChangeTextDocumentParams> _function = (DidChangeTextDocumentParams it) -> {
+      VersionedTextDocumentIdentifier _versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier();
+      final Procedure1<VersionedTextDocumentIdentifier> _function_1 = (VersionedTextDocumentIdentifier it_1) -> {
+        it_1.setUri(fileUri);
+        it_1.setVersion(Integer.valueOf(2));
+      };
+      VersionedTextDocumentIdentifier _doubleArrow = ObjectExtensions.<VersionedTextDocumentIdentifier>operator_doubleArrow(_versionedTextDocumentIdentifier, _function_1);
+      it.setTextDocument(_doubleArrow);
+      TextDocumentContentChangeEvent _textDocumentContentChangeEvent = new TextDocumentContentChangeEvent();
+      final Procedure1<TextDocumentContentChangeEvent> _function_2 = (TextDocumentContentChangeEvent it_1) -> {
+        StringConcatenation _builder_2 = new StringConcatenation();
+        _builder_2.append("type A {");
+        _builder_2.newLine();
+        _builder_2.append("  ");
+        _builder_2.append("int a");
+        _builder_2.newLine();
+        _builder_2.append("  ");
+        _builder_2.append("op foo(a: A): string {}");
+        _builder_2.newLine();
+        _builder_2.append("}");
+        it_1.setText(_builder_2.toString());
+      };
+      TextDocumentContentChangeEvent _doubleArrow_1 = ObjectExtensions.<TextDocumentContentChangeEvent>operator_doubleArrow(_textDocumentContentChangeEvent, _function_2);
+      it.setContentChanges(Collections.<TextDocumentContentChangeEvent>unmodifiableList(CollectionLiterals.<TextDocumentContentChangeEvent>newArrayList(_doubleArrow_1)));
+    };
+    DidChangeTextDocumentParams _doubleArrow = ObjectExtensions.<DidChangeTextDocumentParams>operator_doubleArrow(_didChangeTextDocumentParams, _function);
+    this.languageServer.didChange(_doubleArrow);
+    StringConcatenation _builder_2 = new StringConcatenation();
+    _builder_2.append("0 : [5:1:[typeDeclaration]]");
+    _builder_2.newLine();
+    _builder_2.append("1 : [2:3:[primitiveType], 6:1:[identifier]]");
+    _builder_2.newLine();
+    _builder_2.append("2 : [5:3:[identifier], 9:1:[parameterName], 12:1:[type], 16:6:[primitiveType]]");
+    _builder_2.newLine();
+    _builder_2.append("3 : []");
+    this.assertInfos(fileUri, _builder_2.toString());
+    this.notifications.clear();
+    DidChangeTextDocumentParams _didChangeTextDocumentParams_1 = new DidChangeTextDocumentParams();
+    final Procedure1<DidChangeTextDocumentParams> _function_1 = (DidChangeTextDocumentParams it) -> {
+      VersionedTextDocumentIdentifier _versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier();
+      final Procedure1<VersionedTextDocumentIdentifier> _function_2 = (VersionedTextDocumentIdentifier it_1) -> {
+        it_1.setUri(fileUri);
+        it_1.setVersion(Integer.valueOf(3));
+      };
+      VersionedTextDocumentIdentifier _doubleArrow_1 = ObjectExtensions.<VersionedTextDocumentIdentifier>operator_doubleArrow(_versionedTextDocumentIdentifier, _function_2);
+      it.setTextDocument(_doubleArrow_1);
+      TextDocumentContentChangeEvent _textDocumentContentChangeEvent = new TextDocumentContentChangeEvent();
+      final Procedure1<TextDocumentContentChangeEvent> _function_3 = (TextDocumentContentChangeEvent it_1) -> {
+        StringConcatenation _builder_3 = new StringConcatenation();
+        _builder_3.append("type A {");
+        _builder_3.newLine();
+        _builder_3.append("  ");
+        _builder_3.append("int a");
+        _builder_3.newLine();
+        _builder_3.append("}");
+        it_1.setText(_builder_3.toString());
+      };
+      TextDocumentContentChangeEvent _doubleArrow_2 = ObjectExtensions.<TextDocumentContentChangeEvent>operator_doubleArrow(_textDocumentContentChangeEvent, _function_3);
+      it.setContentChanges(Collections.<TextDocumentContentChangeEvent>unmodifiableList(CollectionLiterals.<TextDocumentContentChangeEvent>newArrayList(_doubleArrow_2)));
+    };
+    DidChangeTextDocumentParams _doubleArrow_1 = ObjectExtensions.<DidChangeTextDocumentParams>operator_doubleArrow(_didChangeTextDocumentParams_1, _function_1);
+    this.languageServer.didChange(_doubleArrow_1);
+    StringConcatenation _builder_3 = new StringConcatenation();
+    _builder_3.append("0 : [5:1:[typeDeclaration]]");
+    _builder_3.newLine();
+    _builder_3.append("1 : [2:3:[primitiveType], 6:1:[identifier]]");
+    _builder_3.newLine();
+    _builder_3.append("2 : []");
+    this.assertInfos(fileUri, _builder_3.toString());
+    this.notifications.clear();
+    DidChangeTextDocumentParams _didChangeTextDocumentParams_2 = new DidChangeTextDocumentParams();
+    final Procedure1<DidChangeTextDocumentParams> _function_2 = (DidChangeTextDocumentParams it) -> {
+      VersionedTextDocumentIdentifier _versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier();
+      final Procedure1<VersionedTextDocumentIdentifier> _function_3 = (VersionedTextDocumentIdentifier it_1) -> {
+        it_1.setUri(fileUri);
+        it_1.setVersion(Integer.valueOf(3));
+      };
+      VersionedTextDocumentIdentifier _doubleArrow_2 = ObjectExtensions.<VersionedTextDocumentIdentifier>operator_doubleArrow(_versionedTextDocumentIdentifier, _function_3);
+      it.setTextDocument(_doubleArrow_2);
+      TextDocumentContentChangeEvent _textDocumentContentChangeEvent = new TextDocumentContentChangeEvent();
+      final Procedure1<TextDocumentContentChangeEvent> _function_4 = (TextDocumentContentChangeEvent it_1) -> {
+        StringConcatenation _builder_4 = new StringConcatenation();
+        _builder_4.append("type A {");
+        _builder_4.newLine();
+        _builder_4.append("  ");
+        _builder_4.append("int a");
+        _builder_4.newLine();
+        _builder_4.append("  ");
+        _builder_4.append("op foo() {}");
+        _builder_4.newLine();
+        _builder_4.append("  ");
+        _builder_4.append("op foo(a: A): string {}");
+        _builder_4.newLine();
+        _builder_4.append("}");
+        it_1.setText(_builder_4.toString());
+      };
+      TextDocumentContentChangeEvent _doubleArrow_3 = ObjectExtensions.<TextDocumentContentChangeEvent>operator_doubleArrow(_textDocumentContentChangeEvent, _function_4);
+      it.setContentChanges(Collections.<TextDocumentContentChangeEvent>unmodifiableList(CollectionLiterals.<TextDocumentContentChangeEvent>newArrayList(_doubleArrow_3)));
+    };
+    DidChangeTextDocumentParams _doubleArrow_2 = ObjectExtensions.<DidChangeTextDocumentParams>operator_doubleArrow(_didChangeTextDocumentParams_2, _function_2);
+    this.languageServer.didChange(_doubleArrow_2);
+    StringConcatenation _builder_4 = new StringConcatenation();
+    _builder_4.append("0 : [5:1:[typeDeclaration]]");
+    _builder_4.newLine();
+    _builder_4.append("1 : [2:3:[primitiveType], 6:1:[identifier]]");
+    _builder_4.newLine();
+    _builder_4.append("2 : [5:3:[identifier]]");
+    _builder_4.newLine();
+    _builder_4.append("3 : [5:3:[identifier], 9:1:[parameterName], 12:1:[type], 16:6:[primitiveType]]");
+    _builder_4.newLine();
+    _builder_4.append("4 : []");
+    this.assertInfos(fileUri, _builder_4.toString());
+  }
+  
+  protected void assertInfos(final String uri, final String expected) {
+    final Map<VersionedTextDocumentIdentifier, List<SemanticHighlightingInformation>> params = this.getSemanticHighlightingParams();
+    Assert.assertEquals(1, params.size());
+    final Function1<Map.Entry<VersionedTextDocumentIdentifier, List<SemanticHighlightingInformation>>, Boolean> _function = (Map.Entry<VersionedTextDocumentIdentifier, List<SemanticHighlightingInformation>> it) -> {
+      String _uri = it.getKey().getUri();
+      return Boolean.valueOf(Objects.equal(_uri, uri));
+    };
+    final Map.Entry<VersionedTextDocumentIdentifier, List<SemanticHighlightingInformation>> entry = IterableExtensions.<Map.Entry<VersionedTextDocumentIdentifier, List<SemanticHighlightingInformation>>>findFirst(params.entrySet(), _function);
+    Assert.assertNotNull(entry);
+    final Comparator<SemanticHighlightingInformation> _function_1 = (SemanticHighlightingInformation left, SemanticHighlightingInformation right) -> {
+      int _line = left.getLine();
+      int _line_1 = right.getLine();
+      return (_line - _line_1);
+    };
+    final Function1<SemanticHighlightingInformation, Pair<SemanticHighlightingInformation, List<List<String>>>> _function_2 = (SemanticHighlightingInformation it) -> {
+      return Pair.<SemanticHighlightingInformation, List<List<String>>>of(it, this.scopes);
+    };
+    final Function1<Pair<SemanticHighlightingInformation, List<List<String>>>, String> _function_3 = (Pair<SemanticHighlightingInformation, List<List<String>>> it) -> {
+      return this.toExpectation(it);
+    };
+    final String actual = IterableExtensions.join(ListExtensions.<Pair<SemanticHighlightingInformation, List<List<String>>>, String>map(ListExtensions.<SemanticHighlightingInformation, Pair<SemanticHighlightingInformation, List<List<String>>>>map(IterableExtensions.<SemanticHighlightingInformation>sortWith(entry.getValue(), _function_1), _function_2), _function_3), "\n");
+    this.assertEquals(expected, actual);
+  }
+}

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/TestLanguageRuntimeModule.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/TestLanguageRuntimeModule.java
@@ -8,10 +8,14 @@
 package org.eclipse.xtext.ide.tests.testlanguage;
 
 import org.eclipse.xtext.formatting2.IFormatter2;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
 import org.eclipse.xtext.ide.server.coloring.IColoringService;
+import org.eclipse.xtext.ide.server.semanticHighlight.ISemanticHighlightingStyleToTokenMapper;
 import org.eclipse.xtext.ide.server.signatureHelp.ISignatureHelpService;
 import org.eclipse.xtext.ide.tests.testlanguage.AbstractTestLanguageRuntimeModule;
 import org.eclipse.xtext.ide.tests.testlanguage.coloring.ColoringServiceImpl;
+import org.eclipse.xtext.ide.tests.testlanguage.editor.syntaxcoloring.SemanticHighlightingCalculatorImpl;
+import org.eclipse.xtext.ide.tests.testlanguage.editor.syntaxcoloring.SemanticHighlightingStyleToTokenMapper;
 import org.eclipse.xtext.ide.tests.testlanguage.formatting2.TestLanguageFormatter;
 import org.eclipse.xtext.ide.tests.testlanguage.signatureHelp.SignatureHelpServiceImpl;
 
@@ -30,5 +34,13 @@ public class TestLanguageRuntimeModule extends AbstractTestLanguageRuntimeModule
   
   public Class<? extends IColoringService> bindIColoringService() {
     return ColoringServiceImpl.class;
+  }
+  
+  public Class<? extends ISemanticHighlightingCalculator> bindISemanticHighlightingCalculator() {
+    return SemanticHighlightingCalculatorImpl.class;
+  }
+  
+  public Class<? extends ISemanticHighlightingStyleToTokenMapper> bindISemanticHighlightingStyleToTokenMapper() {
+    return SemanticHighlightingStyleToTokenMapper.class;
   }
 }

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/editor/syntaxcoloring/SemanticHighlightingCalculatorImpl.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/editor/syntaxcoloring/SemanticHighlightingCalculatorImpl.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.tests.testlanguage.editor.syntaxcoloring;
+
+import com.google.common.base.Objects;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.DefaultSemanticHighlightingCalculator;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.IHighlightedPositionAcceptor;
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.Operation;
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.Parameter;
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.PrimitiveType;
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.Property;
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.TestLanguagePackage;
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.TypeDeclaration;
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.TypeReference;
+import org.eclipse.xtext.nodemodel.ICompositeNode;
+import org.eclipse.xtext.nodemodel.ILeafNode;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ListExtensions;
+
+@SuppressWarnings("all")
+public class SemanticHighlightingCalculatorImpl extends DefaultSemanticHighlightingCalculator {
+  private final static String IDENTIFIER_STYLE = "identifier";
+  
+  private final static String PRIMITIVE_TYPE_STYLE = "primitiveType";
+  
+  private final static String TYPE_STYLE = "type";
+  
+  private final static String TYPE_DECLARATION_STYLE = "typeDeclaration";
+  
+  private final static String PARAMETER_NAME_STYLE = "parameterName";
+  
+  private final static String OP_BODY_STYLE = "opBody";
+  
+  public final static Set<String> STYLES = Collections.<String>unmodifiableSet(CollectionLiterals.<String>newHashSet(SemanticHighlightingCalculatorImpl.IDENTIFIER_STYLE, SemanticHighlightingCalculatorImpl.PRIMITIVE_TYPE_STYLE, SemanticHighlightingCalculatorImpl.TYPE_STYLE, SemanticHighlightingCalculatorImpl.TYPE_DECLARATION_STYLE, SemanticHighlightingCalculatorImpl.PARAMETER_NAME_STYLE, SemanticHighlightingCalculatorImpl.OP_BODY_STYLE));
+  
+  @Override
+  protected boolean highlightElement(final EObject object, final IHighlightedPositionAcceptor acceptor, final CancelIndicator cancelIndicator) {
+    return this.doHighlightElement(object, acceptor);
+  }
+  
+  protected boolean _doHighlightElement(final EObject it, final IHighlightedPositionAcceptor acceptor) {
+    return false;
+  }
+  
+  protected boolean _doHighlightElement(final Property it, final IHighlightedPositionAcceptor acceptor) {
+    return this.doHighlightNode(acceptor, it, TestLanguagePackage.Literals.MEMBER__NAME, SemanticHighlightingCalculatorImpl.IDENTIFIER_STYLE);
+  }
+  
+  protected boolean _doHighlightElement(final Operation it, final IHighlightedPositionAcceptor acceptor) {
+    final boolean canStop = this.doHighlightNode(acceptor, it, TestLanguagePackage.Literals.MEMBER__NAME, SemanticHighlightingCalculatorImpl.IDENTIFIER_STYLE);
+    final ICompositeNode opNode = NodeModelUtils.findActualNodeFor(it);
+    if ((opNode != null)) {
+      final Function1<ILeafNode, Boolean> _function = (ILeafNode it_1) -> {
+        boolean _isHidden = it_1.isHidden();
+        return Boolean.valueOf((!_isHidden));
+      };
+      final List<ILeafNode> inverseChildren = ListExtensions.<ILeafNode>reverse(IterableExtensions.<ILeafNode>toList(IterableExtensions.<ILeafNode>filter(opNode.getLeafNodes(), _function)));
+      int endOffset = (-1);
+      int startOffset = (-1);
+      ILeafNode _head = IterableExtensions.<ILeafNode>head(inverseChildren);
+      String _text = null;
+      if (_head!=null) {
+        _text=_head.getText();
+      }
+      boolean _equals = Objects.equal(_text, "}");
+      if (_equals) {
+        int _endOffset = IterableExtensions.<ILeafNode>head(inverseChildren).getEndOffset();
+        int _minus = (_endOffset - 1);
+        endOffset = _minus;
+      }
+      if ((endOffset != (-1))) {
+        final Function1<ILeafNode, Boolean> _function_1 = (ILeafNode it_1) -> {
+          String _trim = it_1.getText().trim();
+          return Boolean.valueOf(Objects.equal(_trim, "{"));
+        };
+        final ILeafNode opStartNode = IterableExtensions.<ILeafNode>findFirst(inverseChildren, _function_1);
+        if ((opStartNode != null)) {
+          int _offset = opStartNode.getOffset();
+          int _plus = (_offset + 1);
+          startOffset = _plus;
+        }
+      }
+      if (((startOffset >= 0) && (endOffset >= 0))) {
+        acceptor.addPosition(startOffset, (endOffset - startOffset), SemanticHighlightingCalculatorImpl.OP_BODY_STYLE);
+      }
+    }
+    return canStop;
+  }
+  
+  protected boolean _doHighlightElement(final TypeDeclaration it, final IHighlightedPositionAcceptor acceptor) {
+    return this.doHighlightNode(acceptor, it, TestLanguagePackage.Literals.TYPE_DECLARATION__NAME, SemanticHighlightingCalculatorImpl.TYPE_DECLARATION_STYLE);
+  }
+  
+  protected boolean _doHighlightElement(final PrimitiveType it, final IHighlightedPositionAcceptor acceptor) {
+    return this.doHighlightNode(acceptor, it, TestLanguagePackage.Literals.PRIMITIVE_TYPE__NAME, SemanticHighlightingCalculatorImpl.PRIMITIVE_TYPE_STYLE);
+  }
+  
+  protected boolean _doHighlightElement(final TypeReference it, final IHighlightedPositionAcceptor acceptor) {
+    return this.doHighlightNode(acceptor, it, TestLanguagePackage.Literals.TYPE_REFERENCE__TYPE_REF, SemanticHighlightingCalculatorImpl.TYPE_STYLE);
+  }
+  
+  protected boolean _doHighlightElement(final Parameter it, final IHighlightedPositionAcceptor acceptor) {
+    return this.doHighlightNode(acceptor, it, TestLanguagePackage.Literals.PARAMETER__NAME, SemanticHighlightingCalculatorImpl.PARAMETER_NAME_STYLE);
+  }
+  
+  public boolean doHighlightNode(final IHighlightedPositionAcceptor acceptor, final EObject object, final EStructuralFeature feature, final String style) {
+    final Consumer<INode> _function = (INode it) -> {
+      acceptor.addPosition(it.getOffset(), it.getLength(), style);
+    };
+    NodeModelUtils.findNodesForFeature(object, feature).forEach(_function);
+    return false;
+  }
+  
+  public boolean doHighlightElement(final EObject it, final IHighlightedPositionAcceptor acceptor) {
+    if (it instanceof Operation) {
+      return _doHighlightElement((Operation)it, acceptor);
+    } else if (it instanceof PrimitiveType) {
+      return _doHighlightElement((PrimitiveType)it, acceptor);
+    } else if (it instanceof Property) {
+      return _doHighlightElement((Property)it, acceptor);
+    } else if (it instanceof TypeReference) {
+      return _doHighlightElement((TypeReference)it, acceptor);
+    } else if (it instanceof Parameter) {
+      return _doHighlightElement((Parameter)it, acceptor);
+    } else if (it instanceof TypeDeclaration) {
+      return _doHighlightElement((TypeDeclaration)it, acceptor);
+    } else if (it != null) {
+      return _doHighlightElement(it, acceptor);
+    } else {
+      throw new IllegalArgumentException("Unhandled parameter types: " +
+        Arrays.<Object>asList(it, acceptor).toString());
+    }
+  }
+}

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/editor/syntaxcoloring/SemanticHighlightingStyleToTokenMapper.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/editor/syntaxcoloring/SemanticHighlightingStyleToTokenMapper.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.tests.testlanguage.editor.syntaxcoloring;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.xtext.ide.server.semanticHighlight.ISemanticHighlightingStyleToTokenMapper;
+import org.eclipse.xtext.ide.tests.testlanguage.editor.syntaxcoloring.SemanticHighlightingCalculatorImpl;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+
+@SuppressWarnings("all")
+public class SemanticHighlightingStyleToTokenMapper implements ISemanticHighlightingStyleToTokenMapper {
+  @Override
+  public List<String> toScopes(final String styleId) {
+    return Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList(styleId));
+  }
+  
+  @Override
+  public Set<String> getAllStyleIds() {
+    return SemanticHighlightingCalculatorImpl.STYLES;
+  }
+}

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/ide/server/CodeActionService.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/ide/server/CodeActionService.java
@@ -16,6 +16,7 @@ import java.util.List;
 import org.eclipse.emf.common.util.ECollections;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Diagnostic;
@@ -23,6 +24,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.formatting2.regionaccess.ITextReplacement;
 import org.eclipse.xtext.ide.serializer.IChangeSerializer;
@@ -57,7 +59,7 @@ public class CodeActionService implements ICodeActionService {
   private IChangeSerializer serializer;
   
   @Override
-  public List<? extends Command> getCodeActions(final Document document, final XtextResource resource, final CodeActionParams params, final CancelIndicator indicator) {
+  public List<Either<Command, CodeAction>> getCodeActions(final Document document, final XtextResource resource, final CodeActionParams params, final CancelIndicator indicator) {
     final ArrayList<Command> commands = CollectionLiterals.<Command>newArrayList();
     List<Diagnostic> _diagnostics = params.getContext().getDiagnostics();
     for (final Diagnostic d : _diagnostics) {
@@ -75,7 +77,10 @@ public class CodeActionService implements ICodeActionService {
         }
       }
     }
-    return commands;
+    final Function1<Command, Either<Command, CodeAction>> _function = (Command it) -> {
+      return Either.<Command, CodeAction>forLeft(it);
+    };
+    return ListExtensions.<Command, Either<Command, CodeAction>>map(commands, _function);
   }
   
   private Command fixInvalidName(final Diagnostic d, final Document doc, final XtextResource res, final CodeActionParams params) {

--- a/org.eclipse.xtext.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ide/META-INF/MANIFEST.MF
@@ -10,8 +10,8 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtend.lib,
  org.eclipse.core.runtime;bundle-version="3.6.0";resolution:=optional;x-installation:=greedy,
  org.eclipse.equinox.common;bundle-version="3.5.0",
- org.eclipse.lsp4j;bundle-version="[0.4.0,0.5.0)";resolution:=optional,
- org.eclipse.lsp4j.jsonrpc;bundle-version="[0.4.0,0.5.0)";resolution:=optional,
+ org.eclipse.lsp4j;bundle-version="[0.5.0,0.6.0)";resolution:=optional,
+ org.eclipse.lsp4j.jsonrpc;bundle-version="[0.5.0,0.6.0)";resolution:=optional,
  org.eclipse.emf.ecore.change;bundle-version="[2.10.0,3)"
 Import-Package: org.apache.log4j;version="1.2.15"
 Export-Package: org.eclipse.xtext.ide;x-friends:="org.eclipse.xtend.ide,

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/Document.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/Document.xtend
@@ -80,7 +80,44 @@ import org.eclipse.lsp4j.Range
         }
         return new Position(line, column)
     }
-    
+
+    /**
+     * Returns with the text for a certain line without the trailing LF. Throws an {@link IndexOutOfBoundsException} if the zero-based {@code lineNumber}
+     * argument is negative or exceeds the number of lines in the document.
+     */
+    def String getLineContent(int lineNumber) throws IndexOutOfBoundsException {
+        if (lineNumber < 0) {
+            throw new IndexOutOfBoundsException(lineNumber + if (printSourceOnError) "" else (" text was : " + contents));
+        }
+        val char NL = '\n';
+        val l = contents.length;
+        val lineContent = new StringBuilder;
+        var line = 0;
+        for (var i = 0; i < l; i++) {
+            if (line > lineNumber) {
+                return lineContent.toString;
+            }
+            val ch = contents.charAt(i);
+            if (line === lineNumber && ch !== NL) {
+                lineContent.append(ch);
+            }
+            if (ch === NL) {
+                line++;
+            }
+        }
+        if (line < lineNumber) {
+            throw new IndexOutOfBoundsException(lineNumber + if (printSourceOnError) "" else (" text was : " + contents));
+        }
+        return lineContent.toString;
+    }
+
+    /**
+     * Get the number of lines in the document. Empty document has line count: {@code 1}.
+     */
+    def int getLineCount() {
+        return getPosition(contents.length).line + 1;
+    }
+
     def String getSubstring(Range range) {
     		val start = getOffSet(range.start)
     		val end = getOffSet(range.end)

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/codeActions/ICodeActionService.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/codeActions/ICodeActionService.xtend
@@ -7,18 +7,20 @@
  *******************************************************************************/
 package org.eclipse.xtext.ide.server.codeActions
 
+import java.util.List
+import org.eclipse.lsp4j.CodeAction
+import org.eclipse.lsp4j.CodeActionParams
+import org.eclipse.lsp4j.Command
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.xtext.ide.server.Document
 import org.eclipse.xtext.resource.XtextResource
-import org.eclipse.lsp4j.CodeActionParams
 import org.eclipse.xtext.util.CancelIndicator
-import org.eclipse.lsp4j.Command
-import java.util.List
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
 interface ICodeActionService {
 	
-	def List<? extends Command> getCodeActions(Document document, XtextResource resource, CodeActionParams params, CancelIndicator indicator)
+	def List<Either<Command, CodeAction>> getCodeActions(Document document, XtextResource resource, CodeActionParams params, CancelIndicator indicator)
 	
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/coloring/IColoringService.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/coloring/IColoringService.java
@@ -12,7 +12,9 @@ import static java.util.Collections.*;
 import java.util.List;
 
 import org.eclipse.lsp4j.ColoringInformation;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
 import org.eclipse.xtext.ide.server.Document;
+import org.eclipse.xtext.ide.server.semanticHighlight.ISemanticHighlightingStyleToTokenMapper;
 import org.eclipse.xtext.resource.XtextResource;
 
 import com.google.inject.ImplementedBy;
@@ -23,7 +25,9 @@ import com.google.inject.ImplementedBy;
  * model.
  * 
  * @author akos.kitta - Initial contribution and API
+ * @deprecated use the {@link ISemanticHighlightingCalculator} and the {@link ISemanticHighlightingStyleToTokenMapper} instead.
  */
+@Deprecated
 @ImplementedBy(IColoringService.Noop.class)
 public interface IColoringService {
 

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/semanticHighlight/ISemanticHighlightingStyleToTokenMapper.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/semanticHighlight/ISemanticHighlightingStyleToTokenMapper.xtend
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.server.semanticHighlight
+
+import com.google.inject.ImplementedBy
+import com.google.inject.Singleton
+import java.util.List
+import java.util.Set
+import org.eclipse.xtext.ide.editor.syntaxcoloring.IHighlightedPositionAcceptor
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator
+import org.eclipse.xtext.ide.editor.syntaxcoloring.LightweightPosition
+
+/**
+ * Service for mapping the IDs of the highlighting styles to a list of <a href="https://manual.macromates.com/en/language_grammars">TextMate scopes</a>.
+ * 
+ * @see IHighlightedPositionAcceptor#addPosition
+ * @see LightweightPosition#getIds
+ * 
+ */
+@ImplementedBy(Noop)
+interface ISemanticHighlightingStyleToTokenMapper {
+
+	/**
+	 * Maps the highlighting style ID to the corresponding TextMate scopes.
+	 */
+	def List<String> toScopes(String styleId);
+
+	/**
+	 * Returns with a set of distinct style identifiers that are used by the {@link IHighlightedPositionAcceptor} when calculating
+	 * the highlighted positions with the {@link ISemanticHighlightingCalculator}.
+	 * 
+	 * <p>
+	 * Must not return with {@code null} but an empty set instead.
+	 * 
+	 * @see IHighlightedPositionAcceptor#addPosition
+	 */
+	def Set<String> getAllStyleIds();
+
+	@Singleton
+	static class Noop implements ISemanticHighlightingStyleToTokenMapper {
+
+		override toScopes(String styleId) {
+			return SemanticHighlightingRegistry.UNKNOWN_SCOPES;
+		}
+
+		override getAllStyleIds() {
+			return emptySet;
+		}
+
+	}
+
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/semanticHighlight/SemanticHighlightingRegistry.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/semanticHighlight/SemanticHighlightingRegistry.xtend
@@ -1,0 +1,233 @@
+/*******************************************************************************
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.server.semanticHighlight
+
+import com.google.common.base.Preconditions
+import com.google.common.collect.BiMap
+import com.google.common.collect.ImmutableBiMap
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableMultimap
+import com.google.inject.Inject
+import java.util.List
+import org.eclipse.lsp4j.ClientCapabilities
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.SemanticHighlightingInformation
+import org.eclipse.lsp4j.SemanticHighlightingParams
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
+import org.eclipse.lsp4j.services.LanguageClient
+import org.eclipse.lsp4j.util.SemanticHighlightingTokens
+import org.eclipse.xtend.lib.annotations.Data
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator
+import org.eclipse.xtext.ide.editor.syntaxcoloring.MergingHighlightedPositionAcceptor
+import org.eclipse.xtext.ide.server.Document
+import org.eclipse.xtext.ide.server.ILanguageServerAccess
+import org.eclipse.xtext.ide.server.UriExtensions
+import org.eclipse.xtext.resource.IResourceServiceProvider
+import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.util.CancelIndicator
+import org.eclipse.xtext.util.internal.Log
+
+import static extension org.eclipse.lsp4j.util.SemanticHighlightingTokens.encode
+import com.google.common.collect.Maps
+
+/**
+ * Shared semantic highlighting manager per language server.
+ * Responsible for converting the semantic highlighted ranges into the LSP standard by producing a compact,
+ * {@code base64} encoded token string.
+ * 
+ */
+@Log
+class SemanticHighlightingRegistry {
+
+	/**
+	 * Reserved TextMate scope identifier for styles that cannot be handled.
+	 */
+	public static val UNKNOWN_SCOPE = 'unknown.xtext';
+
+	/**
+	 * TextMate scopes indicating an unhandled style ID to TextMate scope mapping.
+	 */
+	public static val UNKNOWN_SCOPES = #[UNKNOWN_SCOPE];
+
+	/**
+	 * A highlighted range with additional <a href="https://manual.macromates.com/en/language_grammars">TextMate scopes</a> information.
+	 */
+	@Data
+	static class HighlightedRange extends Range {
+
+		/**
+		 * The internal index of the corresponding TextMate scope.
+		 */
+		val int scope;
+
+		new(Position start, Position end, int scope) {
+			super(start, end);
+			this.scope = scope;
+		}
+	}
+
+	@Inject
+	extension UriExtensions; 
+
+	/**
+	 * Lookup table for all known TextMate scopes.
+	 */
+	protected BiMap<Integer, List<String>> scopes;
+
+	protected LanguageClient client;
+
+	def void initialize(Iterable<? extends IResourceServiceProvider> allLanguages, ClientCapabilities capabilities, LanguageClient client) {
+		Preconditions.checkState(this.client === null, 'Already initialized.');
+		val enabled = capabilities?.textDocument?.semanticHighlightingCapabilities?.semanticHighlighting ?: false;
+		val builder = ImmutableBiMap.builder;
+		if (enabled) {
+			allLanguages
+				.map[get(ISemanticHighlightingStyleToTokenMapper)]
+				.filterNull
+				.map[mapper|mapper.allStyleIds.map[styleId|mapper.toScopes(styleId)]]
+				.flatten
+				.filter[!nullOrEmpty]
+				.toSet
+				.forEach [ scope, index |
+					builder.put(index, scope)
+				];
+		}
+		scopes = builder.build;
+		this.client = client;
+	}
+
+	/**
+	 * Returns with a list of TextMate scopes for the internal scope index. Returns the
+	 * {@link SemanticHighlightingRegistry#UNKNOWN_SCOPES unknown scopes} if no scopes are registered for the argument.
+	 */
+	def List<String> getScopes(int scopeIndex) {
+		checkInitialized;
+		return scopes.getOrDefault(scopeIndex, SemanticHighlightingRegistry.UNKNOWN_SCOPES);
+	}
+
+	/**
+	 * Returns with the internal scope index for the argument. Returns {@code -1} if the scopes
+	 * argument is {@null}, the {@link SemanticHighlightingRegistry#UNKNOWN_SCOPES unknown scopes}
+	 * or is not registered to this manager.
+	 */
+	def int getIndex(List<String> scopes) {
+		checkInitialized;
+		if (scopes.nullOrUnknown) {
+			return -1;
+		}
+		val index = this.scopes.inverse.get(scopes);
+		return if(index === null) -1 else index;
+	}
+
+	/**
+	 * Returns with a view of all scopes known by this manager.
+	 */
+	def List<List<String>> getAllScopes() {
+		checkInitialized;
+		val builder = ImmutableList.builder;
+		scopes.keySet.forEach [
+			builder.add(Preconditions.checkNotNull(scopes.get(it), '''No scopes are available for index: «it»'''))
+		];
+		return builder.build;
+	}
+
+	def void update(ILanguageServerAccess.Context context) {
+		checkInitialized;
+		if (!(context.resource instanceof XtextResource)) {
+			return;
+		}
+		if (!context.documentOpen) {
+			return;
+		}
+
+		val resource = context.resource as XtextResource;
+		val calculator = resource.resourceServiceProvider?.get(ISemanticHighlightingCalculator);
+		val mapper = resource.resourceServiceProvider?.get(ISemanticHighlightingStyleToTokenMapper);
+		if (calculator === null || mapper === null) {
+			return;
+		}
+
+		val document = context.document;
+		val acceptor = new MergingHighlightedPositionAcceptor(calculator);
+		calculator.provideHighlightingFor(resource, acceptor, CancelIndicator.NullImpl);
+		val ranges = acceptor.positions.map [ position |
+			position.ids.map [ id |
+				val start = document.getPosition(position.offset);
+				val end = document.getPosition(position.offset + position.length);
+				val scope = getIndex(mapper.toScopes(id));
+				return new HighlightedRange(start, end, scope);
+			]
+		].flatten;
+
+		val lines = ranges.toSemanticHighlightingInformation(document);
+		val textDocument = context.toVersionedTextDocumentIdentifier;
+		notifyClient(new SemanticHighlightingParams(textDocument, lines));
+	}
+
+	protected def List<SemanticHighlightingInformation> toSemanticHighlightingInformation(
+		Iterable<? extends HighlightedRange> ranges, Document document) {
+
+		val builder = ImmutableMultimap.builder;
+		ranges.filter[start != end].forEach [
+			val startLine = start.line;
+			val endLine = end.line;
+			if (startLine === endLine) {
+				val length = end.character - start.character;
+				builder.put(startLine, new SemanticHighlightingTokens.Token(start.character, length, scope));
+			} else {
+				val startLineContent = document.getLineContent(startLine);
+				val startLength = startLineContent.length - start.character;
+				builder.put(startLine, new SemanticHighlightingTokens.Token(start.character, startLength, scope));
+				for (var line = startLine + 1; line < endLine; line++) {
+					val lineContent = document.getLineContent(line);
+					builder.put(line, new SemanticHighlightingTokens.Token(0, lineContent.length, scope));
+				}
+				builder.put(endLine, new SemanticHighlightingTokens.Token(0, end.character, scope));
+			}
+		];
+		return builder.build.asMap.entrySet.map [
+			val line = key;
+			val tokens = value;
+			new SemanticHighlightingInformation(line, tokens.encode);
+		].toList.appendEmptyLineTokens(document);
+	}
+
+	protected def List<SemanticHighlightingInformation> appendEmptyLineTokens(
+		List<SemanticHighlightingInformation> infos, Document document) {
+
+		val lineCount = document.lineCount;
+		val tokens = Maps.newHashMap(Maps.uniqueIndex(infos, [line]));
+		for (i : 0 ..< lineCount) {
+			if (!tokens.containsKey(i)) {
+				tokens.put(i, new SemanticHighlightingInformation(i, null))
+			}
+		}
+		return tokens.values.toList;
+	}
+
+	protected def VersionedTextDocumentIdentifier toVersionedTextDocumentIdentifier(ILanguageServerAccess.Context context) {
+		return new VersionedTextDocumentIdentifier => [
+			uri = context.resource.URI.toUriString;
+			version = context.document.version;
+		];
+	}
+
+	protected def void notifyClient(SemanticHighlightingParams params) {
+		client.semanticHighlighting(params);
+	}
+
+	protected def void checkInitialized() {
+		Preconditions.checkState(client !== null, 'Not initialized.');
+	}
+
+	protected def boolean isNullOrUnknown(List<String> nullable) {
+		return nullable === null || nullable == UNKNOWN_SCOPES;
+	}
+
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/DocumentSymbolService.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/DocumentSymbolService.xtend
@@ -14,10 +14,14 @@ import java.util.List
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EObject
+import org.eclipse.lsp4j.DocumentSymbol
+import org.eclipse.lsp4j.DocumentSymbolParams
 import org.eclipse.lsp4j.Location
+import org.eclipse.lsp4j.ReferenceParams
 import org.eclipse.lsp4j.SymbolInformation
 import org.eclipse.lsp4j.SymbolKind
 import org.eclipse.lsp4j.TextDocumentPositionParams
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.xtext.findReferences.IReferenceFinder
 import org.eclipse.xtext.findReferences.IReferenceFinder.IResourceAccess
 import org.eclipse.xtext.findReferences.ReferenceAcceptor
@@ -38,8 +42,6 @@ import org.eclipse.xtext.service.OperationCanceledManager
 import org.eclipse.xtext.util.CancelIndicator
 
 import static extension org.eclipse.emf.ecore.util.EcoreUtil.*
-import org.eclipse.lsp4j.ReferenceParams
-import org.eclipse.lsp4j.DocumentSymbolParams
 
 /**
  * @author kosyakov - Initial contribution and API
@@ -162,7 +164,7 @@ class DocumentSymbolService {
 		return targetURIs
 	}
 	
-	def List<? extends SymbolInformation> getSymbols(
+	def List<Either<SymbolInformation, DocumentSymbol>> getSymbols(
 		Document document,
 		XtextResource resource,
 		DocumentSymbolParams params,
@@ -171,7 +173,7 @@ class DocumentSymbolService {
 		return getSymbols(resource, cancelIndicator)
 	}
 
-	def List<? extends SymbolInformation> getSymbols(XtextResource resource, CancelIndicator cancelIndicator) {
+	def List<Either<SymbolInformation, DocumentSymbol>> getSymbols(XtextResource resource, CancelIndicator cancelIndicator) {
 		val symbols = newLinkedHashMap
 		val contents = resource.getAllProperContents(true)
 		while (contents.hasNext) {
@@ -187,7 +189,7 @@ class DocumentSymbolService {
 				symbol.containerName = containerSymbol?.name
 			}
 		}
-		return symbols.values.toList
+		return symbols.values.map[Either.forLeft(it)].toList
 	}
 
 	protected def EObject getContainer(EObject obj) {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/Document.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/Document.java
@@ -105,6 +105,60 @@ public class Document {
     return new Position(line, column);
   }
   
+  /**
+   * Returns with the text for a certain line without the trailing LF. Throws an {@link IndexOutOfBoundsException} if the zero-based {@code lineNumber}
+   * argument is negative or exceeds the number of lines in the document.
+   */
+  public String getLineContent(final int lineNumber) throws IndexOutOfBoundsException {
+    if ((lineNumber < 0)) {
+      String _xifexpression = null;
+      if (this.printSourceOnError) {
+        _xifexpression = "";
+      } else {
+        _xifexpression = (" text was : " + this.contents);
+      }
+      String _plus = (Integer.valueOf(lineNumber) + _xifexpression);
+      throw new IndexOutOfBoundsException(_plus);
+    }
+    final char NL = '\n';
+    final int l = this.contents.length();
+    final StringBuilder lineContent = new StringBuilder();
+    int line = 0;
+    for (int i = 0; (i < l); i++) {
+      {
+        if ((line > lineNumber)) {
+          return lineContent.toString();
+        }
+        final char ch = this.contents.charAt(i);
+        if (((line == lineNumber) && (ch != NL))) {
+          lineContent.append(ch);
+        }
+        if ((ch == NL)) {
+          line++;
+        }
+      }
+    }
+    if ((line < lineNumber)) {
+      String _xifexpression_1 = null;
+      if (this.printSourceOnError) {
+        _xifexpression_1 = "";
+      } else {
+        _xifexpression_1 = (" text was : " + this.contents);
+      }
+      String _plus_1 = (Integer.valueOf(lineNumber) + _xifexpression_1);
+      throw new IndexOutOfBoundsException(_plus_1);
+    }
+    return lineContent.toString();
+  }
+  
+  /**
+   * Get the number of lines in the document. Empty document has line count: {@code 1}.
+   */
+  public int getLineCount() {
+    int _line = this.getPosition(this.contents.length()).getLine();
+    return (_line + 1);
+  }
+  
   public String getSubstring(final Range range) {
     final int start = this.getOffSet(range.getStart());
     final int end = this.getOffSet(range.getEnd());

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/codeActions/ICodeActionService.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/codeActions/ICodeActionService.java
@@ -8,8 +8,10 @@
 package org.eclipse.xtext.ide.server.codeActions;
 
 import java.util.List;
+import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtext.ide.server.Document;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.util.CancelIndicator;
@@ -19,5 +21,5 @@ import org.eclipse.xtext.util.CancelIndicator;
  */
 @SuppressWarnings("all")
 public interface ICodeActionService {
-  public abstract List<? extends Command> getCodeActions(final Document document, final XtextResource resource, final CodeActionParams params, final CancelIndicator indicator);
+  public abstract List<Either<Command, CodeAction>> getCodeActions(final Document document, final XtextResource resource, final CodeActionParams params, final CancelIndicator indicator);
 }

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/semanticHighlight/ISemanticHighlightingStyleToTokenMapper.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/semanticHighlight/ISemanticHighlightingStyleToTokenMapper.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.server.semanticHighlight;
+
+import com.google.inject.ImplementedBy;
+import com.google.inject.Singleton;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.IHighlightedPositionAcceptor;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.LightweightPosition;
+import org.eclipse.xtext.ide.server.semanticHighlight.SemanticHighlightingRegistry;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+
+/**
+ * Service for mapping the IDs of the highlighting styles to a list of <a href="https://manual.macromates.com/en/language_grammars">TextMate scopes</a>.
+ * 
+ * @see IHighlightedPositionAcceptor#addPosition
+ * @see LightweightPosition#getIds
+ */
+@ImplementedBy(ISemanticHighlightingStyleToTokenMapper.Noop.class)
+@SuppressWarnings("all")
+public interface ISemanticHighlightingStyleToTokenMapper {
+  @Singleton
+  public static class Noop implements ISemanticHighlightingStyleToTokenMapper {
+    @Override
+    public List<String> toScopes(final String styleId) {
+      return SemanticHighlightingRegistry.UNKNOWN_SCOPES;
+    }
+    
+    @Override
+    public Set<String> getAllStyleIds() {
+      return CollectionLiterals.<String>emptySet();
+    }
+  }
+  
+  /**
+   * Maps the highlighting style ID to the corresponding TextMate scopes.
+   */
+  public abstract List<String> toScopes(final String styleId);
+  
+  /**
+   * Returns with a set of distinct style identifiers that are used by the {@link IHighlightedPositionAcceptor} when calculating
+   * the highlighted positions with the {@link ISemanticHighlightingCalculator}.
+   * 
+   * <p>
+   * Must not return with {@code null} but an empty set instead.
+   * 
+   * @see IHighlightedPositionAcceptor#addPosition
+   */
+  public abstract Set<String> getAllStyleIds();
+}

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/semanticHighlight/SemanticHighlightingRegistry.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/semanticHighlight/SemanticHighlightingRegistry.java
@@ -1,0 +1,380 @@
+/**
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.server.semanticHighlight;
+
+import com.google.common.base.Function;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.google.inject.Inject;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.log4j.Logger;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SemanticHighlightingCapabilities;
+import org.eclipse.lsp4j.SemanticHighlightingInformation;
+import org.eclipse.lsp4j.SemanticHighlightingParams;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.util.SemanticHighlightingTokens;
+import org.eclipse.xtend.lib.annotations.Data;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.LightweightPosition;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.MergingHighlightedPositionAcceptor;
+import org.eclipse.xtext.ide.server.Document;
+import org.eclipse.xtext.ide.server.ILanguageServerAccess;
+import org.eclipse.xtext.ide.server.UriExtensions;
+import org.eclipse.xtext.ide.server.semanticHighlight.ISemanticHighlightingStyleToTokenMapper;
+import org.eclipse.xtext.resource.IResourceServiceProvider;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.util.internal.Log;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.ExclusiveRange;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ListExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure2;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Shared semantic highlighting manager per language server.
+ * Responsible for converting the semantic highlighted ranges into the LSP standard by producing a compact,
+ * {@code base64} encoded token string.
+ */
+@Log
+@SuppressWarnings("all")
+public class SemanticHighlightingRegistry {
+  /**
+   * A highlighted range with additional <a href="https://manual.macromates.com/en/language_grammars">TextMate scopes</a> information.
+   */
+  @Data
+  public static class HighlightedRange extends Range {
+    /**
+     * The internal index of the corresponding TextMate scope.
+     */
+    private final int scope;
+    
+    public HighlightedRange(final Position start, final Position end, final int scope) {
+      super(start, end);
+      this.scope = scope;
+    }
+    
+    @Override
+    @Pure
+    public int hashCode() {
+      return 31 * super.hashCode() + this.scope;
+    }
+    
+    @Override
+    @Pure
+    public boolean equals(final Object obj) {
+      if (this == obj)
+        return true;
+      if (obj == null)
+        return false;
+      if (getClass() != obj.getClass())
+        return false;
+      if (!super.equals(obj))
+        return false;
+      SemanticHighlightingRegistry.HighlightedRange other = (SemanticHighlightingRegistry.HighlightedRange) obj;
+      if (other.scope != this.scope)
+        return false;
+      return true;
+    }
+    
+    @Override
+    @Pure
+    public String toString() {
+      return new ToStringBuilder(this)
+      	.addAllFields()
+      	.toString();
+    }
+    
+    @Pure
+    public int getScope() {
+      return this.scope;
+    }
+  }
+  
+  /**
+   * Reserved TextMate scope identifier for styles that cannot be handled.
+   */
+  public final static String UNKNOWN_SCOPE = "unknown.xtext";
+  
+  /**
+   * TextMate scopes indicating an unhandled style ID to TextMate scope mapping.
+   */
+  public final static List<String> UNKNOWN_SCOPES = Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList(SemanticHighlightingRegistry.UNKNOWN_SCOPE));
+  
+  @Inject
+  @Extension
+  private UriExtensions _uriExtensions;
+  
+  /**
+   * Lookup table for all known TextMate scopes.
+   */
+  protected BiMap<Integer, List<String>> scopes;
+  
+  protected LanguageClient client;
+  
+  public void initialize(final Iterable<? extends IResourceServiceProvider> allLanguages, final ClientCapabilities capabilities, final LanguageClient client) {
+    Preconditions.checkState((this.client == null), "Already initialized.");
+    Boolean _elvis = null;
+    TextDocumentClientCapabilities _textDocument = null;
+    if (capabilities!=null) {
+      _textDocument=capabilities.getTextDocument();
+    }
+    SemanticHighlightingCapabilities _semanticHighlightingCapabilities = null;
+    if (_textDocument!=null) {
+      _semanticHighlightingCapabilities=_textDocument.getSemanticHighlightingCapabilities();
+    }
+    Boolean _semanticHighlighting = null;
+    if (_semanticHighlightingCapabilities!=null) {
+      _semanticHighlighting=_semanticHighlightingCapabilities.getSemanticHighlighting();
+    }
+    if (_semanticHighlighting != null) {
+      _elvis = _semanticHighlighting;
+    } else {
+      _elvis = Boolean.valueOf(false);
+    }
+    final Boolean enabled = _elvis;
+    final ImmutableBiMap.Builder<Integer, List<String>> builder = ImmutableBiMap.<Integer, List<String>>builder();
+    if ((enabled).booleanValue()) {
+      final Function1<IResourceServiceProvider, ISemanticHighlightingStyleToTokenMapper> _function = (IResourceServiceProvider it) -> {
+        return it.<ISemanticHighlightingStyleToTokenMapper>get(ISemanticHighlightingStyleToTokenMapper.class);
+      };
+      final Function1<ISemanticHighlightingStyleToTokenMapper, Iterable<List<String>>> _function_1 = (ISemanticHighlightingStyleToTokenMapper mapper) -> {
+        final Function1<String, List<String>> _function_2 = (String styleId) -> {
+          return mapper.toScopes(styleId);
+        };
+        return IterableExtensions.<String, List<String>>map(mapper.getAllStyleIds(), _function_2);
+      };
+      final Function1<List<String>, Boolean> _function_2 = (List<String> it) -> {
+        boolean _isNullOrEmpty = IterableExtensions.isNullOrEmpty(it);
+        return Boolean.valueOf((!_isNullOrEmpty));
+      };
+      final Procedure2<List<String>, Integer> _function_3 = (List<String> scope, Integer index) -> {
+        builder.put(index, scope);
+      };
+      IterableExtensions.<List<String>>forEach(IterableExtensions.<List<String>>toSet(IterableExtensions.<List<String>>filter(Iterables.<List<String>>concat(IterableExtensions.<ISemanticHighlightingStyleToTokenMapper, Iterable<List<String>>>map(IterableExtensions.<ISemanticHighlightingStyleToTokenMapper>filterNull(IterableExtensions.map(allLanguages, _function)), _function_1)), _function_2)), _function_3);
+    }
+    this.scopes = builder.build();
+    this.client = client;
+  }
+  
+  /**
+   * Returns with a list of TextMate scopes for the internal scope index. Returns the
+   * {@link SemanticHighlightingRegistry#UNKNOWN_SCOPES unknown scopes} if no scopes are registered for the argument.
+   */
+  public List<String> getScopes(final int scopeIndex) {
+    this.checkInitialized();
+    return this.scopes.getOrDefault(Integer.valueOf(scopeIndex), SemanticHighlightingRegistry.UNKNOWN_SCOPES);
+  }
+  
+  /**
+   * Returns with the internal scope index for the argument. Returns {@code -1} if the scopes
+   * argument is {@null}, the {@link SemanticHighlightingRegistry#UNKNOWN_SCOPES unknown scopes}
+   * or is not registered to this manager.
+   */
+  public int getIndex(final List<String> scopes) {
+    this.checkInitialized();
+    boolean _isNullOrUnknown = this.isNullOrUnknown(scopes);
+    if (_isNullOrUnknown) {
+      return (-1);
+    }
+    final Integer index = this.scopes.inverse().get(scopes);
+    Integer _xifexpression = null;
+    if ((index == null)) {
+      _xifexpression = Integer.valueOf((-1));
+    } else {
+      _xifexpression = index;
+    }
+    return (_xifexpression).intValue();
+  }
+  
+  /**
+   * Returns with a view of all scopes known by this manager.
+   */
+  public List<List<String>> getAllScopes() {
+    this.checkInitialized();
+    final ImmutableList.Builder<List<String>> builder = ImmutableList.<List<String>>builder();
+    final Consumer<Integer> _function = (Integer it) -> {
+      List<String> _get = this.scopes.get(it);
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("No scopes are available for index: ");
+      _builder.append(it);
+      builder.add(Preconditions.<List<String>>checkNotNull(_get, _builder));
+    };
+    this.scopes.keySet().forEach(_function);
+    return builder.build();
+  }
+  
+  public void update(final ILanguageServerAccess.Context context) {
+    this.checkInitialized();
+    Resource _resource = context.getResource();
+    boolean _not = (!(_resource instanceof XtextResource));
+    if (_not) {
+      return;
+    }
+    boolean _isDocumentOpen = context.isDocumentOpen();
+    boolean _not_1 = (!_isDocumentOpen);
+    if (_not_1) {
+      return;
+    }
+    Resource _resource_1 = context.getResource();
+    final XtextResource resource = ((XtextResource) _resource_1);
+    IResourceServiceProvider _resourceServiceProvider = resource.getResourceServiceProvider();
+    ISemanticHighlightingCalculator _get = null;
+    if (_resourceServiceProvider!=null) {
+      _get=_resourceServiceProvider.<ISemanticHighlightingCalculator>get(ISemanticHighlightingCalculator.class);
+    }
+    final ISemanticHighlightingCalculator calculator = _get;
+    IResourceServiceProvider _resourceServiceProvider_1 = resource.getResourceServiceProvider();
+    ISemanticHighlightingStyleToTokenMapper _get_1 = null;
+    if (_resourceServiceProvider_1!=null) {
+      _get_1=_resourceServiceProvider_1.<ISemanticHighlightingStyleToTokenMapper>get(ISemanticHighlightingStyleToTokenMapper.class);
+    }
+    final ISemanticHighlightingStyleToTokenMapper mapper = _get_1;
+    if (((calculator == null) || (mapper == null))) {
+      return;
+    }
+    final Document document = context.getDocument();
+    final MergingHighlightedPositionAcceptor acceptor = new MergingHighlightedPositionAcceptor(calculator);
+    calculator.provideHighlightingFor(resource, acceptor, CancelIndicator.NullImpl);
+    final Function1<LightweightPosition, List<SemanticHighlightingRegistry.HighlightedRange>> _function = (LightweightPosition position) -> {
+      final Function1<String, SemanticHighlightingRegistry.HighlightedRange> _function_1 = (String id) -> {
+        final Position start = document.getPosition(position.getOffset());
+        int _offset = position.getOffset();
+        int _length = position.getLength();
+        int _plus = (_offset + _length);
+        final Position end = document.getPosition(_plus);
+        final int scope = this.getIndex(mapper.toScopes(id));
+        return new SemanticHighlightingRegistry.HighlightedRange(start, end, scope);
+      };
+      return ListExtensions.<String, SemanticHighlightingRegistry.HighlightedRange>map(((List<String>)Conversions.doWrapArray(position.getIds())), _function_1);
+    };
+    final Iterable<SemanticHighlightingRegistry.HighlightedRange> ranges = Iterables.<SemanticHighlightingRegistry.HighlightedRange>concat(ListExtensions.<LightweightPosition, List<SemanticHighlightingRegistry.HighlightedRange>>map(acceptor.getPositions(), _function));
+    final List<SemanticHighlightingInformation> lines = this.toSemanticHighlightingInformation(ranges, document);
+    final VersionedTextDocumentIdentifier textDocument = this.toVersionedTextDocumentIdentifier(context);
+    SemanticHighlightingParams _semanticHighlightingParams = new SemanticHighlightingParams(textDocument, lines);
+    this.notifyClient(_semanticHighlightingParams);
+  }
+  
+  protected List<SemanticHighlightingInformation> toSemanticHighlightingInformation(final Iterable<? extends SemanticHighlightingRegistry.HighlightedRange> ranges, final Document document) {
+    final ImmutableMultimap.Builder<Integer, SemanticHighlightingTokens.Token> builder = ImmutableMultimap.<Integer, SemanticHighlightingTokens.Token>builder();
+    final Function1<SemanticHighlightingRegistry.HighlightedRange, Boolean> _function = (SemanticHighlightingRegistry.HighlightedRange it) -> {
+      Position _start = it.getStart();
+      Position _end = it.getEnd();
+      return Boolean.valueOf((!Objects.equal(_start, _end)));
+    };
+    final Consumer<SemanticHighlightingRegistry.HighlightedRange> _function_1 = (SemanticHighlightingRegistry.HighlightedRange it) -> {
+      final int startLine = it.getStart().getLine();
+      final int endLine = it.getEnd().getLine();
+      if ((startLine == endLine)) {
+        int _character = it.getEnd().getCharacter();
+        int _character_1 = it.getStart().getCharacter();
+        final int length = (_character - _character_1);
+        int _character_2 = it.getStart().getCharacter();
+        SemanticHighlightingTokens.Token _token = new SemanticHighlightingTokens.Token(_character_2, length, it.scope);
+        builder.put(Integer.valueOf(startLine), _token);
+      } else {
+        final String startLineContent = document.getLineContent(startLine);
+        int _length = startLineContent.length();
+        int _character_3 = it.getStart().getCharacter();
+        final int startLength = (_length - _character_3);
+        int _character_4 = it.getStart().getCharacter();
+        SemanticHighlightingTokens.Token _token_1 = new SemanticHighlightingTokens.Token(_character_4, startLength, it.scope);
+        builder.put(Integer.valueOf(startLine), _token_1);
+        for (int line = (startLine + 1); (line < endLine); line++) {
+          {
+            final String lineContent = document.getLineContent(line);
+            int _length_1 = lineContent.length();
+            SemanticHighlightingTokens.Token _token_2 = new SemanticHighlightingTokens.Token(0, _length_1, it.scope);
+            builder.put(Integer.valueOf(line), _token_2);
+          }
+        }
+        int _character_5 = it.getEnd().getCharacter();
+        SemanticHighlightingTokens.Token _token_2 = new SemanticHighlightingTokens.Token(0, _character_5, it.scope);
+        builder.put(Integer.valueOf(endLine), _token_2);
+      }
+    };
+    IterableExtensions.filter(ranges, _function).forEach(_function_1);
+    final Function1<Map.Entry<Integer, Collection<SemanticHighlightingTokens.Token>>, SemanticHighlightingInformation> _function_2 = (Map.Entry<Integer, Collection<SemanticHighlightingTokens.Token>> it) -> {
+      SemanticHighlightingInformation _xblockexpression = null;
+      {
+        final Integer line = it.getKey();
+        final Collection<SemanticHighlightingTokens.Token> tokens = it.getValue();
+        String _encode = SemanticHighlightingTokens.encode(tokens);
+        _xblockexpression = new SemanticHighlightingInformation((line).intValue(), _encode);
+      }
+      return _xblockexpression;
+    };
+    return this.appendEmptyLineTokens(IterableExtensions.<SemanticHighlightingInformation>toList(IterableExtensions.<Map.Entry<Integer, Collection<SemanticHighlightingTokens.Token>>, SemanticHighlightingInformation>map(builder.build().asMap().entrySet(), _function_2)), document);
+  }
+  
+  protected List<SemanticHighlightingInformation> appendEmptyLineTokens(final List<SemanticHighlightingInformation> infos, final Document document) {
+    final int lineCount = document.getLineCount();
+    final Function<SemanticHighlightingInformation, Integer> _function = (SemanticHighlightingInformation it) -> {
+      return Integer.valueOf(it.getLine());
+    };
+    final HashMap<Integer, SemanticHighlightingInformation> tokens = Maps.<Integer, SemanticHighlightingInformation>newHashMap(Maps.<Integer, SemanticHighlightingInformation>uniqueIndex(infos, _function));
+    ExclusiveRange _doubleDotLessThan = new ExclusiveRange(0, lineCount, true);
+    for (final Integer i : _doubleDotLessThan) {
+      boolean _containsKey = tokens.containsKey(i);
+      boolean _not = (!_containsKey);
+      if (_not) {
+        SemanticHighlightingInformation _semanticHighlightingInformation = new SemanticHighlightingInformation((i).intValue(), null);
+        tokens.put(i, _semanticHighlightingInformation);
+      }
+    }
+    return IterableExtensions.<SemanticHighlightingInformation>toList(tokens.values());
+  }
+  
+  protected VersionedTextDocumentIdentifier toVersionedTextDocumentIdentifier(final ILanguageServerAccess.Context context) {
+    VersionedTextDocumentIdentifier _versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier();
+    final Procedure1<VersionedTextDocumentIdentifier> _function = (VersionedTextDocumentIdentifier it) -> {
+      it.setUri(this._uriExtensions.toUriString(context.getResource().getURI()));
+      it.setVersion(context.getDocument().getVersion());
+    };
+    return ObjectExtensions.<VersionedTextDocumentIdentifier>operator_doubleArrow(_versionedTextDocumentIdentifier, _function);
+  }
+  
+  protected void notifyClient(final SemanticHighlightingParams params) {
+    this.client.semanticHighlighting(params);
+  }
+  
+  protected void checkInitialized() {
+    Preconditions.checkState((this.client != null), "Not initialized.");
+  }
+  
+  protected boolean isNullOrUnknown(final List<String> nullable) {
+    return ((nullable == null) || Objects.equal(nullable, SemanticHighlightingRegistry.UNKNOWN_SCOPES));
+  }
+  
+  private final static Logger LOG = Logger.getLogger(SemanticHighlightingRegistry.class);
+}

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/symbol/DocumentSymbolService.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/symbol/DocumentSymbolService.java
@@ -21,12 +21,14 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtext.findReferences.IReferenceFinder;
 import org.eclipse.xtext.findReferences.ReferenceAcceptor;
 import org.eclipse.xtext.findReferences.TargetURICollector;
@@ -49,6 +51,7 @@ import org.eclipse.xtext.util.IAcceptor;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
@@ -156,11 +159,11 @@ public class DocumentSymbolService {
     return targetURIs;
   }
   
-  public List<? extends SymbolInformation> getSymbols(final Document document, final XtextResource resource, final DocumentSymbolParams params, final CancelIndicator cancelIndicator) {
+  public List<Either<SymbolInformation, DocumentSymbol>> getSymbols(final Document document, final XtextResource resource, final DocumentSymbolParams params, final CancelIndicator cancelIndicator) {
     return this.getSymbols(resource, cancelIndicator);
   }
   
-  public List<? extends SymbolInformation> getSymbols(final XtextResource resource, final CancelIndicator cancelIndicator) {
+  public List<Either<SymbolInformation, DocumentSymbol>> getSymbols(final XtextResource resource, final CancelIndicator cancelIndicator) {
     final LinkedHashMap<EObject, SymbolInformation> symbols = CollectionLiterals.<EObject, SymbolInformation>newLinkedHashMap();
     final TreeIterator<Object> contents = EcoreUtil.<Object>getAllProperContents(resource, true);
     while (contents.hasNext()) {
@@ -181,7 +184,10 @@ public class DocumentSymbolService {
         }
       }
     }
-    return IterableExtensions.<SymbolInformation>toList(symbols.values());
+    final Function1<SymbolInformation, Either<SymbolInformation, DocumentSymbol>> _function = (SymbolInformation it) -> {
+      return Either.<SymbolInformation, DocumentSymbol>forLeft(it);
+    };
+    return IterableExtensions.<Either<SymbolInformation, DocumentSymbol>>toList(IterableExtensions.<SymbolInformation, Either<SymbolInformation, DocumentSymbol>>map(symbols.values(), _function));
   }
   
   protected EObject getContainer(final EObject obj) {

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.ide/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.ide/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.eclipse.lsp4j</groupId>
 			<artifactId>org.eclipse.lsp4j</artifactId>
-			<version>0.4.0</version>
+			<version>0.5.0.M1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ow2.asm</groupId>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.ide/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.ide/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.eclipse.lsp4j</groupId>
 			<artifactId>org.eclipse.lsp4j</artifactId>
-			<version>0.4.0</version>
+			<version>0.5.0.M1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ow2.asm</groupId>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/IdeProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/IdeProjectDescriptor.xtend
@@ -55,7 +55,7 @@ class IdeProjectDescriptor extends ProjectDescriptor {
 						<dependency>
 							<groupId>org.eclipse.lsp4j</groupId>
 							<artifactId>org.eclipse.lsp4j</artifactId>
-							<version>0.4.0</version>
+							<version>0.5.0.M1</version>
 						</dependency>
 						<dependency>
 							<groupId>org.ow2.asm</groupId>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/IdeProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/IdeProjectDescriptor.java
@@ -107,7 +107,7 @@ public class IdeProjectDescriptor extends ProjectDescriptor {
           _builder.append("<artifactId>org.eclipse.lsp4j</artifactId>");
           _builder.newLine();
           _builder.append("\t\t");
-          _builder.append("<version>0.4.0</version>");
+          _builder.append("<version>0.5.0.M1</version>");
           _builder.newLine();
           _builder.append("\t");
           _builder.append("</dependency>");


### PR DESCRIPTION
Implementation of the LS-based semantic highlighting. It does **not** support deltas.

The PR is in **WIP** because of the `lsp4j` dependency. @spoenemann, can you please advise how to tackle the `0.4.0` vs. the `0.5.0` LSP4J version mismatch?

Closes #812.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

CC: @svenefftinge

**Update:**
 - ~Depends on #793.~
 - Depends on #821.