### PR TITLE
[eclipse/xtext-core#824] Don't generate xpand dependency if not needed

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.target/org.xtext.example.full.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.target/org.xtext.example.full.target.target
@@ -8,9 +8,6 @@
 <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xpand" version="0.0.0"/>
-<unit id="org.eclipse.xtend" version="0.0.0"/>
-<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 <repository location="http://download.eclipse.org/releases/2018-09"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.target/org.xtext.example.lsMavenTychoApp.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.target/org.xtext.example.lsMavenTychoApp.target.target
@@ -8,9 +8,6 @@
 <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xpand" version="0.0.0"/>
-<unit id="org.eclipse.xtend" version="0.0.0"/>
-<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 <repository location="http://download.eclipse.org/releases/2018-09"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.target/org.xtext.example.lsMavenTychoFatjar.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.target/org.xtext.example.lsMavenTychoFatjar.target.target
@@ -8,9 +8,6 @@
 <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xpand" version="0.0.0"/>
-<unit id="org.eclipse.xtend" version="0.0.0"/>
-<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 <repository location="http://download.eclipse.org/releases/2018-09"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.target/org.xtext.example.mavenTycho.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.target/org.xtext.example.mavenTycho.target.target
@@ -8,9 +8,6 @@
 <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xpand" version="0.0.0"/>
-<unit id="org.eclipse.xtend" version="0.0.0"/>
-<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 <repository location="http://download.eclipse.org/releases/2018-09"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9.target/org.xtext.example.mavenTychoJ9.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9.target/org.xtext.example.mavenTychoJ9.target.target
@@ -8,9 +8,6 @@
 <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xpand" version="0.0.0"/>
-<unit id="org.eclipse.xtend" version="0.0.0"/>
-<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 <repository location="http://download.eclipse.org/releases/2018-09"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.target/org.xtext.example.mavenTychoP2.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.target/org.xtext.example.mavenTychoP2.target.target
@@ -8,9 +8,6 @@
 <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xpand" version="0.0.0"/>
-<unit id="org.eclipse.xtend" version="0.0.0"/>
-<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 <repository location="http://download.eclipse.org/releases/2018-09"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ProjectDescriptor.xtend
@@ -190,4 +190,8 @@ abstract class ProjectDescriptor {
 	protected def binaryFile(Outlet outlet, String relativePath, URL url) {
 		return new BinaryFile(outlet, relativePath, this, false, url)
 	}
+
+	protected def isFromExistingEcoreModels() {
+		!config.ecore2Xtext.EPackageInfos.isEmpty
+	}
 }

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
@@ -270,10 +270,6 @@ class RuntimeProjectDescriptor extends TestedProjectDescriptor {
 		'''
 	}
 	
-	private def isFromExistingEcoreModels() {
-		!config.ecore2Xtext.EPackageInfos.isEmpty
-	}
-	
 	override buildGradle() {
 		super.buildGradle => [
 			additionalContent = '''

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
@@ -59,9 +59,11 @@ class TargetPlatformProject extends ProjectDescriptor {
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-		<unit id="org.eclipse.xpand" version="0.0.0"/>
-		<unit id="org.eclipse.xtend" version="0.0.0"/>
-		<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
+		«IF isFromExistingEcoreModels»
+			<unit id="org.eclipse.xpand" version="0.0.0"/>
+			<unit id="org.eclipse.xtend" version="0.0.0"/>
+			<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
+		«ENDIF»
 		<repository location="http://download.eclipse.org/releases/2018-09"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ProjectDescriptor.java
@@ -333,6 +333,11 @@ public abstract class ProjectDescriptor {
     return new BinaryFile(outlet, relativePath, this, false, url);
   }
   
+  protected boolean isFromExistingEcoreModels() {
+    boolean _isEmpty = this.config.getEcore2Xtext().getEPackageInfos().isEmpty();
+    return (!_isEmpty);
+  }
+  
   public ProjectDescriptor(final WizardConfiguration config) {
     super();
     this.config = config;

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
@@ -566,11 +566,6 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
     return _builder;
   }
   
-  private boolean isFromExistingEcoreModels() {
-    boolean _isEmpty = this.getConfig().getEcore2Xtext().getEPackageInfos().isEmpty();
-    return (!_isEmpty);
-  }
-  
   @Override
   public GradleBuildFile buildGradle() {
     GradleBuildFile _buildGradle = super.buildGradle();

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
@@ -107,12 +107,17 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.newLine();
     _builder.append("<unit id=\"org.eclipse.emf.sdk.feature.group\" version=\"0.0.0\"/>");
     _builder.newLine();
-    _builder.append("<unit id=\"org.eclipse.xpand\" version=\"0.0.0\"/>");
-    _builder.newLine();
-    _builder.append("<unit id=\"org.eclipse.xtend\" version=\"0.0.0\"/>");
-    _builder.newLine();
-    _builder.append("<unit id=\"org.eclipse.xtend.typesystem.emf\" version=\"0.0.0\"/>");
-    _builder.newLine();
+    {
+      boolean _isFromExistingEcoreModels = this.isFromExistingEcoreModels();
+      if (_isFromExistingEcoreModels) {
+        _builder.append("<unit id=\"org.eclipse.xpand\" version=\"0.0.0\"/>");
+        _builder.newLine();
+        _builder.append("<unit id=\"org.eclipse.xtend\" version=\"0.0.0\"/>");
+        _builder.newLine();
+        _builder.append("<unit id=\"org.eclipse.xtend.typesystem.emf\" version=\"0.0.0\"/>");
+        _builder.newLine();
+      }
+    }
     _builder.append("<repository location=\"http://download.eclipse.org/releases/2018-09\"/>");
     _builder.newLine();
     _builder.append("</location>");


### PR DESCRIPTION
[eclipse/xtext-core#824] Don't generate xpand dependency if not needed
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>