### PR TITLE
GH-882: Fixed the inconsistency between the `range` and `selectionRange`.

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/HierarchicalDocumentSymbolTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/HierarchicalDocumentSymbolTest.xtend
@@ -40,15 +40,15 @@ class HierarchicalDocumentSymbolTest extends AbstractTestLangLanguageServerTest 
 			expectedSymbols = '''
 				symbol "Foo" {
 				    kind: 7
-				    range: [[0, 5] .. [0, 8]]
-				    selectionRange: [[0, 0] .. [2, 1]]
+				    range: [[0, 0] .. [2, 1]]
+				    selectionRange: [[0, 5] .. [0, 8]]
 				    details: 
 				    deprecated: false
 				    children: [
 				        symbol "Foo.bar" {
 				            kind: 7
-				            range: [[1, 5] .. [1, 8]]
-				            selectionRange: [[1, 1] .. [1, 8]]
+				            range: [[1, 1] .. [1, 8]]
+				            selectionRange: [[1, 5] .. [1, 8]]
 				            details: 
 				            deprecated: false
 				            children: [
@@ -65,15 +65,15 @@ class HierarchicalDocumentSymbolTest extends AbstractTestLangLanguageServerTest 
 				}
 				symbol "Bar" {
 				    kind: 7
-				    range: [[3, 5] .. [3, 8]]
-				    selectionRange: [[3, 0] .. [5, 1]]
+				    range: [[3, 0] .. [5, 1]]
+				    selectionRange: [[3, 5] .. [3, 8]]
 				    details: 
 				    deprecated: false
 				    children: [
 				        symbol "Bar.foo" {
 				            kind: 7
-				            range: [[4, 5] .. [4, 8]]
-				            selectionRange: [[4, 1] .. [4, 8]]
+				            range: [[4, 1] .. [4, 8]]
+				            selectionRange: [[4, 5] .. [4, 8]]
 				            details: 
 				            deprecated: false
 				        }

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/HierarchicalDocumentSymbolTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/HierarchicalDocumentSymbolTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 @SuppressWarnings("all")
 public class HierarchicalDocumentSymbolTest extends AbstractTestLangLanguageServerTest {
-  private final static Procedure1<? super InitializeParams> INITIALIZER = ((Procedure1<InitializeParams>) (InitializeParams it) -> {
+  private static final Procedure1<? super InitializeParams> INITIALIZER = ((Procedure1<InitializeParams>) (InitializeParams it) -> {
     ClientCapabilities _clientCapabilities = new ClientCapabilities();
     final Procedure1<ClientCapabilities> _function = (ClientCapabilities it_1) -> {
       TextDocumentClientCapabilities _textDocumentClientCapabilities = new TextDocumentClientCapabilities();
@@ -66,10 +66,10 @@ public class HierarchicalDocumentSymbolTest extends AbstractTestLangLanguageServ
       _builder_1.append("kind: 7");
       _builder_1.newLine();
       _builder_1.append("    ");
-      _builder_1.append("range: [[0, 5] .. [0, 8]]");
+      _builder_1.append("range: [[0, 0] .. [2, 1]]");
       _builder_1.newLine();
       _builder_1.append("    ");
-      _builder_1.append("selectionRange: [[0, 0] .. [2, 1]]");
+      _builder_1.append("selectionRange: [[0, 5] .. [0, 8]]");
       _builder_1.newLine();
       _builder_1.append("    ");
       _builder_1.append("details: ");
@@ -87,10 +87,10 @@ public class HierarchicalDocumentSymbolTest extends AbstractTestLangLanguageServ
       _builder_1.append("kind: 7");
       _builder_1.newLine();
       _builder_1.append("            ");
-      _builder_1.append("range: [[1, 5] .. [1, 8]]");
+      _builder_1.append("range: [[1, 1] .. [1, 8]]");
       _builder_1.newLine();
       _builder_1.append("            ");
-      _builder_1.append("selectionRange: [[1, 1] .. [1, 8]]");
+      _builder_1.append("selectionRange: [[1, 5] .. [1, 8]]");
       _builder_1.newLine();
       _builder_1.append("            ");
       _builder_1.append("details: ");
@@ -139,10 +139,10 @@ public class HierarchicalDocumentSymbolTest extends AbstractTestLangLanguageServ
       _builder_1.append("kind: 7");
       _builder_1.newLine();
       _builder_1.append("    ");
-      _builder_1.append("range: [[3, 5] .. [3, 8]]");
+      _builder_1.append("range: [[3, 0] .. [5, 1]]");
       _builder_1.newLine();
       _builder_1.append("    ");
-      _builder_1.append("selectionRange: [[3, 0] .. [5, 1]]");
+      _builder_1.append("selectionRange: [[3, 5] .. [3, 8]]");
       _builder_1.newLine();
       _builder_1.append("    ");
       _builder_1.append("details: ");
@@ -160,10 +160,10 @@ public class HierarchicalDocumentSymbolTest extends AbstractTestLangLanguageServ
       _builder_1.append("kind: 7");
       _builder_1.newLine();
       _builder_1.append("            ");
-      _builder_1.append("range: [[4, 5] .. [4, 8]]");
+      _builder_1.append("range: [[4, 1] .. [4, 8]]");
       _builder_1.newLine();
       _builder_1.append("            ");
-      _builder_1.append("selectionRange: [[4, 1] .. [4, 8]]");
+      _builder_1.append("selectionRange: [[4, 5] .. [4, 8]]");
       _builder_1.newLine();
       _builder_1.append("            ");
       _builder_1.append("details: ");

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/DocumentSymbolMapper.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/DocumentSymbolMapper.xtend
@@ -141,14 +141,14 @@ class DocumentSymbolMapper {
 		 * like comments.
 		 */
 		def Range getRange(EObject object) {
-			return object.newLocation?.range;
+			return object.newFullLocation?.range;
 		}
 
 		/**
 		 * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
 		 */
 		def Range getSelectionRange(EObject object) {
-			return object.newFullLocation?.range;
+			return object.newLocation?.range;
 		}
 
 	}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/DocumentSymbolService.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/DocumentSymbolService.xtend
@@ -209,7 +209,7 @@ class DocumentSymbolService implements IDocumentSymbolService {
 			deprecated = symbol.deprecated
 			location = new Location => [
 				it.uri = uri
-				range = symbol.range
+				range = symbol.selectionRange
 			]
 			containerName = containerNameProvider.apply(symbol)
 		]

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/symbol/DocumentSymbolMapper.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/symbol/DocumentSymbolMapper.java
@@ -131,10 +131,10 @@ public class DocumentSymbolMapper {
      * like comments.
      */
     public Range getRange(final EObject object) {
-      Location _newLocation = this._documentExtensions.newLocation(object);
+      Location _newFullLocation = this._documentExtensions.newFullLocation(object);
       Range _range = null;
-      if (_newLocation!=null) {
-        _range=_newLocation.getRange();
+      if (_newFullLocation!=null) {
+        _range=_newFullLocation.getRange();
       }
       return _range;
     }
@@ -143,10 +143,10 @@ public class DocumentSymbolMapper {
      * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
      */
     public Range getSelectionRange(final EObject object) {
-      Location _newFullLocation = this._documentExtensions.newFullLocation(object);
+      Location _newLocation = this._documentExtensions.newLocation(object);
       Range _range = null;
-      if (_newFullLocation!=null) {
-        _range=_newFullLocation.getRange();
+      if (_newLocation!=null) {
+        _range=_newLocation.getRange();
       }
       return _range;
     }

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/symbol/DocumentSymbolService.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/symbol/DocumentSymbolService.java
@@ -229,7 +229,7 @@ public class DocumentSymbolService implements IDocumentSymbolService {
       Location _location = new Location();
       final Procedure1<Location> _function_1 = (Location it_1) -> {
         it_1.setUri(uri);
-        it_1.setRange(symbol.getRange());
+        it_1.setRange(symbol.getSelectionRange());
       };
       Location _doubleArrow = ObjectExtensions.<Location>operator_doubleArrow(_location, _function_1);
       it.setLocation(_doubleArrow);

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
@@ -518,68 +518,75 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
    * @since 2.16
    */
   protected String _toExpectation(final DocumentSymbol it) {
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("symbol \"");
-    String _name = it.getName();
-    _builder.append(_name);
-    _builder.append("\" {");
-    _builder.newLineIfNotEmpty();
-    _builder.append("    ");
-    _builder.append("kind: ");
-    int _value = it.getKind().getValue();
-    _builder.append(_value, "    ");
-    _builder.newLineIfNotEmpty();
-    _builder.append("    ");
-    _builder.append("range: ");
-    String _expectation = this.toExpectation(it.getRange());
-    _builder.append(_expectation, "    ");
-    _builder.newLineIfNotEmpty();
-    _builder.append("    ");
-    _builder.append("selectionRange: ");
-    String _expectation_1 = this.toExpectation(it.getSelectionRange());
-    _builder.append(_expectation_1, "    ");
-    _builder.newLineIfNotEmpty();
-    _builder.append("    ");
-    _builder.append("details: ");
-    String _detail = it.getDetail();
-    _builder.append(_detail, "    ");
-    _builder.newLineIfNotEmpty();
-    _builder.append("    ");
-    _builder.append("deprecated: ");
-    Boolean _deprecated = it.getDeprecated();
-    _builder.append(_deprecated, "    ");
-    _builder.newLineIfNotEmpty();
+    String _xblockexpression = null;
     {
-      boolean _isNullOrEmpty = IterableExtensions.isNullOrEmpty(it.getChildren());
-      boolean _not = (!_isNullOrEmpty);
-      if (_not) {
-        _builder.append("    ");
-        _builder.append("children: [");
-        _builder.newLine();
-        _builder.append("    ");
-        _builder.append("\t");
-        {
-          List<DocumentSymbol> _children = it.getChildren();
-          boolean _hasElements = false;
-          for(final DocumentSymbol child : _children) {
-            if (!_hasElements) {
-              _hasElements = true;
-            } else {
-              _builder.appendImmediate("\n", "    \t");
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("selectionRange must be contained in the range: ");
+      _builder.append(it);
+      Assert.assertTrue(_builder.toString(), AbstractLanguageServerTest.contains(it.getRange(), it.getSelectionRange()));
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("symbol \"");
+      String _name = it.getName();
+      _builder_1.append(_name);
+      _builder_1.append("\" {");
+      _builder_1.newLineIfNotEmpty();
+      _builder_1.append("    ");
+      _builder_1.append("kind: ");
+      int _value = it.getKind().getValue();
+      _builder_1.append(_value, "    ");
+      _builder_1.newLineIfNotEmpty();
+      _builder_1.append("    ");
+      _builder_1.append("range: ");
+      String _expectation = this.toExpectation(it.getRange());
+      _builder_1.append(_expectation, "    ");
+      _builder_1.newLineIfNotEmpty();
+      _builder_1.append("    ");
+      _builder_1.append("selectionRange: ");
+      String _expectation_1 = this.toExpectation(it.getSelectionRange());
+      _builder_1.append(_expectation_1, "    ");
+      _builder_1.newLineIfNotEmpty();
+      _builder_1.append("    ");
+      _builder_1.append("details: ");
+      String _detail = it.getDetail();
+      _builder_1.append(_detail, "    ");
+      _builder_1.newLineIfNotEmpty();
+      _builder_1.append("    ");
+      _builder_1.append("deprecated: ");
+      Boolean _deprecated = it.getDeprecated();
+      _builder_1.append(_deprecated, "    ");
+      _builder_1.newLineIfNotEmpty();
+      {
+        boolean _isNullOrEmpty = IterableExtensions.isNullOrEmpty(it.getChildren());
+        boolean _not = (!_isNullOrEmpty);
+        if (_not) {
+          _builder_1.append("    ");
+          _builder_1.append("children: [");
+          _builder_1.newLine();
+          _builder_1.append("    ");
+          _builder_1.append("\t");
+          {
+            List<DocumentSymbol> _children = it.getChildren();
+            boolean _hasElements = false;
+            for(final DocumentSymbol child : _children) {
+              if (!_hasElements) {
+                _hasElements = true;
+              } else {
+                _builder_1.appendImmediate("\n", "    \t");
+              }
+              String _expectation_2 = this.toExpectation(child);
+              _builder_1.append(_expectation_2, "    \t");
             }
-            String _expectation_2 = this.toExpectation(child);
-            _builder.append(_expectation_2, "    \t");
           }
+          _builder_1.newLineIfNotEmpty();
+          _builder_1.append("    ");
+          _builder_1.append("]");
+          _builder_1.newLine();
         }
-        _builder.newLineIfNotEmpty();
-        _builder.append("    ");
-        _builder.append("]");
-        _builder.newLine();
       }
+      _builder_1.append("}");
+      _xblockexpression = _builder_1.toString();
     }
-    _builder.append("}");
-    _builder.newLine();
-    return _builder.toString();
+    return _xblockexpression;
   }
   
   protected String _toExpectation(final CompletionItem it) {
@@ -1168,6 +1175,46 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
+  }
+  
+  /**
+   * {@code true} if the {@code smaller} range is inside or equal to the {@code bigger} range.
+   * Otherwise, {@code false}.
+   */
+  private static boolean contains(final Range bigger, final Range smaller) {
+    return (AbstractLanguageServerTest.contains(bigger, smaller.getStart()) && AbstractLanguageServerTest.contains(bigger, smaller.getEnd()));
+  }
+  
+  /**
+   * {@code true} if the position is either inside or on the border of the range.
+   * Otherwise, {@code false}.
+   */
+  private static boolean contains(final Range range, final Position position) {
+    return ((Objects.equal(range.getStart(), position) || AbstractLanguageServerTest.isBefore(range.getStart(), position)) && (Objects.equal(range.getEnd(), position) || AbstractLanguageServerTest.isBefore(position, range.getEnd())));
+  }
+  
+  /**
+   * {@code true} if {@left} is strictly before than {@code right}.
+   * Otherwise, {@code false}.
+   * <p>
+   * If you want to allow equality, use {@link Position#equals}.
+   */
+  private static boolean isBefore(final Position left, final Position right) {
+    int _line = left.getLine();
+    int _line_1 = right.getLine();
+    boolean _lessThan = (_line < _line_1);
+    if (_lessThan) {
+      return true;
+    }
+    int _line_2 = left.getLine();
+    int _line_3 = right.getLine();
+    boolean _greaterThan = (_line_2 > _line_3);
+    if (_greaterThan) {
+      return false;
+    }
+    int _character = left.getCharacter();
+    int _character_1 = right.getCharacter();
+    return (_character < _character_1);
   }
   
   protected void testSymbol(final Procedure1<? super WorkspaceSymbolConfiguration> configurator) {


### PR DESCRIPTION
Added a test assertion to ensure `selectionRange` is always contained by the `range`.

Closes: #882.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>