### PR TITLE
GH-924: Disabled the semantic highlighting with the default bindings.

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/semanticHighlight/ISemanticHighlightingStyleToTokenMapper.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/semanticHighlight/ISemanticHighlightingStyleToTokenMapper.xtend
@@ -41,8 +41,11 @@ interface ISemanticHighlightingStyleToTokenMapper {
 	 */
 	def Set<String> getAllStyleIds();
 
+	/**
+	 * The shared, default NOOP implementation of the semantic style ID to TextMate token mapper.
+	 */
 	@Singleton
-	static class Noop implements ISemanticHighlightingStyleToTokenMapper {
+	static final class Noop implements ISemanticHighlightingStyleToTokenMapper {
 
 		override toScopes(String styleId) {
 			return SemanticHighlightingRegistry.UNKNOWN_SCOPES;

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/semanticHighlight/SemanticHighlightingRegistry.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/semanticHighlight/SemanticHighlightingRegistry.xtend
@@ -73,7 +73,7 @@ class SemanticHighlightingRegistry {
 	}
 
 	@Inject
-	extension UriExtensions; 
+	extension UriExtensions;
 
 	/**
 	 * Lookup table for all known TextMate scopes.
@@ -149,7 +149,7 @@ class SemanticHighlightingRegistry {
 		val resource = context.resource as XtextResource;
 		val calculator = resource.resourceServiceProvider?.get(ISemanticHighlightingCalculator);
 		val mapper = resource.resourceServiceProvider?.get(ISemanticHighlightingStyleToTokenMapper);
-		if (calculator === null || mapper === null) {
+		if (calculator === null || mapper.isIgnoredMapper) {
 			return;
 		}
 
@@ -168,6 +168,16 @@ class SemanticHighlightingRegistry {
 		val lines = ranges.toSemanticHighlightingInformation(document);
 		val textDocument = context.toVersionedTextDocumentIdentifier;
 		notifyClient(new SemanticHighlightingParams(textDocument, lines));
+	}
+
+	/**
+	 * {@code true} if the argument is an ignored mapper. Otherwise, {@code false}.
+	 * If a mapper is ignored, no semantic highlighting information will be calculated. Clients won't be notified at all.
+	 * 
+	 * By default, the argument is ignored if {@code null}, or instance of the {@link ISemanticHighlightingStyleToTokenMapper.Noop NOOP mapper}.
+	 */
+	protected def boolean isIgnoredMapper(ISemanticHighlightingStyleToTokenMapper mapper) {
+		return mapper === null || mapper instanceof ISemanticHighlightingStyleToTokenMapper.Noop;
 	}
 
 	protected def List<SemanticHighlightingInformation> toSemanticHighlightingInformation(

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/semanticHighlight/ISemanticHighlightingStyleToTokenMapper.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/semanticHighlight/ISemanticHighlightingStyleToTokenMapper.java
@@ -26,8 +26,11 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 @ImplementedBy(ISemanticHighlightingStyleToTokenMapper.Noop.class)
 @SuppressWarnings("all")
 public interface ISemanticHighlightingStyleToTokenMapper {
+  /**
+   * The shared, default NOOP implementation of the semantic style ID to TextMate token mapper.
+   */
   @Singleton
-  public static class Noop implements ISemanticHighlightingStyleToTokenMapper {
+  public static final class Noop implements ISemanticHighlightingStyleToTokenMapper {
     @Override
     public List<String> toScopes(final String styleId) {
       return SemanticHighlightingRegistry.UNKNOWN_SCOPES;

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/semanticHighlight/SemanticHighlightingRegistry.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/semanticHighlight/SemanticHighlightingRegistry.java
@@ -260,7 +260,7 @@ public class SemanticHighlightingRegistry {
       _get_1=_resourceServiceProvider_1.<ISemanticHighlightingStyleToTokenMapper>get(ISemanticHighlightingStyleToTokenMapper.class);
     }
     final ISemanticHighlightingStyleToTokenMapper mapper = _get_1;
-    if (((calculator == null) || (mapper == null))) {
+    if (((calculator == null) || this.isIgnoredMapper(mapper))) {
       return;
     }
     final Document document = context.getDocument();
@@ -283,6 +283,16 @@ public class SemanticHighlightingRegistry {
     final VersionedTextDocumentIdentifier textDocument = this.toVersionedTextDocumentIdentifier(context);
     SemanticHighlightingParams _semanticHighlightingParams = new SemanticHighlightingParams(textDocument, lines);
     this.notifyClient(_semanticHighlightingParams);
+  }
+  
+  /**
+   * {@code true} if the argument is an ignored mapper. Otherwise, {@code false}.
+   * If a mapper is ignored, no semantic highlighting information will be calculated. Clients won't be notified at all.
+   * 
+   * By default, the argument is ignored if {@code null}, or instance of the {@link ISemanticHighlightingStyleToTokenMapper.Noop NOOP mapper}.
+   */
+  protected boolean isIgnoredMapper(final ISemanticHighlightingStyleToTokenMapper mapper) {
+    return ((mapper == null) || (mapper instanceof ISemanticHighlightingStyleToTokenMapper.Noop));
   }
   
   protected List<SemanticHighlightingInformation> toSemanticHighlightingInformation(final Iterable<? extends SemanticHighlightingRegistry.HighlightedRange> ranges, final Document document) {


### PR DESCRIPTION
Closes: #924.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>