### PR TITLE
[eclipse/xtext#1222] Auto-detect upstream repository URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ buildscript {
 	}
 }
 
+plugins {
+  id 'org.ajoberstar.grgit' version '2.2.0'
+}
+
 apply from: "${rootDir}/gradle/versions.gradle"
 apply from: "${rootDir}/gradle/bootstrap-setup.gradle"
 apply from: "${rootDir}/gradle/p2-deployment.gradle"

--- a/gradle/upstream-repositories.gradle
+++ b/gradle/upstream-repositories.gradle
@@ -1,36 +1,85 @@
 /*
  * The build uses either public snapshots or branch-specific repositories on the Jenkins
  * build server as upstream repositories. Use the argument '-PuseJenkinsSnapshots=true'
- * to enable the Jenkins repositories. In this case you can select an upstream branch
- * with the argument '-PupstreamBranch=<branch name>'. Without that argument, the
- * upstream branch is selected automatically based on the version string.
+ * to enable the Jenkins repositories. In this case the upstream branch for each upstream
+ * repository is tried to auto-detect. When a job for the upstream repository exists with
+ * the same name as the current branch, then this is taken. Next, the branch's tracking branch
+ * name is tried, when configured. Last, 'master' is taken as fallback. The upstream branch
+ * name can be explicitly overridden when the argument '-PupstreamBranch=<branch name>'
+ * is set.
  */
 
 if (!hasProperty('JENKINS_URL')) {
-	ext.JENKINS_URL = 'http://services.typefox.io/open-source/jenkins'
+  ext.JENKINS_URL = 'http://services.typefox.io/open-source/jenkins'
 }
 
-if (!hasProperty('upstreamBranch')) {
-	def versionSplit = version.split('\\.')
-	if (versionSplit.length == 4)
-		ext.upstreamBranch = 'milestone_' + version
-	else if (versionSplit[2] == '0-SNAPSHOT')
-		ext.upstreamBranch = 'master'
-	else if (versionSplit[2].endsWith('-SNAPSHOT'))
-		ext.upstreamBranch = 'maintenance_' + version.substring(0, version.lastIndexOf('.'))
-	else
-		ext.upstreamBranch = 'release_' + version
-}
+ext.MVN_REPOPATH = 'lastStableBuild/artifact/build/maven-repository/'
 
-def jenkinsPipelineRepo = { jobName, upstreamBranch -> "$JENKINS_URL/job/$jobName/job/$upstreamBranch/lastStableBuild/artifact/build/maven-repository/" }
+
+def jenkinsPipelineRepo = { jobName, branch ->
+  def upstreamBranch = upstream_branch(jobName, branch)
+  def upstreamRepo = "$JENKINS_URL/job/$jobName/job/$upstreamBranch/$MVN_REPOPATH"
+  logger.debug "[$jobName] Using upstream repository $upstreamRepo"
+  return upstreamRepo
+}
 
 repositories {
-	jcenter()
-	if (findProperty('useJenkinsSnapshots') == 'true') {
-		maven { url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/" }
-		maven { url jenkinsPipelineRepo('xtext-lib','master') }
-	} else {
-		mavenLocal()
-		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
-	}
+  jcenter()
+  if (findProperty('useJenkinsSnapshots') == 'true') {
+    maven { url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/$MVN_REPOPATH" }
+    maven { url jenkinsPipelineRepo('xtext-lib','autodetect') }
+  } else {
+    mavenLocal()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+  }
+}
+
+/**
+ * Retrieves the name of the upstream branch to use for given job. This will be
+ * one of the following:
+ * - the value of property 'upstreamBranch', when explicitly set
+ * - when argument 'branch' is not 'autodetect', then value of 'branch'
+ * - the name of the current branch, when a job exists on Jenkins for the upstream repository also
+ * - the name of the tracking branch, when a tracking branch is configured and a job exists on Jenkins for the tracked branch name
+ *   on the upstream repository
+ * - 'master' as fallback
+ */
+def upstream_branch (jobName, branch) {
+  if (hasProperty('upstreamBranch')) {
+    logger.info "$project.name $jobName] Using upstream branch $upstreamBranch (upstreamBranch property is set)"
+    return ext.upstreamBranch
+  }
+  if (branch != 'autodetect') {
+    logger.info "$project.name $jobName] Using upstream branch $branch (explicitly set)"
+    return branch
+  }
+  def branch_candidates = [grgit.branch.current().name]
+  if (grgit.branch.current().trackingBranch != null) {
+    branch_candidates << grgit.branch.current().trackingBranch.name
+  }
+  
+  def selectedBranch = branch_candidates.find { candidate -> url_exists(new URL("$JENKINS_URL/job/$jobName/job/$candidate/$MVN_REPOPATH")) }
+  if (selectedBranch == null) {
+    // fallback
+    selectedBranch = 'master'
+  }
+  logger.info "[$project.name $jobName] Using upstream branch $selectedBranch (autodetect)"
+  return selectedBranch
+}
+
+/**
+ * Checks an URL that it exists, i.e. no HTTP 404 for it
+ */
+def url_exists (URL url) {
+  logger.debug ("check url $url")
+  def code = url.openConnection().with {
+    requestMethod = 'HEAD'
+    connect()
+    responseCode
+  }
+  if (code == 404) {
+    logger.debug ("$url does not exist")
+    return false
+  }
+  return true
 }


### PR DESCRIPTION
Using plugin org.ajoberstar.grgit to be able to determine the
repository's current branch name.

When using jenkinsPipelineRepo Jenkins is contacted to check the
existence of jobs, starting with the current branch name and falling
back to 'master'. This is done for each upstream repository.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>