### PR TITLE
GH-858: [LS] Added support for the hierarchical document symbols.

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/HierarchicalDocumentSymbolTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/HierarchicalDocumentSymbolTest.xtend
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.server
+
+import org.eclipse.lsp4j.ClientCapabilities
+import org.eclipse.lsp4j.DocumentSymbolCapabilities
+import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.TextDocumentClientCapabilities
+import org.junit.Test
+
+class HierarchicalDocumentSymbolTest extends AbstractTestLangLanguageServerTest {
+
+	static val (InitializeParams)=>void INITIALIZER = [
+		capabilities = new ClientCapabilities() => [
+			textDocument = new TextDocumentClientCapabilities() => [
+				documentSymbol = new DocumentSymbolCapabilities() => [
+					it.hierarchicalDocumentSymbolSupport = true;
+				];
+			];
+		];
+	];
+
+	@Test
+	def void testDocumentSymbol_01() {
+		testDocumentSymbol[
+			initializer = INITIALIZER
+			model = '''
+				type Foo {
+					int bar
+				}
+				type Bar {
+					Foo foo
+				}
+			'''
+			expectedSymbols = '''
+				symbol "Foo" {
+				    kind: 7
+				    range: [[0, 5] .. [0, 8]]
+				    selectionRange: [[0, 0] .. [2, 1]]
+				    details: 
+				    deprecated: false
+				    children: [
+				        symbol "Foo.bar" {
+				            kind: 7
+				            range: [[1, 5] .. [1, 8]]
+				            selectionRange: [[1, 1] .. [1, 8]]
+				            details: 
+				            deprecated: false
+				            children: [
+				                symbol "Foo.bar.int" {
+				                    kind: 7
+				                    range: [[1, 1] .. [1, 4]]
+				                    selectionRange: [[1, 1] .. [1, 4]]
+				                    details: 
+				                    deprecated: false
+				                }
+				            ]
+				        }
+				    ]
+				}
+				symbol "Bar" {
+				    kind: 7
+				    range: [[3, 5] .. [3, 8]]
+				    selectionRange: [[3, 0] .. [5, 1]]
+				    details: 
+				    deprecated: false
+				    children: [
+				        symbol "Bar.foo" {
+				            kind: 7
+				            range: [[4, 5] .. [4, 8]]
+				            selectionRange: [[4, 1] .. [4, 8]]
+				            details: 
+				            deprecated: false
+				        }
+				    ]
+				}
+				'''
+		]
+	}
+}

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/HierarchicalDocumentSymbolTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/HierarchicalDocumentSymbolTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.tests.server;
+
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.DocumentSymbolCapabilities;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
+import org.eclipse.xtext.testing.DocumentSymbolConfiguraiton;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Test;
+
+@SuppressWarnings("all")
+public class HierarchicalDocumentSymbolTest extends AbstractTestLangLanguageServerTest {
+  private final static Procedure1<? super InitializeParams> INITIALIZER = ((Procedure1<InitializeParams>) (InitializeParams it) -> {
+    ClientCapabilities _clientCapabilities = new ClientCapabilities();
+    final Procedure1<ClientCapabilities> _function = (ClientCapabilities it_1) -> {
+      TextDocumentClientCapabilities _textDocumentClientCapabilities = new TextDocumentClientCapabilities();
+      final Procedure1<TextDocumentClientCapabilities> _function_1 = (TextDocumentClientCapabilities it_2) -> {
+        DocumentSymbolCapabilities _documentSymbolCapabilities = new DocumentSymbolCapabilities();
+        final Procedure1<DocumentSymbolCapabilities> _function_2 = (DocumentSymbolCapabilities it_3) -> {
+          it_3.setHierarchicalDocumentSymbolSupport(Boolean.valueOf(true));
+        };
+        DocumentSymbolCapabilities _doubleArrow = ObjectExtensions.<DocumentSymbolCapabilities>operator_doubleArrow(_documentSymbolCapabilities, _function_2);
+        it_2.setDocumentSymbol(_doubleArrow);
+      };
+      TextDocumentClientCapabilities _doubleArrow = ObjectExtensions.<TextDocumentClientCapabilities>operator_doubleArrow(_textDocumentClientCapabilities, _function_1);
+      it_1.setTextDocument(_doubleArrow);
+    };
+    ClientCapabilities _doubleArrow = ObjectExtensions.<ClientCapabilities>operator_doubleArrow(_clientCapabilities, _function);
+    it.setCapabilities(_doubleArrow);
+  });
+  
+  @Test
+  public void testDocumentSymbol_01() {
+    final Procedure1<DocumentSymbolConfiguraiton> _function = (DocumentSymbolConfiguraiton it) -> {
+      it.setInitializer(HierarchicalDocumentSymbolTest.INITIALIZER);
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("type Foo {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("int bar");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      _builder.append("type Bar {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("Foo foo");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      it.setModel(_builder.toString());
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("symbol \"Foo\" {");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("kind: 7");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("range: [[0, 5] .. [0, 8]]");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("selectionRange: [[0, 0] .. [2, 1]]");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("details: ");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("deprecated: false");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("children: [");
+      _builder_1.newLine();
+      _builder_1.append("        ");
+      _builder_1.append("symbol \"Foo.bar\" {");
+      _builder_1.newLine();
+      _builder_1.append("            ");
+      _builder_1.append("kind: 7");
+      _builder_1.newLine();
+      _builder_1.append("            ");
+      _builder_1.append("range: [[1, 5] .. [1, 8]]");
+      _builder_1.newLine();
+      _builder_1.append("            ");
+      _builder_1.append("selectionRange: [[1, 1] .. [1, 8]]");
+      _builder_1.newLine();
+      _builder_1.append("            ");
+      _builder_1.append("details: ");
+      _builder_1.newLine();
+      _builder_1.append("            ");
+      _builder_1.append("deprecated: false");
+      _builder_1.newLine();
+      _builder_1.append("            ");
+      _builder_1.append("children: [");
+      _builder_1.newLine();
+      _builder_1.append("                ");
+      _builder_1.append("symbol \"Foo.bar.int\" {");
+      _builder_1.newLine();
+      _builder_1.append("                    ");
+      _builder_1.append("kind: 7");
+      _builder_1.newLine();
+      _builder_1.append("                    ");
+      _builder_1.append("range: [[1, 1] .. [1, 4]]");
+      _builder_1.newLine();
+      _builder_1.append("                    ");
+      _builder_1.append("selectionRange: [[1, 1] .. [1, 4]]");
+      _builder_1.newLine();
+      _builder_1.append("                    ");
+      _builder_1.append("details: ");
+      _builder_1.newLine();
+      _builder_1.append("                    ");
+      _builder_1.append("deprecated: false");
+      _builder_1.newLine();
+      _builder_1.append("                ");
+      _builder_1.append("}");
+      _builder_1.newLine();
+      _builder_1.append("            ");
+      _builder_1.append("]");
+      _builder_1.newLine();
+      _builder_1.append("        ");
+      _builder_1.append("}");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("]");
+      _builder_1.newLine();
+      _builder_1.append("}");
+      _builder_1.newLine();
+      _builder_1.append("symbol \"Bar\" {");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("kind: 7");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("range: [[3, 5] .. [3, 8]]");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("selectionRange: [[3, 0] .. [5, 1]]");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("details: ");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("deprecated: false");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("children: [");
+      _builder_1.newLine();
+      _builder_1.append("        ");
+      _builder_1.append("symbol \"Bar.foo\" {");
+      _builder_1.newLine();
+      _builder_1.append("            ");
+      _builder_1.append("kind: 7");
+      _builder_1.newLine();
+      _builder_1.append("            ");
+      _builder_1.append("range: [[4, 5] .. [4, 8]]");
+      _builder_1.newLine();
+      _builder_1.append("            ");
+      _builder_1.append("selectionRange: [[4, 1] .. [4, 8]]");
+      _builder_1.newLine();
+      _builder_1.append("            ");
+      _builder_1.append("details: ");
+      _builder_1.newLine();
+      _builder_1.append("            ");
+      _builder_1.append("deprecated: false");
+      _builder_1.newLine();
+      _builder_1.append("        ");
+      _builder_1.append("}");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("]");
+      _builder_1.newLine();
+      _builder_1.append("}");
+      _builder_1.newLine();
+      it.setExpectedSymbols(_builder_1.toString());
+    };
+    this.testDocumentSymbol(_function);
+  }
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/DocumentExtensions.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/DocumentExtensions.xtend
@@ -75,6 +75,18 @@ class DocumentExtensions {
 		return resource.newLocation(textRegion)
 	}
 
+	/**
+	 * Returns with the {@link Location location} that represents the {@link ILocationInFileProvider#getFullTextRegion full text region}
+	 * of the argument.
+	 * 
+	 * @since 2.16
+	 */
+	def Location newFullLocation(EObject object) {
+		val resource = object.eResource
+		val textRegion = locationInFileProvider.getFullTextRegion(object)
+		return resource.newLocation(textRegion)
+	}
+
 	def Location newLocation(EObject owner, EStructuralFeature feature, int indexInList) {
 		val resource = owner.eResource
 		val textRegion = locationInFileProvider.getSignificantTextRegion(owner, feature, indexInList)

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/DocumentSymbolMapper.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/DocumentSymbolMapper.xtend
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.server.symbol
+
+import com.google.common.annotations.Beta
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import org.eclipse.emf.ecore.EClass
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.lsp4j.DocumentSymbol
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.SymbolKind
+import org.eclipse.xtext.ide.server.DocumentExtensions
+import org.eclipse.xtext.naming.IQualifiedNameProvider
+import org.eclipse.xtext.naming.QualifiedName
+import org.eclipse.xtext.resource.IEObjectDescription
+
+/**
+ * Maps an EObject to the corresponding {@link DocumentSymbol document symbol}.
+ */
+@Beta
+@Singleton
+class DocumentSymbolMapper {
+
+	@Inject
+	DocumentSymbolNameProvider nameProvider;
+
+	@Inject
+	DocumentSymbolKindProvider kindProvider;
+
+	@Inject
+	DocumentSymbolRangeProvider rangeProvider;
+
+	@Inject
+	DocumentSymbolDetailsProvider detailsProvider;
+
+	@Inject
+	DocumentSymbolDeprecationInfoProvider deprecationInfoProvider;
+
+	/**
+	 * Converts the {@code EObject} argument into a {@link DocumentSymbol document symbol} without
+	 * the {@link DocumentSymbol#children children} information filled in.
+	 */
+	def DocumentSymbol toDocumentSymbol(EObject object) {
+		return new DocumentSymbol => [
+			name = nameProvider.getName(object);
+			kind = kindProvider.getSymbolKind(object);
+			range = rangeProvider.getRange(object);
+			selectionRange = rangeProvider.getSelectionRange(object);
+			detail = detailsProvider.getDetails(object);
+			deprecated = deprecationInfoProvider.isDeprecated(object);
+			children = newArrayList;
+		];
+	}
+
+	/**
+	 * Provides {@link DocumentSymbol#detail detail} for a {@link DocumentSymbol document symbol}.
+	 * <p>
+	 * Always returns with an empty string by default.
+	 * 
+	 * @see DocumentSymbol#detail
+	 */
+	@Beta
+	@Singleton
+	static class DocumentSymbolDetailsProvider {
+
+		def String getDetails(EObject object) {
+			return '';
+		}
+
+	}
+
+	/**
+	 * Provides a human-readable name for the document symbol.
+	 * 
+	 * @see DocumentSymbol#name
+	 */
+	@Beta
+	@Singleton
+	static class DocumentSymbolNameProvider {
+
+		@Inject
+		extension IQualifiedNameProvider;
+
+		def String getName(EObject object) {
+			return object?.fullyQualifiedName.name;
+		}
+
+		def String getName(IEObjectDescription description) {
+			return description?.name.name;
+		}
+
+		protected def String getName(QualifiedName qualifiedName) {
+			return qualifiedName?.toString;
+		}
+
+	}
+
+	/**
+	 * Provides the {@link SymbolKind symbol kind} information for the document symbol.
+	 * 
+	 * @see DocumentSymbol#kind
+	 */
+	@Beta
+	@Singleton
+	static class DocumentSymbolKindProvider {
+
+		def SymbolKind getSymbolKind(EObject object) {
+			return object?.eClass.symbolKind;
+		}
+
+		def SymbolKind getSymbolKind(IEObjectDescription description) {
+			return description?.EClass.symbolKind;
+		}
+
+		protected def SymbolKind getSymbolKind(EClass clazz) {
+			return SymbolKind.Property;
+		}
+	}
+
+	/**
+	 * Provides {@link DocumentSymbol#range range} and {@link DocumentSymbol#selectionRange selection range} for a document symbol.
+	 * 
+	 * @see DocumentSymbol#range
+	 * @see DocumentSymbol#selectionRange
+	 */
+	@Beta
+	@Singleton
+	static class DocumentSymbolRangeProvider {
+
+		@Inject
+		extension DocumentExtensions;
+
+		/**
+		 * The range enclosing this symbol not including leading/trailing whitespace but everything else
+		 * like comments.
+		 */
+		def Range getRange(EObject object) {
+			return object.newLocation?.range;
+		}
+
+		/**
+		 * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+		 */
+		def Range getSelectionRange(EObject object) {
+			return object.newFullLocation?.range;
+		}
+
+	}
+
+	/**
+	 * Determines whether a document symbol can be marked as {@link DocumentSymbol#deprecated deprecated}.
+	 * 
+	 * @see DocumentSymbol#deprecated
+	 */
+	@Beta
+	@Singleton
+	static class DocumentSymbolDeprecationInfoProvider {
+
+		def boolean isDeprecated(EObject object) {
+			return false;
+		}
+
+		def boolean isDeprecated(IEObjectDescription description) {
+			return false;
+		}
+
+	}
+
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/HierarchicalDocumentSymbolService.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/HierarchicalDocumentSymbolService.xtend
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.server.symbol
+
+import com.google.common.annotations.Beta
+import com.google.common.base.Optional
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import java.util.Iterator
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.emf.ecore.util.EcoreUtil
+import org.eclipse.lsp4j.DocumentSymbol
+import org.eclipse.lsp4j.DocumentSymbolParams
+import org.eclipse.lsp4j.SymbolInformation
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull
+import org.eclipse.xtext.ide.server.Document
+import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.service.OperationCanceledManager
+import org.eclipse.xtext.util.CancelIndicator
+
+/**
+ * Document symbol service that is comply with the LSP <a href="https://microsoft.github.io/language-server-protocol/specification#version_3_10_0">3.10.0</a>
+ * version. Unlike the {@link DocumentSymbolService}, this service can provide hierarchical document symbols.
+ */
+@Beta
+@Singleton
+class HierarchicalDocumentSymbolService implements IDocumentSymbolService {
+
+	@Inject
+	DocumentSymbolMapper symbolMapper;
+
+	@Inject
+	OperationCanceledManager operationCanceledManager;
+
+	/**
+	 * {@code false} if the argument is {@code null} or any of the {@link NonNull} properties
+	 * are {@code null}. Otherwise, {@code true}.
+	 */
+	static def boolean isValid(DocumentSymbol symbol) {
+		return symbol !== null && !DocumentSymbol.declaredFields
+			.filter[annotations.exists[annotationType === NonNull]]
+			.map[accessible = true; it]
+			.map[get(symbol)]
+			.exists[it === null];
+	}
+
+	override getSymbols(Document document, XtextResource resource, DocumentSymbolParams params,
+		CancelIndicator cancelIndicator) {
+
+		return getSymbols(resource, cancelIndicator);
+	}
+
+	def getSymbols(XtextResource resource, CancelIndicator cancelIndicator) {
+		val allSymbols = newHashMap;
+		val rootSymbols = newArrayList;
+		val itr = getAllContents(resource);
+		while (itr.hasNext) {
+			operationCanceledManager.checkCanceled(cancelIndicator);
+			val next = itr.next.toEObject;
+			if (next.present) {
+				val object = next.get;
+				val symbol = symbolMapper.toDocumentSymbol(object);
+				if (symbol.valid) {
+					allSymbols.put(object, symbol);
+					var parent = object.eContainer;
+					if (parent === null) {
+						rootSymbols.add(symbol);
+					} else {
+						var parentSymbol = allSymbols.get(parent);
+						// Find the parent symbol and hook the current one to the parent.
+						while (parentSymbol === null && parent !== null) {
+							parent = parent.eContainer;
+							parentSymbol = allSymbols.get(parent);
+						}
+						// If there parent cannot be found, it is a root.
+						if (parentSymbol === null) {
+							rootSymbols.add(symbol);
+						} else {
+							parentSymbol.children.add(symbol);
+						}
+					}
+				}
+			}
+		}
+		return rootSymbols.map[Either.<SymbolInformation, DocumentSymbol>forRight(it)];
+	}
+
+	protected def Iterator<Object> getAllContents(Resource resource) {
+		return EcoreUtil.getAllProperContents(resource, true);
+	}
+
+	protected def Optional<EObject> toEObject(Object object) {
+		if (object instanceof EObject) {
+			return Optional.of(object);
+		}
+		return Optional.absent;
+	}
+
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/IDocumentSymbolService.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/IDocumentSymbolService.xtend
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.server.symbol
+
+import com.google.common.annotations.Beta
+import com.google.inject.ImplementedBy
+import java.util.List
+import org.eclipse.lsp4j.DocumentSymbol
+import org.eclipse.lsp4j.DocumentSymbolParams
+import org.eclipse.lsp4j.SymbolInformation
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.eclipse.xtext.ide.server.Document
+import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.util.CancelIndicator
+
+/**
+ * Common service interface for providing document symbol information for text documents.
+ * 
+ * <p>
+ * For more details, see the <a href="https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol">{@code textDocument/documentSymbol}</a> LSP method.
+ * 
+ * <p>
+ * This interface is not meant to be injected. Use the {@link DocumentSymbolService} and the {@link HierarchicalDocumentSymbolService} directly instead.
+ */
+@Beta
+@ImplementedBy(Noop)
+interface IDocumentSymbolService {
+
+	def List<Either<SymbolInformation, DocumentSymbol>> getSymbols(Document document, XtextResource resource,
+		DocumentSymbolParams params, CancelIndicator cancelIndicator);
+
+	static class Noop implements IDocumentSymbolService {
+
+		override getSymbols(Document document, XtextResource resource, DocumentSymbolParams params,
+			CancelIndicator cancelIndicator) {
+
+			return emptyList;
+		}
+
+	}
+
+}

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/DocumentExtensions.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/DocumentExtensions.java
@@ -89,6 +89,18 @@ public class DocumentExtensions {
     return this.newLocation(resource, textRegion);
   }
   
+  /**
+   * Returns with the {@link Location location} that represents the {@link ILocationInFileProvider#getFullTextRegion full text region}
+   * of the argument.
+   * 
+   * @since 2.16
+   */
+  public Location newFullLocation(final EObject object) {
+    final Resource resource = object.eResource();
+    final ITextRegion textRegion = this.locationInFileProvider.getFullTextRegion(object);
+    return this.newLocation(resource, textRegion);
+  }
+  
   public Location newLocation(final EObject owner, final EStructuralFeature feature, final int indexInList) {
     final Resource resource = owner.eResource();
     final ITextRegion textRegion = this.locationInFileProvider.getSignificantTextRegion(owner, feature, indexInList);

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/symbol/DocumentSymbolMapper.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/symbol/DocumentSymbolMapper.java
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.server.symbol;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.xtext.ide.server.DocumentExtensions;
+import org.eclipse.xtext.naming.IQualifiedNameProvider;
+import org.eclipse.xtext.naming.QualifiedName;
+import org.eclipse.xtext.resource.IEObjectDescription;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+
+/**
+ * Maps an EObject to the corresponding {@link DocumentSymbol document symbol}.
+ */
+@Beta
+@Singleton
+@SuppressWarnings("all")
+public class DocumentSymbolMapper {
+  /**
+   * Provides {@link DocumentSymbol#detail detail} for a {@link DocumentSymbol document symbol}.
+   * <p>
+   * Always returns with an empty string by default.
+   * 
+   * @see DocumentSymbol#detail
+   */
+  @Beta
+  @Singleton
+  public static class DocumentSymbolDetailsProvider {
+    public String getDetails(final EObject object) {
+      return "";
+    }
+  }
+  
+  /**
+   * Provides a human-readable name for the document symbol.
+   * 
+   * @see DocumentSymbol#name
+   */
+  @Beta
+  @Singleton
+  public static class DocumentSymbolNameProvider {
+    @Inject
+    @Extension
+    private IQualifiedNameProvider _iQualifiedNameProvider;
+    
+    public String getName(final EObject object) {
+      QualifiedName _fullyQualifiedName = null;
+      if (object!=null) {
+        _fullyQualifiedName=this._iQualifiedNameProvider.getFullyQualifiedName(object);
+      }
+      return this.getName(_fullyQualifiedName);
+    }
+    
+    public String getName(final IEObjectDescription description) {
+      QualifiedName _name = null;
+      if (description!=null) {
+        _name=description.getName();
+      }
+      return this.getName(_name);
+    }
+    
+    protected String getName(final QualifiedName qualifiedName) {
+      String _string = null;
+      if (qualifiedName!=null) {
+        _string=qualifiedName.toString();
+      }
+      return _string;
+    }
+  }
+  
+  /**
+   * Provides the {@link SymbolKind symbol kind} information for the document symbol.
+   * 
+   * @see DocumentSymbol#kind
+   */
+  @Beta
+  @Singleton
+  public static class DocumentSymbolKindProvider {
+    public SymbolKind getSymbolKind(final EObject object) {
+      EClass _eClass = null;
+      if (object!=null) {
+        _eClass=object.eClass();
+      }
+      return this.getSymbolKind(_eClass);
+    }
+    
+    public SymbolKind getSymbolKind(final IEObjectDescription description) {
+      EClass _eClass = null;
+      if (description!=null) {
+        _eClass=description.getEClass();
+      }
+      return this.getSymbolKind(_eClass);
+    }
+    
+    protected SymbolKind getSymbolKind(final EClass clazz) {
+      return SymbolKind.Property;
+    }
+  }
+  
+  /**
+   * Provides {@link DocumentSymbol#range range} and {@link DocumentSymbol#selectionRange selection range} for a document symbol.
+   * 
+   * @see DocumentSymbol#range
+   * @see DocumentSymbol#selectionRange
+   */
+  @Beta
+  @Singleton
+  public static class DocumentSymbolRangeProvider {
+    @Inject
+    @Extension
+    private DocumentExtensions _documentExtensions;
+    
+    /**
+     * The range enclosing this symbol not including leading/trailing whitespace but everything else
+     * like comments.
+     */
+    public Range getRange(final EObject object) {
+      Location _newLocation = this._documentExtensions.newLocation(object);
+      Range _range = null;
+      if (_newLocation!=null) {
+        _range=_newLocation.getRange();
+      }
+      return _range;
+    }
+    
+    /**
+     * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+     */
+    public Range getSelectionRange(final EObject object) {
+      Location _newFullLocation = this._documentExtensions.newFullLocation(object);
+      Range _range = null;
+      if (_newFullLocation!=null) {
+        _range=_newFullLocation.getRange();
+      }
+      return _range;
+    }
+  }
+  
+  /**
+   * Determines whether a document symbol can be marked as {@link DocumentSymbol#deprecated deprecated}.
+   * 
+   * @see DocumentSymbol#deprecated
+   */
+  @Beta
+  @Singleton
+  public static class DocumentSymbolDeprecationInfoProvider {
+    public boolean isDeprecated(final EObject object) {
+      return false;
+    }
+    
+    public boolean isDeprecated(final IEObjectDescription description) {
+      return false;
+    }
+  }
+  
+  @Inject
+  private DocumentSymbolMapper.DocumentSymbolNameProvider nameProvider;
+  
+  @Inject
+  private DocumentSymbolMapper.DocumentSymbolKindProvider kindProvider;
+  
+  @Inject
+  private DocumentSymbolMapper.DocumentSymbolRangeProvider rangeProvider;
+  
+  @Inject
+  private DocumentSymbolMapper.DocumentSymbolDetailsProvider detailsProvider;
+  
+  @Inject
+  private DocumentSymbolMapper.DocumentSymbolDeprecationInfoProvider deprecationInfoProvider;
+  
+  /**
+   * Converts the {@code EObject} argument into a {@link DocumentSymbol document symbol} without
+   * the {@link DocumentSymbol#children children} information filled in.
+   */
+  public DocumentSymbol toDocumentSymbol(final EObject object) {
+    DocumentSymbol _documentSymbol = new DocumentSymbol();
+    final Procedure1<DocumentSymbol> _function = (DocumentSymbol it) -> {
+      it.setName(this.nameProvider.getName(object));
+      it.setKind(this.kindProvider.getSymbolKind(object));
+      it.setRange(this.rangeProvider.getRange(object));
+      it.setSelectionRange(this.rangeProvider.getSelectionRange(object));
+      it.setDetail(this.detailsProvider.getDetails(object));
+      it.setDeprecated(Boolean.valueOf(this.deprecationInfoProvider.isDeprecated(object)));
+      it.setChildren(CollectionLiterals.<DocumentSymbol>newArrayList());
+    };
+    return ObjectExtensions.<DocumentSymbol>operator_doubleArrow(_documentSymbol, _function);
+  }
+}

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/symbol/HierarchicalDocumentSymbolService.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/symbol/HierarchicalDocumentSymbolService.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.server.symbol;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.DocumentSymbolParams;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.ide.server.Document;
+import org.eclipse.xtext.ide.server.symbol.DocumentSymbolMapper;
+import org.eclipse.xtext.ide.server.symbol.IDocumentSymbolService;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.service.OperationCanceledManager;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ListExtensions;
+
+/**
+ * Document symbol service that is comply with the LSP <a href="https://microsoft.github.io/language-server-protocol/specification#version_3_10_0">3.10.0</a>
+ * version. Unlike the {@link DocumentSymbolService}, this service can provide hierarchical document symbols.
+ */
+@Beta
+@Singleton
+@SuppressWarnings("all")
+public class HierarchicalDocumentSymbolService implements IDocumentSymbolService {
+  @Inject
+  private DocumentSymbolMapper symbolMapper;
+  
+  @Inject
+  private OperationCanceledManager operationCanceledManager;
+  
+  /**
+   * {@code false} if the argument is {@code null} or any of the {@link NonNull} properties
+   * are {@code null}. Otherwise, {@code true}.
+   */
+  public static boolean isValid(final DocumentSymbol symbol) {
+    return ((symbol != null) && (!IterableExtensions.<Object>exists(IterableExtensions.<Field, Object>map(IterableExtensions.<Field, Field>map(IterableExtensions.<Field>filter(((Iterable<Field>)Conversions.doWrapArray(DocumentSymbol.class.getDeclaredFields())), ((Function1<Field, Boolean>) (Field it) -> {
+      final Function1<Annotation, Boolean> _function = (Annotation it_1) -> {
+        Class<? extends Annotation> _annotationType = it_1.annotationType();
+        return Boolean.valueOf((_annotationType == NonNull.class));
+      };
+      return Boolean.valueOf(IterableExtensions.<Annotation>exists(((Iterable<Annotation>)Conversions.doWrapArray(it.getAnnotations())), _function));
+    })), ((Function1<Field, Field>) (Field it) -> {
+      Field _xblockexpression = null;
+      {
+        it.setAccessible(true);
+        _xblockexpression = it;
+      }
+      return _xblockexpression;
+    })), ((Function1<Field, Object>) (Field it) -> {
+      try {
+        return it.get(symbol);
+      } catch (Throwable _e) {
+        throw Exceptions.sneakyThrow(_e);
+      }
+    })), ((Function1<Object, Boolean>) (Object it) -> {
+      return Boolean.valueOf((it == null));
+    }))));
+  }
+  
+  @Override
+  public List<Either<SymbolInformation, DocumentSymbol>> getSymbols(final Document document, final XtextResource resource, final DocumentSymbolParams params, final CancelIndicator cancelIndicator) {
+    return this.getSymbols(resource, cancelIndicator);
+  }
+  
+  public List<Either<SymbolInformation, DocumentSymbol>> getSymbols(final XtextResource resource, final CancelIndicator cancelIndicator) {
+    final HashMap<EObject, DocumentSymbol> allSymbols = CollectionLiterals.<EObject, DocumentSymbol>newHashMap();
+    final ArrayList<DocumentSymbol> rootSymbols = CollectionLiterals.<DocumentSymbol>newArrayList();
+    final Iterator<Object> itr = this.getAllContents(resource);
+    while (itr.hasNext()) {
+      {
+        this.operationCanceledManager.checkCanceled(cancelIndicator);
+        final Optional<EObject> next = this.toEObject(itr.next());
+        boolean _isPresent = next.isPresent();
+        if (_isPresent) {
+          final EObject object = next.get();
+          final DocumentSymbol symbol = this.symbolMapper.toDocumentSymbol(object);
+          boolean _isValid = HierarchicalDocumentSymbolService.isValid(symbol);
+          if (_isValid) {
+            allSymbols.put(object, symbol);
+            EObject parent = object.eContainer();
+            if ((parent == null)) {
+              rootSymbols.add(symbol);
+            } else {
+              DocumentSymbol parentSymbol = allSymbols.get(parent);
+              while (((parentSymbol == null) && (parent != null))) {
+                {
+                  parent = parent.eContainer();
+                  parentSymbol = allSymbols.get(parent);
+                }
+              }
+              if ((parentSymbol == null)) {
+                rootSymbols.add(symbol);
+              } else {
+                parentSymbol.getChildren().add(symbol);
+              }
+            }
+          }
+        }
+      }
+    }
+    final Function1<DocumentSymbol, Either<SymbolInformation, DocumentSymbol>> _function = (DocumentSymbol it) -> {
+      return Either.<SymbolInformation, DocumentSymbol>forRight(it);
+    };
+    return ListExtensions.<DocumentSymbol, Either<SymbolInformation, DocumentSymbol>>map(rootSymbols, _function);
+  }
+  
+  protected Iterator<Object> getAllContents(final Resource resource) {
+    return EcoreUtil.<Object>getAllProperContents(resource, true);
+  }
+  
+  protected Optional<EObject> toEObject(final Object object) {
+    if ((object instanceof EObject)) {
+      return Optional.<EObject>of(((EObject)object));
+    }
+    return Optional.<EObject>absent();
+  }
+}

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/symbol/IDocumentSymbolService.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/symbol/IDocumentSymbolService.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.server.symbol;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.ImplementedBy;
+import java.util.List;
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.DocumentSymbolParams;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.xtext.ide.server.Document;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+
+/**
+ * Common service interface for providing document symbol information for text documents.
+ * 
+ * <p>
+ * For more details, see the <a href="https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol">{@code textDocument/documentSymbol}</a> LSP method.
+ * 
+ * <p>
+ * This interface is not meant to be injected. Use the {@link DocumentSymbolService} and the {@link HierarchicalDocumentSymbolService} directly instead.
+ */
+@Beta
+@ImplementedBy(IDocumentSymbolService.Noop.class)
+@SuppressWarnings("all")
+public interface IDocumentSymbolService {
+  public static class Noop implements IDocumentSymbolService {
+    @Override
+    public List<Either<SymbolInformation, DocumentSymbol>> getSymbols(final Document document, final XtextResource resource, final DocumentSymbolParams params, final CancelIndicator cancelIndicator) {
+      return CollectionLiterals.<Either<SymbolInformation, DocumentSymbol>>emptyList();
+    }
+  }
+  
+  public abstract List<Either<SymbolInformation, DocumentSymbol>> getSymbols(final Document document, final XtextResource resource, final DocumentSymbolParams params, final CancelIndicator cancelIndicator);
+}

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
@@ -37,6 +37,7 @@ import org.eclipse.lsp4j.DocumentFormattingParams
 import org.eclipse.lsp4j.DocumentHighlight
 import org.eclipse.lsp4j.DocumentHighlightKind
 import org.eclipse.lsp4j.DocumentRangeFormattingParams
+import org.eclipse.lsp4j.DocumentSymbol
 import org.eclipse.lsp4j.DocumentSymbolParams
 import org.eclipse.lsp4j.FileChangeType
 import org.eclipse.lsp4j.FileEvent
@@ -148,6 +149,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 	protected List<Pair<String, Object>> notifications = newArrayList()
 	protected File root
 	protected LanguageInfo languageInfo
+	protected boolean hierarchicalDocumentSymbolSupport = false;
 
 	protected def Path getTestRootPath() {
 		root.toPath().toAbsolutePath().normalize()
@@ -168,6 +170,8 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 			rootUri = root.toURI.normalize.toUriString
 		]
 		initializer?.apply(params)
+		hierarchicalDocumentSymbolSupport = params.capabilities?.textDocument?.documentSymbol?.
+			hierarchicalDocumentSymbolSupport ?: false;
 		return languageServer.initialize(params).get
 	}
 
@@ -255,6 +259,24 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		    location: «location.toExpectation»
 		    «IF !containerName.nullOrEmpty»
 		    	container: "«containerName»"
+		    «ENDIF»
+		}
+	'''
+
+	/**
+	 * @since 2.16
+	 */
+	protected def dispatch String toExpectation(DocumentSymbol it) '''
+		symbol "«name»" {
+		    kind: «kind.value»
+		    range: «range.toExpectation»
+		    selectionRange: «selectionRange.toExpectation»
+		    details: «detail»
+		    deprecated: «deprecated»
+		    «IF !children.nullOrEmpty»
+		    children: [
+		    	«FOR child : children SEPARATOR'\n'»«child.toExpectation»«ENDFOR»
+		    ]
 		    «ENDIF»
 		}
 	'''
@@ -421,7 +443,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 	}
 
 	protected def FileInfo initializeContext(TextDocumentConfiguration configuration) {
-		initialize
+		initialize(configuration.initializer)
 		// create files on disk and notify languageServer
 		if (!configuration.filesInScope.isEmpty) {
 			val createdFiles = configuration.filesInScope.entrySet.map[key.writeFile(value.toString)]
@@ -519,9 +541,10 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		val symbolsFuture = languageServer.documentSymbol(new DocumentSymbolParams(new TextDocumentIdentifier(fileUri)))
 		val symbols = symbolsFuture.get
 		if (configuration.assertSymbols !== null) {
-			configuration.assertSymbols.apply(symbols.map[getLeft])
+			configuration.assertSymbols.apply(symbols)
 		} else {
-			val String actualSymbols = symbols.toExpectation
+			val unwrappedSymbols = symbols.map[if(hierarchicalDocumentSymbolSupport) getRight else getLeft]
+			val String actualSymbols = unwrappedSymbols.toExpectation
 			assertEquals(expectedSymbols, actualSymbols)
 		}
 	}
@@ -682,7 +705,7 @@ class DocumentHighlightConfiguration extends TextDocumentPositionConfiguration {
 @Accessors
 class DocumentSymbolConfiguraiton extends TextDocumentConfiguration {
 	String expectedSymbols = ''
-	(List<? extends SymbolInformation>)=>void assertSymbols = null
+	(List<Either<SymbolInformation, DocumentSymbol>>)=>void assertSymbols = null
 }
 
 @Accessors
@@ -710,6 +733,7 @@ class TextDocumentConfiguration {
 	Map<String, CharSequence> filesInScope = emptyMap
 	String model
 	String filePath
+	(InitializeParams)=>void initializer
 }
 
 @Accessors

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionParams;
@@ -46,6 +47,7 @@ import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.DocumentSymbolCapabilities;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.FileChangeType;
 import org.eclipse.lsp4j.FileEvent;
@@ -63,6 +65,7 @@ import org.eclipse.lsp4j.SemanticHighlightingParams;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.SignatureInformation;
 import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
@@ -267,6 +270,8 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
   
   protected LanguageInfo languageInfo;
   
+  protected boolean hierarchicalDocumentSymbolSupport = false;
+  
   protected Path getTestRootPath() {
     return this.root.toPath().toAbsolutePath().normalize();
   }
@@ -300,6 +305,26 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
       if (initializer!=null) {
         initializer.apply(params);
       }
+      Boolean _elvis = null;
+      ClientCapabilities _capabilities = params.getCapabilities();
+      TextDocumentClientCapabilities _textDocument = null;
+      if (_capabilities!=null) {
+        _textDocument=_capabilities.getTextDocument();
+      }
+      DocumentSymbolCapabilities _documentSymbol = null;
+      if (_textDocument!=null) {
+        _documentSymbol=_textDocument.getDocumentSymbol();
+      }
+      Boolean _hierarchicalDocumentSymbolSupport = null;
+      if (_documentSymbol!=null) {
+        _hierarchicalDocumentSymbolSupport=_documentSymbol.getHierarchicalDocumentSymbolSupport();
+      }
+      if (_hierarchicalDocumentSymbolSupport != null) {
+        _elvis = _hierarchicalDocumentSymbolSupport;
+      } else {
+        _elvis = Boolean.valueOf(false);
+      }
+      this.hierarchicalDocumentSymbolSupport = (_elvis).booleanValue();
       return this.languageServer.initialize(params).get();
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
@@ -482,6 +507,74 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
         _builder.append(_containerName, "    ");
         _builder.append("\"");
         _builder.newLineIfNotEmpty();
+      }
+    }
+    _builder.append("}");
+    _builder.newLine();
+    return _builder.toString();
+  }
+  
+  /**
+   * @since 2.16
+   */
+  protected String _toExpectation(final DocumentSymbol it) {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("symbol \"");
+    String _name = it.getName();
+    _builder.append(_name);
+    _builder.append("\" {");
+    _builder.newLineIfNotEmpty();
+    _builder.append("    ");
+    _builder.append("kind: ");
+    int _value = it.getKind().getValue();
+    _builder.append(_value, "    ");
+    _builder.newLineIfNotEmpty();
+    _builder.append("    ");
+    _builder.append("range: ");
+    String _expectation = this.toExpectation(it.getRange());
+    _builder.append(_expectation, "    ");
+    _builder.newLineIfNotEmpty();
+    _builder.append("    ");
+    _builder.append("selectionRange: ");
+    String _expectation_1 = this.toExpectation(it.getSelectionRange());
+    _builder.append(_expectation_1, "    ");
+    _builder.newLineIfNotEmpty();
+    _builder.append("    ");
+    _builder.append("details: ");
+    String _detail = it.getDetail();
+    _builder.append(_detail, "    ");
+    _builder.newLineIfNotEmpty();
+    _builder.append("    ");
+    _builder.append("deprecated: ");
+    Boolean _deprecated = it.getDeprecated();
+    _builder.append(_deprecated, "    ");
+    _builder.newLineIfNotEmpty();
+    {
+      boolean _isNullOrEmpty = IterableExtensions.isNullOrEmpty(it.getChildren());
+      boolean _not = (!_isNullOrEmpty);
+      if (_not) {
+        _builder.append("    ");
+        _builder.append("children: [");
+        _builder.newLine();
+        _builder.append("    ");
+        _builder.append("\t");
+        {
+          List<DocumentSymbol> _children = it.getChildren();
+          boolean _hasElements = false;
+          for(final DocumentSymbol child : _children) {
+            if (!_hasElements) {
+              _hasElements = true;
+            } else {
+              _builder.appendImmediate("\n", "    \t");
+            }
+            String _expectation_2 = this.toExpectation(child);
+            _builder.append(_expectation_2, "    \t");
+          }
+        }
+        _builder.newLineIfNotEmpty();
+        _builder.append("    ");
+        _builder.append("]");
+        _builder.newLine();
       }
     }
     _builder.append("}");
@@ -849,7 +942,7 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
   }
   
   protected FileInfo initializeContext(final TextDocumentConfiguration configuration) {
-    this.initialize();
+    this.initialize(configuration.getInitializer());
     boolean _isEmpty = configuration.getFilesInScope().isEmpty();
     boolean _not = (!_isEmpty);
     if (_not) {
@@ -1014,15 +1107,22 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
       DocumentSymbolParams _documentSymbolParams = new DocumentSymbolParams(_textDocumentIdentifier);
       final CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> symbolsFuture = this.languageServer.documentSymbol(_documentSymbolParams);
       final List<Either<SymbolInformation, DocumentSymbol>> symbols = symbolsFuture.get();
-      Procedure1<? super List<? extends SymbolInformation>> _assertSymbols = configuration.getAssertSymbols();
+      Procedure1<? super List<Either<SymbolInformation, DocumentSymbol>>> _assertSymbols = configuration.getAssertSymbols();
       boolean _tripleNotEquals = (_assertSymbols != null);
       if (_tripleNotEquals) {
-        final Function1<Either<SymbolInformation, DocumentSymbol>, SymbolInformation> _function = (Either<SymbolInformation, DocumentSymbol> it) -> {
-          return it.getLeft();
-        };
-        configuration.getAssertSymbols().apply(ListExtensions.<Either<SymbolInformation, DocumentSymbol>, SymbolInformation>map(symbols, _function));
+        configuration.getAssertSymbols().apply(symbols);
       } else {
-        final String actualSymbols = this.toExpectation(symbols);
+        final Function1<Either<SymbolInformation, DocumentSymbol>, Object> _function = (Either<SymbolInformation, DocumentSymbol> it) -> {
+          Object _xifexpression = null;
+          if (this.hierarchicalDocumentSymbolSupport) {
+            _xifexpression = it.getRight();
+          } else {
+            _xifexpression = it.getLeft();
+          }
+          return _xifexpression;
+        };
+        final List<Object> unwrappedSymbols = ListExtensions.<Either<SymbolInformation, DocumentSymbol>, Object>map(symbols, _function);
+        final String actualSymbols = this.toExpectation(unwrappedSymbols);
         this.assertEquals(configuration.getExpectedSymbols(), actualSymbols);
       }
     } catch (Throwable _e) {
@@ -1256,6 +1356,8 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
       return _toExpectation((CompletionItem)it);
     } else if (it instanceof DocumentHighlight) {
       return _toExpectation((DocumentHighlight)it);
+    } else if (it instanceof DocumentSymbol) {
+      return _toExpectation((DocumentSymbol)it);
     } else if (it instanceof Hover) {
       return _toExpectation((Hover)it);
     } else if (it instanceof Location) {

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/DocumentSymbolConfiguraiton.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/DocumentSymbolConfiguraiton.java
@@ -8,7 +8,9 @@
 package org.eclipse.xtext.testing;
 
 import java.util.List;
+import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtext.testing.TextDocumentConfiguration;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
@@ -19,7 +21,7 @@ import org.eclipse.xtext.xbase.lib.Pure;
 public class DocumentSymbolConfiguraiton extends TextDocumentConfiguration {
   private String expectedSymbols = "";
   
-  private Procedure1<? super List<? extends SymbolInformation>> assertSymbols = null;
+  private Procedure1<? super List<Either<SymbolInformation, DocumentSymbol>>> assertSymbols = null;
   
   @Pure
   public String getExpectedSymbols() {
@@ -31,11 +33,11 @@ public class DocumentSymbolConfiguraiton extends TextDocumentConfiguration {
   }
   
   @Pure
-  public Procedure1<? super List<? extends SymbolInformation>> getAssertSymbols() {
+  public Procedure1<? super List<Either<SymbolInformation, DocumentSymbol>>> getAssertSymbols() {
     return this.assertSymbols;
   }
   
-  public void setAssertSymbols(final Procedure1<? super List<? extends SymbolInformation>> assertSymbols) {
+  public void setAssertSymbols(final Procedure1<? super List<Either<SymbolInformation, DocumentSymbol>>> assertSymbols) {
     this.assertSymbols = assertSymbols;
   }
 }

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/TextDocumentConfiguration.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/TextDocumentConfiguration.java
@@ -8,8 +8,10 @@
 package org.eclipse.xtext.testing;
 
 import java.util.Map;
+import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 
 @Accessors
@@ -20,6 +22,8 @@ public class TextDocumentConfiguration {
   private String model;
   
   private String filePath;
+  
+  private Procedure1<? super InitializeParams> initializer;
   
   @Pure
   public Map<String, CharSequence> getFilesInScope() {
@@ -46,5 +50,14 @@ public class TextDocumentConfiguration {
   
   public void setFilePath(final String filePath) {
     this.filePath = filePath;
+  }
+  
+  @Pure
+  public Procedure1<? super InitializeParams> getInitializer() {
+    return this.initializer;
+  }
+  
+  public void setInitializer(final Procedure1<? super InitializeParams> initializer) {
+    this.initializer = initializer;
   }
 }


### PR DESCRIPTION
Closes: eclipse/xtext-eclipse#858.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>