### PR TITLE
[eclipse/xtext-1311] Perform KeywordHelperTest with ISO encoding

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/tests/AbstractXtextTests.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/tests/AbstractXtextTests.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.Charset;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
@@ -38,7 +39,7 @@ import org.eclipse.xtext.testing.GlobalRegistries;
 import org.eclipse.xtext.testing.GlobalRegistries.GlobalStateMemento;
 import org.eclipse.xtext.testing.serializer.SerializerTestHelper;
 import org.eclipse.xtext.util.CancelIndicator;
-import org.eclipse.xtext.util.StringInputStream;
+import org.eclipse.xtext.util.LazyStringInputStream;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -172,8 +173,19 @@ public abstract class AbstractXtextTests extends Assert implements ResourceLoadH
 		return getInjector().getInstance(InvariantChecker.class);
 	}
 
+	/**
+	 * Equivalent to <code>getAsStream(model, Charset.defaultCharset())</code>.
+	 */
 	protected InputStream getAsStream(String model) {
-		return new StringInputStream(model);
+		return getAsStream(model, Charset.defaultCharset());
+	}
+	
+	/**
+	 * Gets the string as input stream with specified encoding.
+	 * @since 2.16
+	 */
+	protected InputStream getAsStream(String model, Charset encoding) {
+		return new LazyStringInputStream(model, encoding.name());
 	}
 	
 	// parse methods

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/KeywordHelperTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/KeywordHelperTest.xtend
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext.generator
 
+import java.nio.charset.StandardCharsets
 import org.eclipse.emf.ecore.EPackage
 import org.eclipse.emf.ecore.xml.type.XMLTypePackage
 import org.eclipse.xtext.Grammar
@@ -14,11 +15,11 @@ import org.eclipse.xtext.XtextStandaloneSetup
 import org.eclipse.xtext.testing.GlobalRegistries
 import org.eclipse.xtext.testing.GlobalRegistries.GlobalStateMemento
 import org.eclipse.xtext.tests.AbstractXtextTests
+import org.eclipse.xtext.xtext.generator.grammarAccess.GrammarAccessExtensions
+import org.eclipse.xtext.xtext.generator.parser.antlr.KeywordHelper
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.eclipse.xtext.xtext.generator.parser.antlr.KeywordHelper
-import org.eclipse.xtext.xtext.generator.grammarAccess.GrammarAccessExtensions
 
 /**
  * @author Christian Dietrich - Initial contribution and API
@@ -54,6 +55,10 @@ class KeywordHelperTest extends AbstractXtextTests {
 		assertEquals("KW_EOF", keywordHelper.getRuleName("EOF"))
 		assertEquals("Model", keywordHelper.getRuleName("model"))
 		assertEquals("AeOeUeaeOeUe", keywordHelper.getRuleName("ƒ÷‹‰ˆ¸ﬂ")) //ﬂ is not escaped
+	}
+	
+	override protected getAsStream(String model) {
+		getAsStream(model, StandardCharsets.ISO_8859_1)
 	}
 	
 }

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/KeywordHelperTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/KeywordHelperTest.java
@@ -7,6 +7,8 @@
  */
 package org.eclipse.xtext.xtext.generator;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.xml.type.XMLTypePackage;
@@ -79,5 +81,10 @@ public class KeywordHelperTest extends AbstractXtextTests {
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
+  }
+  
+  @Override
+  protected InputStream getAsStream(final String model) {
+    return this.getAsStream(model, StandardCharsets.ISO_8859_1);
   }
 }


### PR DESCRIPTION
Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>