### PR TITLE
[eclipse/xtext-core#828] Use the newest version of xtext-gradle-plugin: 2.0.1

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'org.xtext:xtext-gradle-plugin:1.0.21'
+		classpath 'org.xtext:xtext-gradle-plugin:2.0.1'
 	}
 }
 

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.gradle/org.xtext.example.gradle.parent/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.gradle/org.xtext.example.gradle.parent/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'org.xtext:xtext-gradle-plugin:1.0.21'
+		classpath 'org.xtext:xtext-gradle-plugin:2.0.1'
 	}
 }
 

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsGradleApp/org.xtext.example.lsGradleApp.parent/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsGradleApp/org.xtext.example.lsGradleApp.parent/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'org.xtext:xtext-gradle-plugin:1.0.21'
+		classpath 'org.xtext:xtext-gradle-plugin:2.0.1'
 	}
 }
 

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsGradleFatjar/org.xtext.example.lsGradleFatjar.parent/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsGradleFatjar/org.xtext.example.lsGradleFatjar.parent/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'org.xtext:xtext-gradle-plugin:1.0.21'
+		classpath 'org.xtext:xtext-gradle-plugin:2.0.1'
 	}
 }
 

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/XtextVersion.xtend
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/XtextVersion.xtend
@@ -20,7 +20,7 @@ class XtextVersion {
 	}
 
 	def getXtextGradlePluginVersion() {
-		'1.0.21'
+		'2.0.1'
 	}
 
 	/**

--- a/org.eclipse.xtext.util/xtend-gen/org/eclipse/xtext/util/XtextVersion.java
+++ b/org.eclipse.xtext.util/xtend-gen/org/eclipse/xtext/util/XtextVersion.java
@@ -44,7 +44,7 @@ public class XtextVersion {
   }
   
   public String getXtextGradlePluginVersion() {
-    return "1.0.21";
+    return "2.0.1";
   }
   
   /**


### PR DESCRIPTION
[eclipse/xtext-core#828] Use the newest version of xtext-gradle-plugin: 2.0.1

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>