### PR TITLE
#864: Rewrite MergeableManifest to MergeableManifest2 to avoid reflection

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/ManifestMerger2Test.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/ManifestMerger2Test.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+package org.eclipse.xtext.generator;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.jar.Manifest;
+
+import org.eclipse.xtext.util.MergeableManifest2;
+import org.eclipse.xtext.util.MergeableManifest2.Attributes;
+import org.eclipse.xtext.util.StringInputStream;
+import org.eclipse.xtext.util.Strings;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Adaption of olf {@link ManifestMergerTest} for new
+ * {@link MergeableManifest2}.
+ * 
+ * @author Arne Deutsch - Initial contribution and API
+ */
+public class ManifestMerger2Test extends Assert {
+
+	@Test
+	public void testMergeRequiredBundles() throws Exception {
+		String packageName = getClass().getPackage().getName().replace('.', '/');
+		InputStream resourceAsStream = getClass().getResourceAsStream("/" + packageName + "/Test_Manifest.MF");
+		MergeableManifest2 manifest = new MergeableManifest2(resourceAsStream);
+		Attributes attrs = manifest.getMainAttributes();
+		String before = attrs.get(MergeableManifest2.REQUIRE_BUNDLE).replaceAll("\\s", "");
+		manifest.addRequiredBundles(Collections.singleton("foo.bar.baz"));
+		String after = attrs.get(MergeableManifest2.REQUIRE_BUNDLE);
+		assertEquals(before + ",foo.bar.baz", after.replaceAll("\\s", ""));
+	}
+
+	@Test
+	public void testMergeExportedPackages() throws Exception {
+		String packageName = getClass().getPackage().getName().replace('.', '/');
+		InputStream resourceAsStream = getClass().getResourceAsStream("/" + packageName + "/Test_Manifest.MF");
+		MergeableManifest2 manifest = new MergeableManifest2(resourceAsStream);
+		assertFalse(manifest.isModified());
+
+		manifest.addExportedPackages(Collections.singleton("org.eclipse.xtext"));
+		assertFalse(manifest.isModified());
+
+		manifest.addRequiredBundles(Collections.singleton("org.eclipse.xtend"));
+		assertFalse(manifest.isModified());
+
+		manifest.addImportedPackages(Collections.singleton("org.apache.log4j"));
+		assertFalse(manifest.isModified());
+	}
+
+	@Test
+	public void testNoLongLine() throws Exception {
+		String packageName = getClass().getPackage().getName().replace('.', '/');
+		InputStream resourceAsStream = getClass().getResourceAsStream("/" + packageName + "/Test_Manifest.MF");
+		MergeableManifest2 manifest = new MergeableManifest2(resourceAsStream);
+		manifest.addExportedPackages(Collections.singleton("foobar"));
+		assertTrue(manifest.isModified());
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		manifest.write(out);
+		String result = out.toString();
+		String lookup = "Require-Bundle: org.eclipse.xtext,";
+		int idx = result.indexOf(lookup);
+		assertTrue(idx != -1);
+		idx += lookup.length();
+		String lineDelimiter = Strings.newLine();
+		for (int i = 0; i < lineDelimiter.length(); i++) {
+			assertEquals(result, lineDelimiter.charAt(i), result.charAt(idx + i));
+		}
+		assertEquals(result, ' ', result.charAt(idx + lineDelimiter.length()));
+	}
+
+	@Test
+	public void testSplit512Length() throws Exception {
+		String packageName = getClass().getPackage().getName().replace('.', '/');
+		InputStream resourceAsStream = getClass().getResourceAsStream("/" + packageName + "/Test_Manifest.MF");
+		MergeableManifest2 manifest = new MergeableManifest2(resourceAsStream);
+		char[] buff = new char[712];
+		Arrays.fill(buff, 'c');
+		manifest.addExportedPackages(Collections.singleton(new String(buff)));
+		assertTrue(manifest.isModified());
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		manifest.write(out);
+		String result = out.toString();
+		try {
+			new Manifest(new StringInputStream(result));
+		} catch (Exception e) {
+			fail("long line has not been splitted into chunks");
+		}
+	}
+
+	@Test
+	public void testNoChanges() throws Exception {
+		String packageName = getClass().getPackage().getName().replace('.', '/');
+		InputStream resourceAsStream = getClass().getResourceAsStream("/" + packageName + "/Test_Manifest.MF");
+		MergeableManifest2 manifest = new MergeableManifest2(resourceAsStream);
+		Attributes attrs = manifest.getMainAttributes();
+		String before = attrs.get(MergeableManifest2.EXPORT_PACKAGE).replaceAll("\\s", "");
+		manifest.addExportedPackages(Collections.singleton("foo.bar.baz"));
+		String after = attrs.get(MergeableManifest2.EXPORT_PACKAGE);
+		assertEquals(before + ",foo.bar.baz", after.replaceAll("\\s", ""));
+	}
+
+}

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/MergeableManifest2Test.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/MergeableManifest2Test.java
@@ -1,0 +1,1004 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.util;
+
+import static com.google.common.base.Strings.*;
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.junit.Test;
+
+/**
+ * @author Arne Deutsch - Initial contribution and API
+ */
+public class MergeableManifest2Test {
+
+	private static final String NL = System.lineSeparator();
+
+	@Test
+	public void make512Safe_empty() throws Exception {
+		assertEquals("", make512Safe(""));
+	}
+
+	@Test
+	public void make512Safe_512Lines() throws Exception {
+		assertEquals(repeat("\n", 512), make512Safe(repeat("\n", 512)));
+	}
+
+	@Test
+	public void make512Safe_2Lines_512chars() throws Exception {
+		assertEquals(repeat("a", 255) + "\n" + repeat("b", 255) + "\n",
+				make512Safe(repeat("a", 255) + "\n" + repeat("b", 255) + "\n"));
+	}
+
+	@Test
+	public void make512Safe_2Lines_513chars() throws Exception {
+		assertEquals(repeat("a", 256) + "\n" + repeat("b", 255) + "\n",
+				make512Safe(repeat("a", 256) + "\n" + repeat("b", 255) + "\n"));
+	}
+
+	@Test
+	public void make512Safe_oneLine512Chars() throws Exception {
+		assertEquals(repeat("a", 512) + "\n", make512Safe(repeat("a", 512)));
+	}
+
+	@Test
+	public void make512Safe_oneLine513Chars() throws Exception {
+		assertEquals(repeat("a", 510) + "\n aaa\n", make512Safe(repeat("a", 513)));
+	}
+
+	@Test
+	public void make512Safe_oneLine1025Chars() throws Exception {
+		assertEquals(repeat("a", 510) + "\n " + repeat("a", 510) + "\n aaaaa\n", make512Safe(repeat("a", 1025)));
+	}
+
+	@Test
+	public void make512Safe_2Lines_One513chars() throws Exception {
+		assertEquals(repeat("a", 255) + "\n" + repeat("b", 510) + "\n bbb\n",
+				make512Safe(repeat("a", 255) + "\n" + repeat("b", 513) + "\n"));
+	}
+
+	@Test
+	public void manifest_empty() throws Exception {
+		MergeableManifest2 manifest = newManifest("");
+
+		assertTrue(manifest.getEntries().isEmpty());
+		assertTrue(manifest.getMainAttributes().isEmpty());
+		assertFalse(manifest.isModified());
+	}
+
+	@Test
+	public void manifest_emptyLine() throws Exception {
+		MergeableManifest2 manifest = newManifest("\n");
+
+		assertTrue(manifest.getEntries().isEmpty());
+		assertTrue(manifest.getMainAttributes().isEmpty());
+		assertFalse(manifest.isModified());
+	}
+
+	@Test
+	public void manifest_emptyLine_windowsStyle() throws Exception {
+		MergeableManifest2 manifest = newManifest("\r\n");
+
+		assertTrue(manifest.getEntries().isEmpty());
+		assertTrue(manifest.getMainAttributes().isEmpty());
+		assertFalse(manifest.isModified());
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_LineWith513Chars() throws Exception {
+		newManifest(repeat("a", 513));
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_toLingALine() throws Exception {
+		newManifest("test: " + repeat("a", 512) + NL);
+	}
+
+	@Test
+	public void manifest_oneMainEntry() throws Exception {
+		MergeableManifest2 manifest = newManifest("test: ttt\n");
+
+		assertTrue(manifest.getEntries().isEmpty());
+		assertEquals(1, manifest.getMainAttributes().size());
+		assertEquals("ttt", getMainAttributeValue(manifest, "test"));
+	}
+
+	@Test
+	public void manifest_oneMainEntry_windowsStyle() throws Exception {
+		MergeableManifest2 manifest = newManifest("test: ttt\r\n");
+
+		assertEquals("ttt", getMainAttributeValue(manifest, "test"));
+	}
+
+	@Test
+	public void manifest_oneMainEntry_valueEndingWithBlank() throws Exception {
+		MergeableManifest2 manifest = newManifest("test: ttt \n");
+
+		assertEquals("ttt ", getMainAttributeValue(manifest, "test"));
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneMainEntry_blankAfterName() throws Exception {
+		newManifest("test : ttt\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneMainEntry_nameOnly() throws Exception {
+		newManifest("test\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneMainEntry_nameAndColon() throws Exception {
+		newManifest("test:\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneMainEntry_nameBlankAndColon() throws Exception {
+		newManifest("test :\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneMainEntry_noName() throws Exception {
+		newManifest(": ttt\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneMainEntry_noNameButBlank() throws Exception {
+		newManifest(" : ttt\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneMainEntry_nameLongerThen70Chars() throws Exception {
+		newManifest(repeat("a", 71) + ": ttt\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneMainEntry_nameWithInvalidCharacter() throws Exception {
+		newManifest("#: ttt\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneMainEntry_nameWithInvalidCharacter2() throws Exception {
+		newManifest(";: ttt\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneMainEntry_nameWithInvalidCharacter3() throws Exception {
+		newManifest("~: ttt\n");
+	}
+
+	@Test
+	public void manifest_oneMainEntry_withAllValidCharacterClasses() throws Exception {
+		MergeableManifest2 manifest = newManifest("abcxyz_ABCXYZ-123: 123\n");
+
+		assertEquals("123", getMainAttributeValue(manifest, "abcxyz_ABCXYZ-123"));
+	}
+
+	@Test
+	public void manifest_oneMainEntry_continuesOnSecondLine() throws Exception {
+		MergeableManifest2 manifest = newManifest("test: 123\n 456\n");
+
+		assertEquals("123456", getMainAttributeValue(manifest, "test"));
+	}
+
+	@Test
+	public void manifest_oneMainEntry_continuesOnSecondLine_windowsStyle() throws Exception {
+		MergeableManifest2 manifest = newManifest("test: 123\r\n 456\r\n");
+
+		assertEquals("123456", getMainAttributeValue(manifest, "test"));
+	}
+
+	@Test
+	public void manifest_oneMainEntry_continuesOnSecondAndThirdLine() throws Exception {
+		MergeableManifest2 manifest = newManifest("test: 123\n 456\n 789\n");
+
+		assertEquals("123456789", getMainAttributeValue(manifest, "test"));
+	}
+
+	@Test
+	public void manifest_duplicateMainEntry() throws Exception {
+		MergeableManifest2 manifest = newManifest("test: 1\ntest: 2\n");
+
+		assertEquals("2", getMainAttributeValue(manifest, "test"));
+	}
+
+	@Test
+	public void manifest_duplicateMainEntry_onTwoLines() throws Exception {
+		MergeableManifest2 manifest = newManifest("test: 1\n 2\ntest: 2\n 3\n");
+
+		assertEquals("23", getMainAttributeValue(manifest, "test"));
+	}
+
+	@Test
+	public void manifest_oneEntry_name() throws Exception {
+		MergeableManifest2 manifest = newManifest("\nName: test\n");
+
+		assertNull(getMainAttributeValue(manifest, "test"));
+		assertNotNull(manifest.getAttributes("test"));
+		assertEquals(0, manifest.getAttributes("test").size());
+	}
+
+	@Test
+	public void manifest_oneEntry_name_beforeMultipleNewlines() throws Exception {
+		MergeableManifest2 manifest = newManifest("\n\nName: test\n");
+
+		assertNull(getMainAttributeValue(manifest, "test"));
+		assertNotNull(manifest.getAttributes("test"));
+		assertEquals(0, manifest.getAttributes("test").size());
+	}
+
+	@Test
+	public void manifest_oneEntry_name_windowsStyle() throws Exception {
+		MergeableManifest2 manifest = newManifest("\r\nName: test\r\n");
+
+		assertNull(getMainAttributeValue(manifest, "test"));
+		assertNotNull(manifest.getAttributes("test"));
+		assertEquals(0, manifest.getAttributes("test").size());
+	}
+
+	@Test
+	public void manifest_oneEntry_nameAsLowerCase() throws Exception {
+		MergeableManifest2 manifest = newManifest("\nname: test\n");
+
+		assertNull(getMainAttributeValue(manifest, "test"));
+		assertNotNull(manifest.getAttributes("test"));
+		assertEquals(0, manifest.getAttributes("test").size());
+	}
+
+	@Test
+	public void manifest_oneEntry_name_onTwoLines() throws Exception {
+		MergeableManifest2 manifest = newManifest("\nName: test\n 123\n");
+
+		assertEquals(0, manifest.getAttributes("test123").size());
+	}
+
+	@Test
+	public void manifest_oneEntry_name_onThreeLines() throws Exception {
+		MergeableManifest2 manifest = newManifest("\nName: test\n 123\n asdf\n");
+
+		assertEquals(0, manifest.getAttributes("test123asdf").size());
+	}
+
+	@Test
+	public void manifest_oneEntry_withOneAttribute() throws Exception {
+		MergeableManifest2 manifest = newManifest("\nName: test\na1: v1\n");
+
+		assertNull(getMainAttributeValue(manifest, "test"));
+		assertNull(getMainAttributeValue(manifest, "a1"));
+		assertEquals(1, manifest.getAttributes("test").size());
+		assertEquals("v1", getAttributeValue(manifest, "test", "a1"));
+	}
+
+	@Test
+	public void manifest_oneEntry_withTwoAttributes() throws Exception {
+		MergeableManifest2 manifest = newManifest("\nName: test\na1: v1\na2: v2\n");
+
+		assertEquals(2, manifest.getAttributes("test").size());
+		assertEquals("v1", getAttributeValue(manifest, "test", "a1"));
+		assertEquals("v2", getAttributeValue(manifest, "test", "a2"));
+	}
+
+	@Test
+	public void manifest_oneEntry_withOneAttributeOnMultipleLines() throws Exception {
+		MergeableManifest2 manifest = newManifest("\nName: test\na1: v1\n 2\n 3\n");
+
+		assertEquals(1, manifest.getAttributes("test").size());
+		assertEquals("v123", getAttributeValue(manifest, "test", "a1"));
+	}
+
+	@Test
+	public void manifest_twoEntries() throws Exception {
+		MergeableManifest2 manifest = newManifest("\nName: test1\n\nName: test2\n");
+
+		assertNull(getMainAttributeValue(manifest, "test1"));
+		assertNull(getMainAttributeValue(manifest, "test2"));
+		assertNotNull(manifest.getAttributes("test1"));
+		assertNotNull(manifest.getAttributes("test2"));
+		assertEquals(0, manifest.getAttributes("test1").size());
+		assertEquals(0, manifest.getAttributes("test2").size());
+	}
+
+	@Test
+	public void manifest_twoEntries_withValues() throws Exception {
+		MergeableManifest2 manifest = newManifest(
+				"\nName: test1\ntest1_a1: v1a1\ntest1_a2: v1a2\n\nName: test2\ntest2_a1: v2a1\ntest2_a2: v2a2\n");
+
+		assertEquals(2, manifest.getAttributes("test1").size());
+		assertEquals("v1a1", getAttributeValue(manifest, "test1", "test1_a1"));
+		assertEquals("v1a2", getAttributeValue(manifest, "test1", "test1_a2"));
+		assertEquals(2, manifest.getAttributes("test2").size());
+		assertEquals("v2a1", getAttributeValue(manifest, "test2", "test2_a1"));
+		assertEquals("v2a2", getAttributeValue(manifest, "test2", "test2_a2"));
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneEntry_name_invalidFormat() throws Exception {
+		newManifest("\nName : test\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneEntry_name_invalidFormat2() throws Exception {
+		newManifest("\nN:1\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneEntry_name_invalidFormat3() throws Exception {
+		newManifest("\nZame: test\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneEntry_name_invalidFormat4() throws Exception {
+		newManifest("\nNZme: test\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneEntry_name_invalidFormat5() throws Exception {
+		newManifest("\nNaZe: test\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneEntry_name_invalidFormat6() throws Exception {
+		newManifest("\nNamZ: test\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneEntry_name_invalidFormat7() throws Exception {
+		newManifest("\nNameZ test\n");
+	}
+
+	@Test(expected = IOException.class)
+	public void manifest_oneEntry_name_invalidFormat8() throws Exception {
+		newManifest("\nName:Ztest\n");
+	}
+
+	@Test
+	public void write_empty() throws Exception {
+		assertEquals("", write(""));
+	}
+
+	@Test
+	public void write_versionOnly() throws Exception {
+		assertEquals("Manifest-Version: 1.0" + NL, write("Manifest-Version: 1.0" + NL));
+	}
+
+	@Test
+	public void write_signatureVersionOnly() throws Exception {
+		assertEquals("Signature-Version: 1.0" + NL, write("Signature-Version: 1.0" + NL));
+	}
+
+	@Test
+	public void write_oneMainEntry_missingVersion() throws Exception {
+		assertEquals("", write("test: 0\n"));
+	}
+
+	@Test
+	public void write_oneMainEntry_afterVersion() throws Exception {
+		assertEquals("Manifest-Version: 1.0" + NL + "test: 0" + NL,
+				write("Manifest-Version: 1.0" + NL + "test: 0" + NL));
+	}
+
+	@Test
+	public void write_oneMainEntry_beforeVersion() throws Exception {
+		assertEquals("Manifest-Version: 1.0" + NL + "test: 0" + NL,
+				write("test: 0" + NL + "Manifest-Version: 1.0" + NL));
+	}
+
+	@Test
+	public void write_twoMainEntries_afterVersion() throws Exception {
+		assertEquals("Manifest-Version: 1.0" + NL + "test0: 0" + NL + "test1: 1" + NL,
+				write("Manifest-Version: 1.0" + NL + "test0: 0" + NL + "test1: 1" + NL));
+	}
+
+	@Test
+	public void write_mainEntry_lineWith512chars() throws Exception {
+		assertEquals("Manifest-Version: 1.0" + NL + "test: " + repeat("a", 504) + NL,
+				write("Manifest-Version: 1.0" + NL + "test: " + repeat("a", 504) + NL));
+	}
+
+	@Test
+	public void write_mainEntry_lineWithMoreThen512chars() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.getMainAttributes().put("test", repeat("a", 512));
+
+		assertEquals("Manifest-Version: 1.0" + NL + "test: " + repeat("a", 504) + NL + " aaaaaaaa" + NL,
+				write(manifest));
+	}
+
+	@Test
+	public void write_oneEntry_onlyName() throws Exception {
+		assertEquals("Manifest-Version: 1.0" + NL + NL + "Name: test" + NL,
+				write("Manifest-Version: 1.0" + NL + NL + "Name: test" + NL));
+	}
+
+	@Test
+	public void write_oneName_oneEntry() throws Exception {
+		assertEquals("Manifest-Version: 1.0" + NL + NL + "Name: test" + NL + "t0: 0" + NL,
+				write("Manifest-Version: 1.0" + NL + NL + "Name: test" + NL + "t0: 0" + NL));
+	}
+
+	@Test
+	public void write_oneName_oneEntry_emptyValue() throws Exception {
+		assertEquals("Manifest-Version: 1.0" + NL + NL + "Name: test" + NL,
+				write("Manifest-Version: 1.0" + NL + NL + "Name: test" + NL + "t0: " + NL));
+	}
+
+	@Test
+	public void write_oneName_twoEntries() throws Exception {
+		assertEquals("Manifest-Version: 1.0" + NL + NL + "Name: test" + NL + "t0: 0" + NL + "t1: 1" + NL,
+				write("Manifest-Version: 1.0" + NL + NL + "Name: test" + NL + "t0: 0" + NL + "t1: 1" + NL));
+	}
+
+	@Test
+	public void write_twoNames_twoEntries() throws Exception {
+		assertEquals(
+				"Manifest-Version: 1.0" + NL + NL + "Name: test0" + NL + "t0: 0" + NL + "t1: 1" + NL + NL
+						+ "Name: test1" + NL + "t2: 2" + NL + "t3: 3" + NL,
+				write("Manifest-Version: 1.0" + NL + NL + "Name: test0" + NL + "t0: 0" + NL + "t1: 1" + NL + NL
+						+ "Name: test1" + NL + "t2: 2" + NL + "t3: 3" + NL));
+	}
+
+	@Test
+	public void write_oneName_oneEntry_lineWithMoreThen512chars() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + NL + "Name: test" + NL);
+		manifest.getEntries().get("test").put("t0", repeat("a", 512));
+
+		assertEquals(
+				"Manifest-Version: 1.0" + NL + NL + "Name: test" + NL + "t0: " + repeat("a", 506) + NL + " aaaaaa" + NL,
+				write(manifest));
+	}
+
+	@Test
+	public void clear_removesAllEntries() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + NL + "Name: test" + NL);
+		manifest.clear();
+
+		assertEquals("", write(manifest));
+	}
+
+	@Test
+	public void putValue_addOneMainEntry() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.getMainAttributes().put("test", "1");
+
+		assertTrue(manifest.isModified());
+		assertEquals("1", manifest.getMainAttributes().get("test"));
+	}
+
+	@Test
+	public void putValue_addOneMainEntry_twice() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.getMainAttributes().put("test", "1");
+		manifest.getMainAttributes().put("test", "2");
+
+		assertTrue(manifest.isModified());
+		assertEquals("2", manifest.getMainAttributes().get("test"));
+	}
+
+	@Test
+	public void putValue_addOneMainEntry_alreadyThere() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "test: 1" + NL);
+		manifest.getMainAttributes().put("test", "1");
+
+		assertFalse(manifest.isModified());
+		assertEquals("1", manifest.getMainAttributes().get("test"));
+	}
+
+	@Test
+	public void cloneMethod() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + NL + "Name: test" + NL);
+		manifest.getEntries().get("test").put("t0", repeat("a", 512));
+		MergeableManifest2 copy = manifest.clone();
+
+		assertEquals(
+				"Manifest-Version: 1.0" + NL + NL + "Name: test" + NL + "t0: " + repeat("a", 506) + NL + " aaaaaa" + NL,
+				write(copy));
+	}
+
+	@Test
+	public void addRequiredBundles_missingAttribute_emptyValues() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addRequiredBundles(Collections.emptySet());
+
+		assertFalse(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_missingAttribute_oneValue() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addRequiredBundles(Collections.singleton("a"));
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: a" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_missingAttribute_oneEmptyValue() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addRequiredBundles(Collections.singleton(""));
+
+		assertFalse(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_missingAttribute_twoValues() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addRequiredBundles(new HashSet<>(java.util.Arrays.asList("a", "b")));
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: a," + NL + " b" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_oneValueBefore_addingOneValue() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Require-Bundle: a" + NL);
+		manifest.addRequiredBundles(Collections.singleton("b"));
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: a," + NL + " b" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_oneValueBefore_addingExistingValue() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Require-Bundle: a" + NL);
+		manifest.addRequiredBundles(Collections.singleton("a"));
+
+		assertFalse(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: a" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_missingAttribute_oneValue_withVersion() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addRequiredBundles(Collections.singleton("a;1.0"));
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: a;1.0" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_oneValueBefore_addingExistingValue_withVersion() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Require-Bundle: a" + NL);
+		manifest.addRequiredBundles(Collections.singleton("a;1.0"));
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: a;1.0" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_oneValueBefore_addingExistingValueVersion_withoutVersion() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Require-Bundle: a;1.0" + NL);
+		manifest.addRequiredBundles(Collections.singleton("a"));
+
+		assertFalse(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: a;1.0" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_oneValueBefore_addingExistingValueVersion_withSameVersion() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Require-Bundle: a;1.0" + NL);
+		manifest.addRequiredBundles(Collections.singleton("a;1.0"));
+
+		assertFalse(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: a;1.0" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_oneValueBefore_addingExistingValueVersion_withDifferentVersion() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Require-Bundle: a;1.0" + NL);
+		manifest.addRequiredBundles(Collections.singleton("a;1.1"));
+
+		assertFalse(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: a;1.0" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_threeValuesBefore_addingMoreVersions() throws Exception {
+		MergeableManifest2 manifest = newManifest(
+				"Manifest-Version: 1.0" + NL + "Require-Bundle: a;1.0," + NL + " b," + NL + " c" + NL);
+		manifest.addRequiredBundles(new HashSet<>(java.util.Arrays.asList("b", "d;2.1", "e")));
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: a;1.0," + NL + " b," + NL + " c," + NL + " d;2.1,"
+				+ NL + " e" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_quoting() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addRequiredBundles(Collections.singleton("\"a,b\""));
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: \"a,b\"" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_quoting_quotedEntryAlreadyPresent() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Require-Bundle: \"a,b;1.0\"" + NL);
+		manifest.addRequiredBundles(Collections.singleton("c"));
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: \"a,b;1.0\"," + NL + " c" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_quoting_unclosed() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addRequiredBundles(Collections.singleton("\"a,b"));
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: \"a," + NL + " b" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_quoting_version() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addRequiredBundles(Collections.singleton("org.antlr.runtime;bundle-version=\"[3.2.0,3.2.1)\""));
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: org.antlr.runtime;bundle-version=\"[3.2.0,3.2.1)\""
+				+ NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_quoting_version_toExisting() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL
+				+ "Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version=\"[2.13.0,2.14.0)\"" + NL);
+		manifest.addRequiredBundles(Collections.singleton("org.antlr.runtime;bundle-version=\"[3.2.0,3.2.1)\""));
+
+		assertEquals("Manifest-Version: 1.0" + NL
+				+ "Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version=\"[2.13.0,2.14.0)\"," + NL
+				+ " org.antlr.runtime;bundle-version=\"[3.2.0,3.2.1)\"" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_quoting_version_toExistingWithPreivous() throws Exception {
+		MergeableManifest2 manifest = newManifest(
+				"Manifest-Version: 1.0" + NL + "Require-Bundle: org.eclipse.xtext.util," + NL
+						+ " org.eclipse.xtext.xbase.lib;bundle-version=\"[2.13.0,2.14.0)\"" + NL);
+		manifest.addRequiredBundles(Collections.singleton("org.antlr.runtime;bundle-version=\"[3.2.0,3.2.1)\""));
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: org.eclipse.xtext.util," + NL
+				+ " org.eclipse.xtext.xbase.lib;bundle-version=\"[2.13.0,2.14.0)\"," + NL
+				+ " org.antlr.runtime;bundle-version=\"[3.2.0,3.2.1)\"" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_bundleSymbolicNamePresent() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Bundle-SymbolicName: self" + NL);
+		manifest.addRequiredBundles(Collections.singleton("a"));
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Bundle-SymbolicName: self" + NL + "Require-Bundle: a" + NL,
+				write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_bundleSymbolicNamePresent_addSelf() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Bundle-SymbolicName: self" + NL);
+		manifest.addRequiredBundles(Collections.singleton("self"));
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Bundle-SymbolicName: self" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_bundleSymbolicNameWithVersionPresent_addSelf() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Bundle-SymbolicName: self;1.1" + NL);
+		manifest.addRequiredBundles(Collections.singleton("self"));
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Bundle-SymbolicName: self;1.1" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_projectNamePresent_addSelf() throws Exception {
+		MergeableManifest2 manifest = new MergeableManifest2(new StringInputStream("Manifest-Version: 1.0" + NL),
+				"self");
+		manifest.addRequiredBundles(Collections.singleton("self"));
+
+		assertEquals("Manifest-Version: 1.0" + NL, write(manifest));
+	}
+
+	@Test
+	public void addRequiredBundles_projectNamePresent_addOther() throws Exception {
+		MergeableManifest2 manifest = new MergeableManifest2(new StringInputStream("Manifest-Version: 1.0" + NL),
+				"self");
+		manifest.addRequiredBundles(Collections.singleton("other"));
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: other" + NL, write(manifest));
+	}
+
+	@Test
+	public void addExportedPackages_oneEntry() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addExportedPackages("a");
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Export-Package: a" + NL, write(manifest));
+	}
+
+	@Test
+	public void addExportedPackages_oneEntry_alreadyExisting() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Export-Package: a" + NL);
+		manifest.addExportedPackages("a");
+
+		assertFalse(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Export-Package: a" + NL, write(manifest));
+	}
+
+	@Test
+	public void addExportedPackages_oneEntry_usingSet() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addExportedPackages(Collections.singleton("a"));
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Export-Package: a" + NL, write(manifest));
+	}
+
+	@Test
+	public void addExportedPackages_twoEntries() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addExportedPackages("a", "b");
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Export-Package: a," + NL + " b" + NL, write(manifest));
+	}
+
+	@Test
+	public void addExportedPackages_threeValuesBefore_addingMoreVersions() throws Exception {
+		MergeableManifest2 manifest = newManifest(
+				"Manifest-Version: 1.0" + NL + "Export-Package: a;1.0," + NL + " b," + NL + " c" + NL);
+		manifest.addExportedPackages("b", "d;2.1", "e");
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Export-Package: a;1.0," + NL + " b," + NL + " c," + NL + " d;2.1,"
+				+ NL + " e" + NL, write(manifest));
+	}
+
+	@Test
+	public void addImportedPackages_oneEntry() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addImportedPackages("a");
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Import-Package: a" + NL, write(manifest));
+	}
+
+	@Test
+	public void addImportedPackages_oneEntry_alreadyExisting() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Import-Package: a" + NL);
+		manifest.addImportedPackages("a");
+
+		assertFalse(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Import-Package: a" + NL, write(manifest));
+	}
+
+	@Test
+	public void addImportedPackages_oneEntry_usingSet() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addImportedPackages(Collections.singleton("a"));
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Import-Package: a" + NL, write(manifest));
+	}
+
+	@Test
+	public void addImportedPackages_twoEntries() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.addImportedPackages("a", "b");
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Import-Package: a," + NL + " b" + NL, write(manifest));
+	}
+
+	@Test
+	public void addImportedPackages_threeValuesBefore_addingMoreVersions() throws Exception {
+		MergeableManifest2 manifest = newManifest(
+				"Manifest-Version: 1.0" + NL + "Import-Package: a;1.0," + NL + " b," + NL + " c" + NL);
+		manifest.addImportedPackages("b", "d;2.1", "e");
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Import-Package: a;1.0," + NL + " b," + NL + " c," + NL + " d;2.1,"
+				+ NL + " e" + NL, write(manifest));
+	}
+
+	@Test
+	public void stableOrderOfMainAttributes_1() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Require-Bundle: a" + NL
+				+ "Export-Package: b" + NL + "Import-Package: c" + NL);
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Require-Bundle: a" + NL + "Export-Package: b" + NL
+				+ "Import-Package: c" + NL, write(manifest));
+	}
+
+	@Test
+	public void stableOrderOfMainAttributes_2() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Import-Package: c" + NL
+				+ "Require-Bundle: a" + NL + "Export-Package: b" + NL);
+
+		assertEquals("Manifest-Version: 1.0" + NL + "Import-Package: c" + NL + "Require-Bundle: a" + NL
+				+ "Export-Package: b" + NL, write(manifest));
+	}
+
+	@Test
+	public void stableOrderOfAttributes_1() throws Exception {
+		MergeableManifest2 manifest = newManifest(NL + "Name: a" + NL + "a0: 0" + NL + "a1: 1" + NL + "a2: 2" + NL);
+
+		assertEquals(NL + "Name: a" + NL + "a0: 0" + NL + "a1: 1" + NL + "a2: 2" + NL, write(manifest));
+	}
+
+	@Test
+	public void stableOrderOfAttributes_2() throws Exception {
+		MergeableManifest2 manifest = newManifest(NL + "Name: a" + NL + "a2: 2" + NL + "a1: 1" + NL + "a0: 0" + NL);
+
+		assertEquals(NL + "Name: a" + NL + "a2: 2" + NL + "a1: 1" + NL + "a0: 0" + NL, write(manifest));
+	}
+
+	@Test
+	public void stableOrderOfAttributeNames_1() throws Exception {
+		MergeableManifest2 manifest = newManifest(NL + "Name: a" + NL + "a0: 0" + NL + NL + "Name: b" + NL + "b0: 0"
+				+ NL + NL + "Name: c" + NL + "c0: 0" + NL);
+
+		assertEquals(NL + "Name: a" + NL + "a0: 0" + NL + NL + "Name: b" + NL + "b0: 0" + NL + NL + "Name: c" + NL
+				+ "c0: 0" + NL, write(manifest));
+	}
+
+	@Test
+	public void stableOrderOfAttributeNames_2() throws Exception {
+		MergeableManifest2 manifest = newManifest(NL + "Name: c" + NL + "c0: 0" + NL + NL + "Name: b" + NL + "b0: 0"
+				+ NL + NL + "Name: a" + NL + "a0: 0" + NL);
+
+		assertEquals(NL + "Name: c" + NL + "c0: 0" + NL + NL + "Name: b" + NL + "b0: 0" + NL + NL + "Name: a" + NL
+				+ "a0: 0" + NL, write(manifest));
+	}
+
+	@Test
+	public void setBree() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.setBREE("test");
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Bundle-RequiredExecutionEnvironment: test" + NL, write(manifest));
+		assertEquals("test", manifest.getBREE());
+	}
+
+	@Test
+	public void setBree_replaceOld() throws Exception {
+		MergeableManifest2 manifest = newManifest(
+				"Manifest-Version: 1.0" + NL + "Bundle-RequiredExecutionEnvironment: test" + NL);
+		manifest.setBREE("new");
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Bundle-RequiredExecutionEnvironment: new" + NL, write(manifest));
+		assertEquals("new", manifest.getBREE());
+	}
+
+	@Test
+	public void setBree_existingValue() throws Exception {
+		MergeableManifest2 manifest = newManifest(
+				"Manifest-Version: 1.0" + NL + "Bundle-RequiredExecutionEnvironment: test" + NL);
+		manifest.setBREE("test");
+
+		assertFalse(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Bundle-RequiredExecutionEnvironment: test" + NL, write(manifest));
+		assertEquals("test", manifest.getBREE());
+	}
+
+	@Test
+	public void setBundleActivator() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL);
+		manifest.setBundleActivator("test");
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Bundle-Activator: test" + NL, write(manifest));
+		assertEquals("test", manifest.getBundleActivator());
+	}
+
+	@Test
+	public void setBundleActivator_replaceOld() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Bundle-Activator: test" + NL);
+		manifest.setBundleActivator("new");
+
+		assertTrue(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Bundle-Activator: new" + NL, write(manifest));
+		assertEquals("new", manifest.getBundleActivator());
+	}
+
+	@Test
+	public void setBundleActivator_existingValue() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Bundle-Activator: test" + NL);
+		manifest.setBundleActivator("test");
+
+		assertFalse(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0" + NL + "Bundle-Activator: test" + NL, write(manifest));
+		assertEquals("test", manifest.getBundleActivator());
+	}
+
+	@Test
+	public void setLineDelimiter() throws Exception {
+		MergeableManifest2 manifest = newManifest("Manifest-Version: 1.0" + NL + "Bundle-Activator: test" + NL);
+		manifest.setLineDelimiter("###");
+
+		assertFalse(manifest.isModified());
+		assertEquals("Manifest-Version: 1.0###Bundle-Activator: test###", write(manifest));
+	}
+
+	@Test
+	public void equals_true() throws Exception {
+		MergeableManifest2 manifest0 = newManifest("Manifest-Version: 1.0" + NL + "Bundle-Activator: test" + NL);
+		MergeableManifest2 manifest1 = newManifest("Manifest-Version: 1.0" + NL + "Bundle-Activator: test" + NL);
+
+		assertTrue(manifest0.equals(manifest1));
+	}
+
+	@Test
+	public void equals_false_becauseOfMainEntry() throws Exception {
+		MergeableManifest2 manifest0 = newManifest("Manifest-Version: 1.0" + NL + "Bundle-Activator: test" + NL);
+		MergeableManifest2 manifest1 = newManifest("Manifest-Version: 1.0" + NL + "Bundle-Activator: other" + NL);
+
+		assertFalse(manifest0.equals(manifest1));
+	}
+
+	@Test
+	public void equals_false_becauseOfEntry() throws Exception {
+		MergeableManifest2 manifest0 = newManifest(NL + "Name: a" + NL + "a0: 0" + NL);
+		MergeableManifest2 manifest1 = newManifest(NL + "Name: a" + NL + "a0: other" + NL);
+
+		assertFalse(manifest0.equals(manifest1));
+	}
+
+	@Test
+	public void hashCode_same() throws Exception {
+		MergeableManifest2 manifest0 = newManifest("Manifest-Version: 1.0" + NL + "Bundle-Activator: test" + NL);
+		MergeableManifest2 manifest1 = newManifest("Manifest-Version: 1.0" + NL + "Bundle-Activator: test" + NL);
+
+		assertEquals(manifest0.hashCode(), manifest1.hashCode());
+	}
+
+	@Test
+	public void hachCode_differ_becauseOfMainEntry() throws Exception {
+		MergeableManifest2 manifest0 = newManifest("Manifest-Version: 1.0" + NL + "Bundle-Activator: test" + NL);
+		MergeableManifest2 manifest1 = newManifest("Manifest-Version: 1.0" + NL + "Bundle-Activator: other" + NL);
+
+		assertNotEquals(manifest0.hashCode(), manifest1.hashCode());
+	}
+
+	@Test
+	public void hachCode_differ_becauseOfEntry() throws Exception {
+		MergeableManifest2 manifest0 = newManifest(NL + "Name: a" + NL + "a0: 0" + NL);
+		MergeableManifest2 manifest1 = newManifest(NL + "Name: a" + NL + "a0: other" + NL);
+
+		assertNotEquals(manifest0.hashCode(), manifest1.hashCode());
+	}
+
+	private String make512Safe(String input) {
+		return make512Safe(input, "\n");
+	}
+
+	private String make512Safe(String input, String newline) {
+		return MergeableManifest2.make512Safe(new StringBuffer(input), newline);
+	}
+
+	private String write(String input) throws IOException {
+		return write(newManifest(input));
+	}
+
+	private String write(MergeableManifest2 manifest) throws IOException {
+		ByteArrayOutputStream stream = new ByteArrayOutputStream();
+		manifest.write(stream);
+		return stream.toString();
+	}
+
+	private MergeableManifest2 newManifest(String content) throws IOException {
+		return new MergeableManifest2(new StringInputStream(content));
+	}
+
+	private Object getMainAttributeValue(MergeableManifest2 manifest, String attributeName) {
+		return manifest.getMainAttributes().get(attributeName);
+	}
+
+	private Object getAttributeValue(MergeableManifest2 manifest, String attributeName, String entryName) {
+		return manifest.getAttributes(attributeName).get(entryName);
+	}
+
+}

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/MergeableManifest.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/MergeableManifest.java
@@ -33,7 +33,10 @@ import com.google.common.collect.Lists;
  * @author Sven Efftinge - Initial contribution and API
  * @author Jan Koehnlein - merging of parameterized entries
  * @since 2.2 moved to org.eclipse.xtext.util
+ * @deprecated Uses reflection which will not work well with future java
+ * versions. Use {@link MergeableManifest2} instead.
  */
+@Deprecated
 public class MergeableManifest extends Manifest {
 
 	public static final Attributes.Name BUNDLE_NAME = new Attributes.Name("Bundle-Name");
@@ -117,8 +120,8 @@ public class MergeableManifest extends Manifest {
 		}
 
 		/*
-		 * Copied from base class, but replaced call to make72Safe(buffer) with make512Safe(buffer)
-         * and does not write empty values
+		 * Copied from base class, but replaced call to make72Safe(buffer) with
+		 * make512Safe(buffer) and does not write empty values
 		 */
 		@SuppressWarnings("deprecation")
 		public void myWriteMain(DataOutputStream out) throws IOException {
@@ -159,8 +162,8 @@ public class MergeableManifest extends Manifest {
 		}
 
 		/*
-		 * Copied from base class, but omitted call to make72Safe(buffer)
-		 * and does not write empty values
+		 * Copied from base class, but omitted call to make72Safe(buffer) and
+		 * does not write empty values
 		 */
 		@SuppressWarnings("deprecation")
 		public void myWrite(DataOutputStream out) throws IOException {
@@ -214,7 +217,8 @@ public class MergeableManifest extends Manifest {
 	 * adds the qualified names to the require-bundle attribute, if not already
 	 * present.
 	 *
-	 * @param bundles - passing parameterized bundled (e.g. versions, etc.) is not supported
+	 * @param bundles - passing parameterized bundled (e.g. versions, etc.) is
+	 * not supported
 	 */
 	public void addRequiredBundles(Set<String> bundles) {
 		// TODO manage transitive dependencies
@@ -227,7 +231,8 @@ public class MergeableManifest extends Manifest {
 				bundleName = bundleName.substring(0, idx);
 			}
 		}
-		if (bundleName != null && bundles.contains(bundleName) || projectName != null && bundles.contains(projectName)) {
+		if (bundleName != null && bundles.contains(bundleName)
+				|| projectName != null && bundles.contains(projectName)) {
 			bundlesToMerge = new LinkedHashSet<String>(bundles);
 			bundlesToMerge.remove(bundleName);
 			bundlesToMerge.remove(projectName);
@@ -247,13 +252,13 @@ public class MergeableManifest extends Manifest {
 	public String getBREE() {
 		return (String) getMainAttributes().get(BUNDLE_REQUIRED_EXECUTION_ENV);
 	}
-	
+
 	/**
 	 * @since 2.9
 	 */
 	public void setBREE(String bree) {
 		String oldValue = getBREE();
-		if(Objects.equal(oldValue, bree)) {
+		if (Objects.equal(oldValue, bree)) {
 			return;
 		}
 		getMainAttributes().put(BUNDLE_REQUIRED_EXECUTION_ENV, bree);
@@ -272,21 +277,21 @@ public class MergeableManifest extends Manifest {
 	 */
 	public void setBundleActivator(String activator) {
 		String oldValue = getBundleActivator();
-		if(Objects.equal(oldValue, activator)) {
+		if (Objects.equal(oldValue, activator)) {
 			return;
 		}
 		getMainAttributes().put(BUNDLE_ACTIVATOR, activator);
 		this.modified = true;
 	}
-	
+
 	/**
 	 * @since 2.11
 	 */
-	public void setLineDelimiter (String delimiter) {
+	public void setLineDelimiter(String delimiter) {
 		this.lineDelimiter = delimiter;
-		
+
 	}
-	
+
 	public boolean isModified() {
 		return modified;
 	}
@@ -299,7 +304,7 @@ public class MergeableManifest extends Manifest {
 	public void write(OutputStream out) throws IOException {
 		DataOutputStream dos = new DataOutputStream(out);
 		// Write out the main attributes for the manifest
-		((OrderAwareAttributes) getMainAttributes()).myWriteMain(dos);
+		getMainAttributes().myWriteMain(dos);
 		// Now write out the pre-entry attributes
 		Iterator<Map.Entry<String, Attributes>> it = getEntries().entrySet().iterator();
 		while (it.hasNext()) {
@@ -331,7 +336,7 @@ public class MergeableManifest extends Manifest {
 		this.modified = modified.get();
 		getMainAttributes().put(EXPORT_PACKAGE, result);
 	}
-	
+
 	/**
 	 * adds the qualified names to the export-package attribute, if not already
 	 * present.
@@ -351,7 +356,7 @@ public class MergeableManifest extends Manifest {
 		this.modified = modified.get();
 		getMainAttributes().put(IMPORT_PACKAGE, result);
 	}
-	
+
 	/**
 	 * @since 2.0
 	 */
@@ -360,16 +365,16 @@ public class MergeableManifest extends Manifest {
 		boolean inQuote = false;
 		for (int i = 0; i < string.length(); i++)
 			switch (string.charAt(i)) {
-				case ',':
-					if (inQuote)
-						result.get(result.size() - 1).append(string.charAt(i));
-					else
-						result.add(new StringBuilder());
-					break;
-				case '"':
-					inQuote = !inQuote;
-				default:
+			case ',':
+				if (inQuote)
 					result.get(result.size() - 1).append(string.charAt(i));
+				else
+					result.add(new StringBuilder());
+				break;
+			case '"':
+				inQuote = !inQuote;
+			default:
+				result.get(result.size() - 1).append(string.charAt(i));
 			}
 		String[] resultArray = new String[result.size()];
 		for (int i = 0; i < result.size(); i++)
@@ -378,17 +383,21 @@ public class MergeableManifest extends Manifest {
 	}
 
 	/**
-	 * @deprecated Use {@link #mergeIntoCommaSeparatedList(String, Set, Wrapper, String)} instead.
+	 * @deprecated Use
+	 * {@link #mergeIntoCommaSeparatedList(String, Set, Wrapper, String)}
+	 * instead.
 	 */
 	@Deprecated
-	public static String mergeIntoCommaSeparatedList(String currentString, Set<String> toMergeIn, Wrapper<Boolean> modified) {
+	public static String mergeIntoCommaSeparatedList(String currentString, Set<String> toMergeIn,
+			Wrapper<Boolean> modified) {
 		return mergeIntoCommaSeparatedList(currentString, toMergeIn, modified, LINEBREAK);
 	}
-	
+
 	/**
 	 * @since 2.11
 	 */
-	public static String mergeIntoCommaSeparatedList(String currentString, Set<String> toMergeIn, Wrapper<Boolean> modified, String lineDelimiter) {
+	public static String mergeIntoCommaSeparatedList(String currentString, Set<String> toMergeIn,
+			Wrapper<Boolean> modified, String lineDelimiter) {
 		String string = currentString == null ? "" : currentString;
 		String[] split = splitQuoteAware(string);
 		Map<String, String> name2parameters = new LinkedHashMap<String, String>();
@@ -404,7 +413,7 @@ public class MergeableManifest extends Manifest {
 			if (!value.trim().equals("")) {
 				Pair<String, String> nameParameter = getSplitEntry(value.trim());
 				String existingParameter = name2parameters.get(nameParameter.getFirst());
-				if(existingParameter != null) {
+				if (existingParameter != null) {
 					continue;
 				}
 				boolean newModified = modified.get();
@@ -418,30 +427,40 @@ public class MergeableManifest extends Manifest {
 		while (iterator.hasNext()) {
 			Entry<String, String> entry = iterator.next();
 			buff.append(entry.getKey());
-			if(entry.getValue() != null) {
+			if (entry.getValue() != null) {
 				buff.append(";").append(entry.getValue());
 			}
 			if (iterator.hasNext())
-				buff.append(","+lineDelimiter+" ");
+				buff.append("," + lineDelimiter + " ");
 		}
 		String result = buff.toString();
 		return result;
 	}
-	
+
 	/**
 	 * @since 2.3
 	 */
-	protected static Pair<String,String> getSplitEntry(String entry) {
+	protected static Pair<String, String> getSplitEntry(String entry) {
 		int semicolon = entry.indexOf(';');
 		String name;
 		String parameter;
-		if(semicolon == -1) {
-			name=entry;
+		if (semicolon == -1) {
+			name = entry;
 			parameter = null;
-		} else { 
+		} else {
 			name = entry.substring(0, semicolon);
 			parameter = entry.substring(semicolon + 1);
 		}
 		return Tuples.create(name, parameter);
 	}
+
+	public void addImportedPackages(String... packages) {
+		addImportedPackages(newHashSet(packages));
+	}
+
+	@Override
+	public OrderAwareAttributes getMainAttributes() {
+		return (OrderAwareAttributes) super.getMainAttributes();
+	}
+
 }

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/MergeableManifest2.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/MergeableManifest2.java
@@ -1,0 +1,672 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.util;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Functionality to read and write Manifest files. Guarantees that modifying
+ * does not destroy the order of the elements to ensure minimal diffs for
+ * load/save cycles.
+ * 
+ * Re-implementation from {@link MergeableManifest} but without reflection.
+ * Reflection causes warnings that it might get be removed in future versions.
+ * Hence we implement the functionality with all the inherited one by ourself.
+ * 
+ * @author Arne Deutsch - Initial contribution and API
+ */
+public class MergeableManifest2 implements Cloneable {
+
+	public static final String MANIFEST_VERSION = "Manifest-Version";
+	public static final String SIGNATURE_VERSION = "Signature-Version";
+	public static final String REQUIRE_BUNDLE = "Require-Bundle";
+	public static final String BUNDLE_SYMBOLIC_NAME = "Bundle-SymbolicName";
+	public static final String EXPORT_PACKAGE = "Export-Package";
+	public static final String IMPORT_PACKAGE = "Import-Package";
+	public static final String BUNDLE_REQUIREDEXECUTIONENVIRONMENT = "Bundle-RequiredExecutionEnvironment";
+	public static final String BUNDLE_ACTIVATOR = "Bundle-Activator";
+
+	private String name;
+	private String version;
+	private String bree;
+	private String bundleActivator;
+	private String newline = System.lineSeparator();
+	private Attributes mainAttributes = new Attributes();
+	private Map<String, Attributes> entries = new LinkedHashMap<>();
+	private boolean modified;
+
+	/**
+	 * Create a new manifest from the given stream and with the given name. As
+	 * the stream is created by the caller the caller is also responsible for
+	 * closing it.
+	 * 
+	 * @param stream The stream to read the manifest content from.
+	 * @param name The name of the manifest, written to "Bundle-SymbolicName".
+	 */
+	public MergeableManifest2(InputStream stream, String name) throws IOException {
+		this.name = name;
+		read(stream);
+		this.modified = false;
+	}
+
+	/**
+	 * Create a new manifest from the given stream. As the stream is created by
+	 * the caller the caller is also responsible for closing it.
+	 * 
+	 * @param stream The stream to read the manifest content from.
+	 */
+	public MergeableManifest2(InputStream stream) throws IOException {
+		read(stream);
+		this.modified = false;
+	}
+
+	/**
+	 * Create a copy from the given one.
+	 * 
+	 * @param toCopy The original manifest to copy.
+	 */
+	public MergeableManifest2(MergeableManifest2 toCopy) {
+		this.name = toCopy.name;
+		this.version = toCopy.version;
+		this.newline = toCopy.newline;
+		this.mainAttributes.putAll(toCopy.mainAttributes);
+		this.entries.putAll(toCopy.entries);
+		this.modified = false;
+	}
+
+	private void read(InputStream stream) throws IOException {
+		read(new BufferedReader(new InputStreamReader(stream)).lines().collect(Collectors.toList()));
+	}
+
+	private void read(List<String> lines) throws IOException {
+		int lineIndex = readHeader(lines, 0);
+		readEntries(lines, lineIndex);
+	}
+
+	private int readHeader(List<String> lines, int startIndex) throws IOException {
+		int lineIndex = startIndex;
+		while (lineIndex < lines.size()) {
+			String line = lines.get(lineIndex);
+			lineIndex++;
+			while (lineIndex < lines.size() && lines.get(lineIndex).startsWith(" ")) {
+				line += lines.get(lineIndex).substring(1);
+				lineIndex++;
+			}
+			if (line.isEmpty()) {
+				return lineIndex; // end of header
+			} else if (line.length() > 512) {
+				throw new IOException("Line is to long '" + line + "'");
+			} else if (line.contains(": ")) {
+				String[] split = line.split(": ", 2);
+				String name = split[0];
+				if (!isValidName(name)) {
+					throw new IOException("Missing name of value");
+				}
+				String value = split[1];
+				if (name.equals(MANIFEST_VERSION)) {
+					version = value;
+				} else if (version == null && name.equals(SIGNATURE_VERSION)) {
+					version = value;
+				} else if (name.equals(BUNDLE_SYMBOLIC_NAME)) {
+					this.name = bundleName(value);
+				} else if (name.equals(BUNDLE_REQUIREDEXECUTIONENVIRONMENT)) {
+					bree = value;
+				} else if (name.equals(BUNDLE_ACTIVATOR)) {
+					bundleActivator = value;
+				}
+				mainAttributes.put(name, value);
+			} else {
+				throw new IOException("Missing ': '");
+			}
+		}
+		return lineIndex;
+	}
+
+	private void readEntries(List<String> lines, int startIndex) throws IOException {
+		int lineIndex = startIndex;
+		Attributes attributes = null;
+		while (lineIndex < lines.size()) {
+			String line = lines.get(lineIndex);
+			lineIndex++;
+			while (lineIndex < lines.size() && lines.get(lineIndex).startsWith(" ")) {
+				line += lines.get(lineIndex).substring(1);
+				lineIndex++;
+			}
+			if (line.toLowerCase().startsWith("name: ")) {
+				String name = line.substring("name: ".length());
+				attributes = entries.get(name);
+				if (attributes == null) {
+					attributes = new Attributes();
+					entries.put(name, attributes);
+				}
+			} else if (line.contains(": ")) {
+				String[] split = line.split(": ", 2);
+				String name = split[0];
+				if (!isValidName(name)) {
+					throw new IOException("Missing name of value");
+				}
+				String value = split[1];
+				if (attributes == null)
+					throw new IOException("Missing name of entry");
+				attributes.put(name, value);
+			} else if (line.isEmpty()) {
+				// nothing to do
+			} else {
+				throw new IOException("Missing ': '");
+			}
+		}
+	}
+
+	private boolean isValidName(String name) {
+		if (name.isEmpty() || name.length() > 70)
+			return false;
+		for (int n = 0; n < name.length(); n++) {
+			char c = name.charAt(n);
+			if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_')
+				continue;
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * @return the attributes read from the header. Does not include the entries
+	 * that are started with "Name: XXX" line.
+	 */
+	public Attributes getMainAttributes() {
+		return mainAttributes;
+	}
+
+	/**
+	 * @return the attribute section that has been started with the name from
+	 * the "Name: XXX" line.
+	 */
+	public Attributes getAttributes(String name) {
+		return entries.get(name);
+	}
+
+	/**
+	 * @return all entries started with "Name: XXX" line but not the main
+	 * attributes.
+	 */
+	public Map<String, Attributes> getEntries() {
+		return entries;
+	}
+
+	/**
+	 * @return true in case any modification has been applied to the manifest
+	 * since it was read.
+	 */
+	public boolean isModified() {
+		return modified;
+	}
+
+	/**
+	 * Remove all main entries and all section entries.
+	 */
+	public void clear() {
+		mainAttributes.clear();
+		entries.clear();
+	}
+
+	/**
+	 * Add the set with given bundles to the "Require-Bundle" main attribute.
+	 * 
+	 * @param requiredBundles The set with all bundles to add.
+	 */
+	public void addRequiredBundles(Set<String> requiredBundles) {
+		addRequiredBundles(requiredBundles.toArray(new String[requiredBundles.size()]));
+	}
+
+	/**
+	 * Add the list with given bundles to the "Require-Bundle" main attribute.
+	 * 
+	 * @param requiredBundles The list of all bundles to add.
+	 */
+	public void addRequiredBundles(String... requiredBundles) {
+		String oldBundles = mainAttributes.get(REQUIRE_BUNDLE);
+		if (oldBundles == null)
+			oldBundles = "";
+		String result = oldBundles;
+		for (String bundle : requiredBundles) {
+			if (name != null && name.equals(bundleName(bundle)))
+				continue;
+			result = mergeIntoCommaSeparatedList(bundle, result);
+		}
+		modified |= !oldBundles.equals(result);
+		if (!oldBundles.equals(result))
+			mainAttributes.put(REQUIRE_BUNDLE, result);
+	}
+
+	/**
+	 * Add the set with given bundles to the "Import-Package" main attribute.
+	 * 
+	 * @param importedPackages The set of all packages to add.
+	 */
+	public void addImportedPackages(Set<String> importedPackages) {
+		addImportedPackages(importedPackages.toArray(new String[importedPackages.size()]));
+	}
+
+	/**
+	 * Add the list with given bundles to the "Import-Package" main attribute.
+	 * 
+	 * @param importedPackages The list of all packages to add.
+	 */
+	public void addImportedPackages(String... importedPackages) {
+		String oldBundles = mainAttributes.get(IMPORT_PACKAGE);
+		if (oldBundles == null)
+			oldBundles = "";
+		String result = oldBundles;
+		for (String bundle : importedPackages) {
+			result = mergeIntoCommaSeparatedList(bundle, result);
+		}
+		modified |= !oldBundles.equals(result);
+		if (!oldBundles.equals(result))
+			mainAttributes.put(IMPORT_PACKAGE, result);
+	}
+
+	/**
+	 * Add the set with given bundles to the "Export-Package" main attribute.
+	 * 
+	 * @param exportedPackages The set of all packages to add.
+	 */
+	public void addExportedPackages(Set<String> exportedPackages) {
+		addExportedPackages(exportedPackages.toArray(new String[exportedPackages.size()]));
+	}
+
+	/**
+	 * Add the list with given bundles to the "Export-Package" main attribute.
+	 * 
+	 * @param exportedPackages The list of all packages to add.
+	 */
+	public void addExportedPackages(String... exportedPackages) {
+		String oldBundles = mainAttributes.get(EXPORT_PACKAGE);
+		if (oldBundles == null)
+			oldBundles = "";
+		String result = oldBundles;
+		for (String bundle : exportedPackages) {
+			result = mergeIntoCommaSeparatedList(bundle, result);
+		}
+		modified |= !oldBundles.equals(result);
+		if (!oldBundles.equals(result))
+			mainAttributes.put(EXPORT_PACKAGE, result);
+	}
+
+	private static String mergeIntoCommaSeparatedList(String bundle, String oldBundles) {
+		if (oldBundles.isEmpty())
+			return bundle;
+		String result = "";
+		String[] oldBundleList = oldBundles.split(",");
+		String newBundleName = bundleName(bundle);
+		String newBundleVersion = bundleVersion(bundle);
+		String seperator = "";
+		boolean merged = false;
+		for (String oldBundle : oldBundleList) {
+			String oldBundleName = bundleName(oldBundle);
+			String oldBundleVersion = bundleVersion(oldBundle);
+			String bundleName;
+			String bundleVersion;
+			if (oldBundleName.equals(newBundleName)) {
+				bundleName = newBundleName;
+				bundleVersion = !"".equals(oldBundleVersion) ? oldBundleVersion : newBundleVersion;
+				merged = true;
+			} else {
+				bundleName = oldBundleName;
+				bundleVersion = oldBundleVersion;
+			}
+			result += seperator + bundleName + (bundleVersion == "" ? "" : (";" + bundleVersion));
+			seperator = ",";
+		}
+		if (!merged)
+			result += "," + bundle;
+		return result;
+	}
+
+	private static String bundleName(String bundle) {
+		return bundle.contains(";") ? bundle.split(";")[0] : bundle;
+	}
+
+	private static String bundleVersion(String bundle) {
+		return bundle.contains(";") ? bundle.split(";")[1] : "";
+	}
+
+	/**
+	 * Set the main attribute "Bundle-RequiredExecutionEnvironment" to the given
+	 * value.
+	 * 
+	 * @param bree The new value
+	 */
+	public void setBREE(String bree) {
+		String old = mainAttributes.get(BUNDLE_REQUIREDEXECUTIONENVIRONMENT);
+		if (!bree.equals(old)) {
+			this.mainAttributes.put(BUNDLE_REQUIREDEXECUTIONENVIRONMENT, bree);
+			this.modified = true;
+			this.bree = bree;
+		}
+	}
+
+	/**
+	 * @return the value of the main attribute
+	 * "Bundle-RequiredExecutionEnvironment".
+	 */
+	public String getBREE() {
+		return bree;
+	}
+
+	/**
+	 * Set the main attribute "Bundle-Activator" to the given value.
+	 * 
+	 * @param bundleActivator The new value
+	 */
+	public void setBundleActivator(String bundleActivator) {
+		String old = mainAttributes.get(BUNDLE_ACTIVATOR);
+		if (!bundleActivator.equals(old)) {
+			this.mainAttributes.put(BUNDLE_ACTIVATOR, bundleActivator);
+			this.modified = true;
+			this.bundleActivator = bundleActivator;
+		}
+	}
+
+	/**
+	 * @return the value of the main attribute "Bundle-Activator".
+	 */
+	public String getBundleActivator() {
+		return bundleActivator;
+	}
+
+	/**
+	 * Set the line delimiter to a specific value. Is only used for writing, NOT
+	 * for reading!
+	 * 
+	 * @param lineDelimeter typically either "\n" or "\r\n".
+	 */
+	public void setLineDelimiter(String lineDelimeter) {
+		newline = lineDelimeter;
+	}
+
+	/**
+	 * Write the contents to the manifest to the given stream. As the stream is
+	 * created by the caller the caller is also responsible for closing it.
+	 * 
+	 * @param stream the stream to write the output to.
+	 */
+	public void write(OutputStream stream) throws IOException {
+		write(new BufferedWriter(new OutputStreamWriter(stream)));
+	}
+
+	private void write(BufferedWriter writer) throws IOException {
+		writeHeader(writer);
+		writeEntries(writer);
+		writer.flush();
+	}
+
+	private void writeHeader(BufferedWriter writer) throws IOException {
+		if (version == null)
+			return;
+		String manifestVersion = mainAttributes.get(MANIFEST_VERSION);
+		if (manifestVersion != null)
+			writer.append(MANIFEST_VERSION).append(": ").append(manifestVersion).append(newline);
+		String signatureVersion = mainAttributes.get(SIGNATURE_VERSION);
+		if (signatureVersion != null)
+			writer.append(SIGNATURE_VERSION).append(": ").append(signatureVersion).append(newline);
+		for (Entry<String, String> entry : mainAttributes.entrySet()) {
+			String key = entry.getKey();
+			if (key.equals(MANIFEST_VERSION) || key.equals(SIGNATURE_VERSION))
+				continue;
+			String value = entry.getValue();
+			writer.append(make512Safe(new StringBuffer(key + ": " + separateCommas(value)), newline));
+		}
+	}
+
+	private void writeEntries(BufferedWriter writer) throws IOException {
+		for (Entry<String, Attributes> entry : entries.entrySet()) {
+			writer.write(newline);
+			writer.append("Name: ").append(entry.getKey()).append(newline);
+			for (Entry<String, String> child : entry.getValue().entrySet()) {
+				String key = child.getKey();
+				String value = child.getValue();
+				if (value.isEmpty())
+					continue;
+				writer.append(make512Safe(new StringBuffer(key + ": " + separateCommas(value)), newline));
+			}
+		}
+	}
+
+	private String separateCommas(String value) {
+		if (!value.contains(","))
+			return value;
+		String result = "";
+		String rest = value;
+		String seperator = "";
+		while (!rest.isEmpty()) {
+			int commaIndex = rest.indexOf(',');
+			if (commaIndex == -1) {
+				result += seperator + rest;
+				rest = "";
+			} else {
+				int quote0Index = rest.indexOf('"');
+				if (quote0Index == -1 || commaIndex < quote0Index) {
+					result += seperator + rest.substring(0, commaIndex);
+					rest = rest.substring(commaIndex + 1);
+				} else {
+					int quote1Index = rest.indexOf('"', quote0Index + 1);
+					if (quote1Index == -1) {
+						result += seperator + rest.substring(0, commaIndex);
+						rest = rest.substring(commaIndex + 1);
+					} else {
+						commaIndex = rest.indexOf(',', quote1Index);
+						if (commaIndex == -1) {
+							result += seperator + rest;
+							rest = "";
+						} else {
+							result += seperator + rest.substring(0, commaIndex);
+							rest = rest.substring(commaIndex + 1);
+						}
+					}
+				}
+			}
+			seperator = "," + newline + " ";
+		}
+		return result;
+	}
+
+	@Override
+	public MergeableManifest2 clone() throws CloneNotSupportedException {
+		return new MergeableManifest2(this);
+	}
+
+	/**
+	 * Return a string that ensures that no line is longer then 512 characters
+	 * and lines are broken according to manifest specification.
+	 * 
+	 * @param input The buffer containing the content that should be made safe
+	 * @param newline The string to use to create newlines (usually "\n" or
+	 * "\r\n")
+	 * @return The string with no longer lines then 512, ready to be read again
+	 * by {@link MergeableManifest2}.
+	 */
+	public static String make512Safe(StringBuffer input, String newline) {
+		StringBuilder result = new StringBuilder();
+		String content = input.toString();
+		String rest = content;
+		while (!rest.isEmpty()) {
+			if (rest.contains("\n")) {
+				String line = rest.substring(0, rest.indexOf("\n"));
+				rest = rest.substring(rest.indexOf("\n") + 1);
+				if (line.length() > 1 && line.charAt(line.length() - 1) == '\r')
+					line = line.substring(0, line.length() - 1);
+				append512Safe(line, result, newline);
+			} else {
+				append512Safe(rest, result, newline);
+				break;
+			}
+		}
+		return result.toString();
+	}
+
+	private static String append512Safe(String toAppend, StringBuilder result, String newline) {
+		boolean hasAppended = false;
+		while (toAppend.length() > 512) {
+			if (hasAppended)
+				result.append(" ");
+			hasAppended = true;
+			result.append(toAppend.substring(0, 510)).append(newline);
+			toAppend = toAppend.substring(510);
+		}
+		if (hasAppended)
+			result.append(" ");
+		result.append(toAppend).append(newline);
+		return toAppend;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((entries == null) ? 0 : entries.hashCode());
+		result = prime * result + ((mainAttributes == null) ? 0 : mainAttributes.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MergeableManifest2 other = (MergeableManifest2) obj;
+		if (entries == null) {
+			if (other.entries != null)
+				return false;
+		} else if (!entries.equals(other.entries))
+			return false;
+		if (mainAttributes == null) {
+			if (other.mainAttributes != null)
+				return false;
+		} else if (!mainAttributes.equals(other.mainAttributes))
+			return false;
+		return true;
+	}
+
+	/**
+	 * A map that updates the "modified" state of the owning
+	 * {@link MergeableManifest2}.
+	 */
+	public class Attributes implements Map<String, String> {
+
+		private LinkedHashMap<String, String> content = new LinkedHashMap<>();
+
+		@Override
+		public int size() {
+			return content.size();
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return content.isEmpty();
+		}
+
+		@Override
+		public boolean containsKey(Object key) {
+			return content.containsKey(key);
+		}
+
+		@Override
+		public boolean containsValue(Object value) {
+			return content.containsValue(value);
+		}
+
+		@Override
+		public String get(Object key) {
+			return content.get(key);
+		}
+
+		@Override
+		public String put(String key, String value) {
+			if (value.equals(content.get(key)))
+				return value;
+			modified = true;
+			return content.put(key, value);
+		}
+
+		@Override
+		public String remove(Object key) {
+			modified = true;
+			return content.remove(key);
+		}
+
+		@Override
+		public void putAll(Map<? extends String, ? extends String> m) {
+			modified = true;
+			content.putAll(m);
+		}
+
+		@Override
+		public void clear() {
+			modified = true;
+			content.clear();
+		}
+
+		@Override
+		public Set<String> keySet() {
+			return content.keySet();
+		}
+
+		@Override
+		public Collection<String> values() {
+			return content.values();
+		}
+
+		@Override
+		public Set<Entry<String, String>> entrySet() {
+			return content.entrySet();
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((content == null) ? 0 : content.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			Attributes other = (Attributes) obj;
+			if (content == null) {
+				if (other.content != null)
+					return false;
+			} else if (!content.equals(other.content))
+				return false;
+			return true;
+		}
+
+	}
+
+}

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/Strings.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/Strings.java
@@ -576,4 +576,5 @@ public class Strings {
 		}
 		return document.toString();
 	}
+
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.xtend
@@ -19,7 +19,6 @@ import java.util.HashMap
 import java.util.List
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.mwe.core.WorkflowContext
-import org.eclipse.emf.mwe.core.issues.Issues
 import org.eclipse.emf.mwe.core.lib.AbstractWorkflowComponent2
 import org.eclipse.emf.mwe.core.monitor.ProgressMonitor
 import org.eclipse.emf.mwe.utils.StandaloneSetup
@@ -29,7 +28,7 @@ import org.eclipse.xtext.Grammar
 import org.eclipse.xtext.XtextStandaloneSetup
 import org.eclipse.xtext.parser.IEncodingProvider
 import org.eclipse.xtext.resource.IResourceServiceProvider
-import org.eclipse.xtext.util.MergeableManifest
+import org.eclipse.xtext.util.MergeableManifest2
 import org.eclipse.xtext.util.Tuples
 import org.eclipse.xtext.util.internal.Log
 import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess
@@ -183,7 +182,7 @@ class XtextGenerator extends AbstractWorkflowComponent2 {
 		}
 	}
 	
-	private def void handleException(Exception ex, Issues issues) {
+	private def void handleException(Exception ex, org.eclipse.emf.mwe.core.issues.Issues issues) {
 		if (ex instanceof CompositeGeneratorException) {
 			ex.exceptions.forEach[handleException(issues)]
 		} else {
@@ -270,7 +269,7 @@ class XtextGenerator extends AbstractWorkflowComponent2 {
 		var InputStream in
 		try {
 			in = metaInf.readBinaryFile(manifest.path)
-			val merge = new MergeableManifest(in, manifest.bundleName)
+			val merge = new MergeableManifest2(in, manifest.bundleName)
 			merge.lineDelimiter = codeConfig.lineDelimiter
 			merge.addExportedPackages(manifest.exportedPackages)
 			merge.addRequiredBundles(manifest.requiredBundles)

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/ManifestAccess.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/ManifestAccess.xtend
@@ -7,17 +7,17 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext.generator.model
 
+import com.google.inject.Injector
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.util.Set
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend2.lib.StringConcatenationClient
 import org.eclipse.xtext.generator.IFileSystemAccess2
-import org.eclipse.xtext.util.MergeableManifest
+import org.eclipse.xtext.util.MergeableManifest2
+import org.eclipse.xtext.util.Strings
 import org.eclipse.xtext.util.internal.Log
 import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent
-import com.google.inject.Injector
-import org.eclipse.xtext.util.Strings
 
 /**
  * Configuration object for MANIFEST.MF files for use in Eclipse.
@@ -129,12 +129,12 @@ class ManifestAccess extends TextFileAccess implements IGuiceAwareGeneratorCompo
 	
 	override void writeTo(IFileSystemAccess2 fileSystemAccess) {
 		if (fileSystemAccess !== null) {
-			val contentToWrite = MergeableManifest.make512Safe(new StringBuffer(content), lineDelimiter)
+			val contentToWrite = MergeableManifest2.make512Safe(new StringBuffer(content), lineDelimiter)
 			// make sure all the constraints for the manifest are respected
-			val mergableManifest = new MergeableManifest(new ByteArrayInputStream(contentToWrite.getBytes("UTF-8")))
-			mergableManifest.lineDelimiter = lineDelimiter
+			val mergeableManifest = new MergeableManifest2(new ByteArrayInputStream(contentToWrite.getBytes("UTF-8")))
+			mergeableManifest.lineDelimiter = lineDelimiter
 			var bout = new ByteArrayOutputStream()
-			mergableManifest.write(bout)
+			mergeableManifest.write(bout)
 			fileSystemAccess.generateFile(path, new ByteArrayInputStream(bout.toByteArray))
 		}
 	}

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGenerator.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGenerator.java
@@ -35,7 +35,7 @@ import org.eclipse.xtext.Grammar;
 import org.eclipse.xtext.XtextStandaloneSetup;
 import org.eclipse.xtext.parser.IEncodingProvider;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
-import org.eclipse.xtext.util.MergeableManifest;
+import org.eclipse.xtext.util.MergeableManifest2;
 import org.eclipse.xtext.util.Triple;
 import org.eclipse.xtext.util.Tuples;
 import org.eclipse.xtext.util.internal.Log;
@@ -362,7 +362,7 @@ public class XtextGenerator extends AbstractWorkflowComponent2 {
     try {
       in = metaInf.readBinaryFile(manifest.getPath());
       String _bundleName = manifest.getBundleName();
-      final MergeableManifest merge = new MergeableManifest(in, _bundleName);
+      final MergeableManifest2 merge = new MergeableManifest2(in, _bundleName);
       merge.setLineDelimiter(this.codeConfig.getLineDelimiter());
       merge.addExportedPackages(manifest.getExportedPackages());
       merge.addRequiredBundles(manifest.getRequiredBundles());

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/ManifestAccess.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/ManifestAccess.java
@@ -18,7 +18,7 @@ import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.generator.IFileSystemAccess2;
-import org.eclipse.xtext.util.MergeableManifest;
+import org.eclipse.xtext.util.MergeableManifest2;
 import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.util.internal.Log;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
@@ -262,13 +262,13 @@ public class ManifestAccess extends TextFileAccess implements IGuiceAwareGenerat
       if ((fileSystemAccess != null)) {
         CharSequence _content = this.getContent();
         StringBuffer _stringBuffer = new StringBuffer(_content);
-        final String contentToWrite = MergeableManifest.make512Safe(_stringBuffer, this.lineDelimiter);
+        final String contentToWrite = MergeableManifest2.make512Safe(_stringBuffer, this.lineDelimiter);
         byte[] _bytes = contentToWrite.getBytes("UTF-8");
         ByteArrayInputStream _byteArrayInputStream = new ByteArrayInputStream(_bytes);
-        final MergeableManifest mergableManifest = new MergeableManifest(_byteArrayInputStream);
-        mergableManifest.setLineDelimiter(this.lineDelimiter);
+        final MergeableManifest2 mergeableManifest = new MergeableManifest2(_byteArrayInputStream);
+        mergeableManifest.setLineDelimiter(this.lineDelimiter);
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        mergableManifest.write(bout);
+        mergeableManifest.write(bout);
         byte[] _byteArray = bout.toByteArray();
         ByteArrayInputStream _byteArrayInputStream_1 = new ByteArrayInputStream(_byteArray);
         fileSystemAccess.generateFile(this.getPath(), _byteArrayInputStream_1);


### PR DESCRIPTION
Adding extensive unit tests to ensure behaviour does not change.
Use only MergableMenufest2 internally.

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>