### PR TITLE
[eclipse/xtext#1272] Set Xtext bootstrap 2.15

### DIFF
--- a/gradle/bootstrap-setup.gradle
+++ b/gradle/bootstrap-setup.gradle
@@ -23,8 +23,6 @@ configurations {
 					useVersion(versions.xtext_bootstrap)
 				if (requested.group == 'com.google.inject' && requested.name == 'guice')
 					useVersion(versions.guice)
-				if (requested.group == 'org.eclipse.jdt' && requested.name == 'org.eclipse.jdt.core')
-					useVersion(versions.jdtCore)
 			}
 		}
 		exclude group: 'asm'

--- a/gradle/bootstrap-setup.gradle
+++ b/gradle/bootstrap-setup.gradle
@@ -14,16 +14,13 @@ repositories {
 	}
 }
 
-// The Xtend compiler version to use
-def bootstrapXtendVersion = versions.xtext_bootstrap
-
 configurations {
 	xtendCompiler {
 		description 'Bootstrap dependencies for the Xtend compiler'
 		resolutionStrategy {
 			eachDependency {
 				if (requested.group == 'org.eclipse.xtext' || requested.group == 'org.eclipse.xtend')
-					useVersion(bootstrapXtendVersion)
+					useVersion(versions.xtext_bootstrap)
 				if (requested.group == 'com.google.inject' && requested.name == 'guice')
 					useVersion(versions.guice)
 				if (requested.group == 'org.eclipse.jdt' && requested.name == 'org.eclipse.jdt.core')
@@ -35,7 +32,7 @@ configurations {
 }
 
 dependencies {
-	xtendCompiler "org.eclipse.xtend:org.eclipse.xtend.core:$bootstrapXtendVersion"
-	xtendCompiler "org.eclipse.xtext:org.eclipse.xtext.smap:$bootstrapXtendVersion"
+	xtendCompiler "org.eclipse.xtend:org.eclipse.xtend.core:${versions.xtext_bootstrap}"
+	xtendCompiler "org.eclipse.xtext:org.eclipse.xtext.smap:${versions.xtext_bootstrap}"
 	xtendCompiler "org.xtext:xtext-gradle-builder:$versions.xtext_gradle_plugin"
 }

--- a/gradle/p2-deployment.gradle
+++ b/gradle/p2-deployment.gradle
@@ -13,7 +13,7 @@ p2gen {
 	exclude 'org.eclipse.xtext.xtext.bootstrap'
 
 	dependencies {
-		repositoryUrl 'http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.14.0'
+		repositoryUrl 'http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.15.0'
 		feature 'org.eclipse.xtext.sdk'
 	}
 	dependencies {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -6,7 +6,7 @@ version = '2.16.0-SNAPSHOT'
 
 ext.versions = [
 	'xtext': version,
-	'xtext_bootstrap': '2.14.0',
+	'xtext_bootstrap': '2.15.0',
 	'gradle_plugins': '0.1.0',
 	'xtext_gradle_plugin': '2.0.1',
 	// When adjusting the `lsp4j` version here, do not forget to do the followings:

--- a/releng/releng-target/xtext-core.target.target
+++ b/releng/releng-target/xtext-core.target.target
@@ -3,7 +3,7 @@
 <target name="org.eclipse.xtext.helios.target" sequenceNumber="0">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.14.0"/>
+			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.15.0"/>
 			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
Refactored to use xtext_bootstrap property from versions.gradle
Changed target definition.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>