### PR TITLE
[#950] Fixed regression in Strings.convertFromJavaString

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/ManifestMergerTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/ManifestMergerTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 
 /**
  * @author Sven Efftinge - Initial contribution and API
- *
  */
+@SuppressWarnings("deprecation")
 public class ManifestMergerTest extends Assert {
 	private static final String NL = Strings.newLine();
 

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/StringsTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/StringsTest.java
@@ -10,7 +10,6 @@ package org.eclipse.xtext.util;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.IntFunction;
 import java.util.function.IntPredicate;
 
 import org.junit.Assert;

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/StringsTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/StringsTest.java
@@ -241,4 +241,10 @@ public class StringsTest extends Assert {
 		assertEquals(input, Strings.convertFromJavaString(expected, true));
 	}
 	
+	@Test(expected=IllegalArgumentException.class)
+	public void testConvertIllegalEscapeSequence() throws Exception {
+		String input = "\\/";
+		Strings.convertFromJavaString(input, true);
+	}
+	
 }

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/StringsTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/StringsTest.java
@@ -10,6 +10,8 @@ package org.eclipse.xtext.util;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.IntFunction;
+import java.util.function.IntPredicate;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -245,6 +247,42 @@ public class StringsTest extends Assert {
 	public void testConvertIllegalEscapeSequence() throws Exception {
 		String input = "\\/";
 		Strings.convertFromJavaString(input, true);
+	}
+	
+	@Test
+	public void testIsHex() {
+		IntPredicate ref = (c) -> {
+					switch (c) {
+					case '0':
+					case '1':
+					case '2':
+					case '3':
+					case '4':
+					case '5':
+					case '6':
+					case '7':
+					case '8':
+					case '9':
+					case 'a':
+					case 'b':
+					case 'c':
+					case 'd':
+					case 'e':
+					case 'f':
+					case 'A':
+					case 'B':
+					case 'C':
+					case 'D':
+					case 'E':
+					case 'F':
+						return true;
+					default:
+						return false;
+				}
+		};
+		for(int c = Character.MIN_VALUE; c <= Character.MAX_VALUE; c++) {
+			Assert.assertTrue((char)c +  " \\u" + Integer.toString(c, 16), ref.test(c) == JavaStringConverter.isHex((char) c));
+		}
 	}
 	
 }

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaStringConverter.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaStringConverter.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.util;
+
+/**
+ * Reusable and customizable implementation of the methdo pair 
+ * {@link Strings#convertToJavaString(String)} and 
+ * {@link Strings#convertFromJavaString(String, boolean)}.
+ * 
+ * @since 2.16
+ */
+public class JavaStringConverter {
+	
+	/**
+	 * Resolve Java control character sequences with to the actual character value.
+	 * Optionally handle unicode escape sequences, too. 
+	 */
+	public String convertFromJavaString(String string, boolean useUnicode) {
+		int length = string.length();
+		StringBuilder result = new StringBuilder(length);
+		for(int nextIndex = 0; nextIndex < length;) {
+			nextIndex = unescapeCharAndAppendTo(string, useUnicode, nextIndex, result);
+		}
+		return result.toString();
+	}
+	
+	protected int unescapeCharAndAppendTo(String string, boolean useUnicode, int index, StringBuilder result) {
+		char c = string.charAt(index++);
+		if (c == '\\') {
+			index = doUnescapeCharAndAppendTo(string, useUnicode, index, result);
+		} else {
+			result.append(c);
+		}
+		return index;
+	}
+	
+	protected int doUnescapeCharAndAppendTo(String string, boolean useUnicode, int index, StringBuilder result) {
+		char c = string.charAt(index++);
+		switch(c) {
+			case 'b':
+				c = '\b';
+				break;	
+			case 't':
+				c = '\t';
+				break;
+			case 'n':
+				c = '\n';
+				break;
+			case 'f':
+				c = '\f';
+				break;
+			case 'r':
+				c = '\r';
+				break;
+			case '"':
+			case '\'':
+			case '\\':
+				break;
+			case 'u':
+				if (useUnicode) {
+					return unescapeUnicodeSequence(string, index, result);
+				}
+		}
+		result.append(c);
+		return index;
+	}
+
+	protected int unescapeUnicodeSequence(String string, int index, StringBuilder result) {
+		try {
+			if(index+4 > string.length())
+				throw new IllegalArgumentException("Illegal \\uxxxx encoding in " + string);
+			result.append((char) Integer.parseInt(string.substring(index, index + 4), 16));
+			return index + 4;
+		} catch(NumberFormatException e) {
+			throw new IllegalArgumentException("Illegal \\uxxxx encoding in " + string);
+		}
+	}
+	
+	/**
+	 * Escapes control characters with a preceding backslash.
+	 * Encodes special chars as unicode escape sequence. 
+	 * The resulting string is safe to be put into a Java string literal between
+	 * the quotes.
+	 */
+	public String convertToJavaString(String theString) {
+		return convertToJavaString(theString, true);
+	}
+	
+	/**
+	 * Escapes control characters with a preceding backslash.
+	 * Optionally encodes special chars as unicode escape sequence. 
+	 * The resulting string is safe to be put into a Java string literal between
+	 * the quotes.
+	 */
+	public String convertToJavaString(String input, boolean useUnicode) {
+		int length = input.length();
+		StringBuilder result = new StringBuilder(length + 4);
+		for (int i = 0; i < length; i++) {
+			escapeAndAppendTo(input.charAt(i), useUnicode, result);
+		}
+		return result.toString();
+	}
+	
+	protected void escapeAndAppendTo(char c, boolean useUnicode, StringBuilder result) {
+		String appendMe;
+		switch (c) {
+			case '\b':
+				appendMe = "\\b";
+				break;	
+			case '\t':
+				appendMe = "\\t";
+				break;
+			case '\n':
+				appendMe = "\\n";
+				break;
+			case '\f':
+				appendMe = "\\f";
+				break;
+			case '\r':
+				appendMe = "\\r";
+				break;
+			case '"':
+				appendMe = "\\\"";
+				break;
+			case '\'':
+				appendMe = "\\'";
+				break;
+			case '\\':
+				appendMe = "\\\\";
+				break;
+			default:
+				if (useUnicode && mustEncodeAsEscapeSequence(c)) {
+					result.append("\\u");
+					for (int i = 12; i >= 0; i-=4) {
+						result.append(toHex((c >> i) & 0xF));
+					}
+				} else {
+					result.append(c);
+				}
+				return;
+		}
+		result.append(appendMe);
+	}
+	
+	protected boolean mustEncodeAsEscapeSequence(char next) {
+		return next < 0x0020 || next > 0x007e;
+	}
+	
+	public char toHex(int i) {
+		return "0123456789ABCDEF".charAt(i & 0xF);
+	}
+}

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaStringConverter.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaStringConverter.java
@@ -265,14 +265,10 @@ public class JavaStringConverter {
 	}
 
 	public static boolean isHex(char c) {
-		if ('0' <= c && c <= 'f') {
-			if (c <= '9')
-				return true;
-			if ('A' <= c && c <= 'F')
-				return true;
-			if ('a' <= c)
-				return true;	
-		}
-		return false;
+		// this performs slightly better than a switch on all the 22 valid chars especially
+		// for the mismatches
+		
+		return '0' <= c && (c = (char) (c| 0x20)) <= 'f' && (c <= '9' || 'a' <= c);
 	}
+	
 }

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaStringConverter.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaStringConverter.java
@@ -193,4 +193,62 @@ public class JavaStringConverter {
 	public char toHex(int i) {
 		return "0123456789ABCDEF".charAt(i & 0xF);
 	}
+	
+	protected boolean isHexSequence(String in, int off, int chars) {
+		return doIsHexSequence(in, off, chars);
+	}
+	
+	public static boolean doIsHexSequence(String in, int off, int chars) {
+		for (int i = off; i < in.length() && i < off + chars; i++) {
+			char c = in.charAt(i);
+			if (!isHex(c)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	protected boolean isHexSequence(char[] in, int off, int chars) {
+		return doIsHexSequence(in, off, chars);
+	}
+	
+	public static boolean doIsHexSequence(char[] in, int off, int chars) {
+		for (int i = off; i < in.length && i < off + chars; i++) {
+			char c = in[i];
+			if (!isHex(c)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	protected static boolean isHex(char c) {
+		switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+				return true;
+			default:
+				return false;
+		}
+	}
 }

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaStringConverter.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaStringConverter.java
@@ -65,11 +65,18 @@ public class JavaStringConverter {
 				if (useUnicode) {
 					return unescapeUnicodeSequence(string, index, result);
 				}
+				// intentional fallThrough
+			default:
+				return handleUnknownEscapeSequence(string, c, useUnicode, index, result);
 		}
 		result.append(c);
 		return index;
 	}
 
+	protected int handleUnknownEscapeSequence(String string, char c, boolean useUnicode, int index, StringBuilder result) {
+		throw new IllegalArgumentException("Illegal escape character \\" + c);
+	}
+	
 	protected int unescapeUnicodeSequence(String string, int index, StringBuilder result) {
 		try {
 			if(index+4 > string.length())

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaStringConverter.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaStringConverter.java
@@ -36,7 +36,7 @@ public class JavaStringConverter {
 			result.append(string, fromInclusive, toExclusive);	
 		} else {
 			for(int i = fromInclusive; i < toExclusive; i++) {
-				validateAndAppendChar(result, string.charAt(i));
+				validateAndAppendChar(string.charAt(i), result);
 			}
 		}
 	}
@@ -68,17 +68,17 @@ public class JavaStringConverter {
 		if (c == '\\') {
 			return doUnescapeCharAndAppendTo(string, useUnicode, index, result);
 		}
-		validateAndAppendChar(result, c);
+		validateAndAppendChar(c, result);
 		return index;
 	}
 	
-	protected void validateAndAppendChar(StringBuilder result, char c) {
-		if (validate(result, c)) {
+	protected void validateAndAppendChar(char c, StringBuilder result) {
+		if (validate(c, result)) {
 			result.append(c);	
 		}
 	}
 	
-	protected boolean validate(StringBuilder result, char c) {
+	protected boolean validate(char c, StringBuilder result) {
 		return true;
 	}
 
@@ -113,7 +113,7 @@ public class JavaStringConverter {
 			default:
 				return handleUnknownEscapeSequence(string, c, useUnicode, index, result);
 		}
-		validateAndAppendChar(result, c);
+		validateAndAppendChar(c, result);
 		return index;
 	}
 
@@ -133,7 +133,7 @@ public class JavaStringConverter {
 				appendMe = buildChar(appendMe, c2);
 				appendMe = buildChar(appendMe, c3);
 				appendMe = buildChar(appendMe, c4);
-				validateAndAppendChar(result, (char) appendMe);
+				validateAndAppendChar((char) appendMe, result);
 				return index + 4;
 			}
 		}

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/MergeableManifest.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/MergeableManifest.java
@@ -123,7 +123,6 @@ public class MergeableManifest extends Manifest {
 		 * Copied from base class, but replaced call to make72Safe(buffer) with
 		 * make512Safe(buffer) and does not write empty values
 		 */
-		@SuppressWarnings("deprecation")
 		public void myWriteMain(DataOutputStream out) throws IOException {
 			// write out the *-Version header first, if it exists
 			String vername = Name.MANIFEST_VERSION.toString();
@@ -165,7 +164,6 @@ public class MergeableManifest extends Manifest {
 		 * Copied from base class, but omitted call to make72Safe(buffer) and
 		 * does not write empty values
 		 */
-		@SuppressWarnings("deprecation")
 		public void myWrite(DataOutputStream out) throws IOException {
 			Iterator<Map.Entry<Object, Object>> it = entrySet().iterator();
 			while (it.hasNext()) {
@@ -299,7 +297,6 @@ public class MergeableManifest extends Manifest {
 	/*
 	 * Copied from base class to omit the call to make72Safe(..).
 	 */
-	@SuppressWarnings("deprecation")
 	@Override
 	public void write(OutputStream out) throws IOException {
 		DataOutputStream dos = new DataOutputStream(out);

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/Strings.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/Strings.java
@@ -121,69 +121,14 @@ public class Strings {
 		return s.substring(0, 1).toLowerCase() + s.substring(1);
 	}
 
+	private static final JavaStringConverter CONVERTER = new JavaStringConverter();
+	
 	/**
 	 * Resolve Java control character sequences with to the actual character value.
 	 * Optionally handle unicode escape sequences, too. 
 	 */
 	public static String convertFromJavaString(String string, boolean useUnicode) {
-		int length = string.length();
-		StringBuilder result = new StringBuilder(length);
-		for(int nextIndex = 0; nextIndex < length;) {
-			nextIndex = unescapeCharAndAppendTo(string, useUnicode, nextIndex, result);
-		}
-		return result.toString();
-	}
-
-	private static int unescapeCharAndAppendTo(String string, boolean useUnicode, int index, StringBuilder result) {
-		char c = string.charAt(index++);
-		if (c == '\\') {
-			index = doUnescapeCharAndAppendTo(string, useUnicode, index, result);
-		} else {
-			result.append(c);
-		}
-		return index;
-	}
-
-	private static int doUnescapeCharAndAppendTo(String string, boolean useUnicode, int index, StringBuilder result) {
-		char c = string.charAt(index++);
-		switch(c) {
-			case 'b':
-				c = '\b';
-				break;	
-			case 't':
-				c = '\t';
-				break;
-			case 'n':
-				c = '\n';
-				break;
-			case 'f':
-				c = '\f';
-				break;
-			case 'r':
-				c = '\r';
-				break;
-			case '"':
-			case '\'':
-			case '\\':
-				break;
-			case 'u':
-				if (useUnicode) {
-					return unescapeUnicodeSequence(string, index, result);
-				}
-		}
-		result.append(c);
-		return index;
-	}
-
-	private static int unescapeUnicodeSequence(String string, int index, StringBuilder result) {
-		try {
-			if(index+4 > string.length())
-				throw new IllegalArgumentException("Illegal \\uxxxx encoding in " + string);
-			result.append((char) Integer.parseInt(string.substring(index, index + 4), 16));
-			return index + 4;
-		} catch(NumberFormatException e) {
-			throw new IllegalArgumentException("Illegal \\uxxxx encoding in " + string);
-		}
+		return CONVERTER.convertFromJavaString(string, useUnicode);
 	}
 
 	/**
@@ -193,7 +138,7 @@ public class Strings {
 	 * the quotes.
 	 */
 	public static String convertToJavaString(String theString) {
-		return convertToJavaString(theString, true);
+		return CONVERTER.convertToJavaString(theString, true);
 	}
 	
 	/**
@@ -203,61 +148,11 @@ public class Strings {
 	 * the quotes.
 	 */
 	public static String convertToJavaString(String input, boolean useUnicode) {
-		int length = input.length();
-		StringBuilder result = new StringBuilder(length + 4);
-		for (int i = 0; i < length; i++) {
-			escapeAndAppendTo(input.charAt(i), useUnicode, result);
-		}
-		return result.toString();
-	}
-
-	private static void escapeAndAppendTo(char c, boolean useUnicode, StringBuilder result) {
-		String appendMe;
-		switch (c) {
-			case '\b':
-				appendMe = "\\b";
-				break;	
-			case '\t':
-				appendMe = "\\t";
-				break;
-			case '\n':
-				appendMe = "\\n";
-				break;
-			case '\f':
-				appendMe = "\\f";
-				break;
-			case '\r':
-				appendMe = "\\r";
-				break;
-			case '"':
-				appendMe = "\\\"";
-				break;
-			case '\'':
-				appendMe = "\\'";
-				break;
-			case '\\':
-				appendMe = "\\\\";
-				break;
-			default:
-				if (useUnicode && mustEncodeAsEscapeSequence(c)) {
-					result.append("\\u");
-					for (int i = 12; i >= 0; i-=4) {
-						result.append(toHex((c >> i) & 0xF));
-					}
-				} else {
-					result.append(c);
-				}
-				return;
-		}
-		result.append(appendMe);
-	}
-
-	private static boolean mustEncodeAsEscapeSequence(char next) {
-		return next < 0x0020 || next > 0x007e;
+		return CONVERTER.convertToJavaString(input, useUnicode);
 	}
 
 	public static char toHex(int i) {
-		return "0123456789ABCDEF".charAt(i & 0xF);
+		return CONVERTER.toHex(i);
 	}
 
 	/**

--- a/org.eclipse.xtext/src/org/eclipse/xtext/conversion/impl/STRINGValueConverter.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/conversion/impl/STRINGValueConverter.java
@@ -72,6 +72,8 @@ public class STRINGValueConverter extends AbstractLexerBasedConverter<String> {
 		int errorLength = -1;
 		int nextIndex = 1;
 		
+		protected Implementation() {}
+		
 		public String convertFromJavaString(String literal) {
 			int idx = literal.indexOf('\\');
 			if (idx < 0 && literal.length() > 1 && literal.charAt(0) == literal.charAt(literal.length() - 1)) {
@@ -120,12 +122,7 @@ public class STRINGValueConverter extends AbstractLexerBasedConverter<String> {
 		}
 		
 		@Override
-		protected boolean isInvalidUnicodeEscapeSequence(String string, int index) {
-			return super.isInvalidUnicodeEscapeSequence(string, index) || !isHexSequence(string, index, 4);
-		}
-		
-		@Override
-		protected int handleInvalidUnicodeEscapeSequnce(String string, int index, StringBuilder result) {
+		protected int handleInvalidUnicodeEscapeSequence(String string, int index, StringBuilder result) {
 			result.append('u');
 			errorMessage = "Invalid unicode";
 			errorIndex = index - 2;

--- a/org.eclipse.xtext/src/org/eclipse/xtext/conversion/impl/STRINGValueConverter.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/conversion/impl/STRINGValueConverter.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.conversion.impl;
 import org.eclipse.xtext.conversion.ValueConverterException;
 import org.eclipse.xtext.conversion.ValueConverterWithValueException;
 import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.util.JavaStringConverter;
 import org.eclipse.xtext.util.Strings;
 
 /**
@@ -46,43 +47,116 @@ public class STRINGValueConverter extends AbstractLexerBasedConverter<String> {
 	 * @see Strings#convertFromJavaString(String, boolean)
 	 */
 	protected String convertFromString(String literal, INode node) throws ValueConverterWithValueException {
-		int length = literal.length();
-		StringBuilder result = new StringBuilder(length);
-		ErrorInfo errorInfo = new ErrorInfo();
+		Implementation converter = createConverter();
+		String result = converter.convertFromJavaString(literal);
+		if (converter.errorMessage != null) {
+			throw new ValueConverterWithValueException(converter.errorMessage, node, result.toString(), converter.errorIndex,
+					converter.errorLength, null);
+		}
+		return result;
+	}
+
+	/**
+	 * @since 2.16
+	 */
+	protected Implementation createConverter() {
+		return new Implementation();
+	}
+	
+	/**
+	 * @since 2.16
+	 */
+	protected class Implementation extends JavaStringConverter {
+		String errorMessage = null;
+		int errorIndex = -1;
+		int errorLength = -1;
 		int nextIndex = 1;
-		while(nextIndex < length - 1) {
-			nextIndex = unescapeCharAndAppendTo(literal, nextIndex, result, errorInfo);
+		
+		public String convertFromJavaString(String literal) {
+			int idx = literal.indexOf('\\');
+			if (idx < 0 && literal.length() > 1 && literal.charAt(0) == literal.charAt(literal.length() - 1)) {
+				return literal.substring(1, literal.length() - 1);
+			}
+			return convertFromJavaString(literal, true, 1, new StringBuilder(literal.length()));
 		}
 		
-		if (nextIndex < length) {
-			if (nextIndex != length - 1) {
-				throw new IllegalStateException();
+		@Override
+		protected String convertFromJavaString(String string, boolean useUnicode, int index, StringBuilder result) {
+			int length = string.length();
+			while(index < length - 1) {
+				nextIndex = index = unescapeCharAndAppendTo(string, useUnicode, index, result);
 			}
-			char next = literal.charAt(nextIndex);
-			if (literal.charAt(0) != next) {
-				result.append(next);
-				if (errorInfo.errorMessage == null) {
-					if (next == '\\') {
-						errorInfo.errorMessage = getInvalidEscapeSequenceMessage();
-						errorInfo.errorIndex = nextIndex;
-						errorInfo.errorLength = 1;
-					} else {
-						errorInfo.errorMessage = getStringNotClosedMessage();
-					}
-				} else {
-					errorInfo.errorMessage = getStringNotClosedMessage();
-					errorInfo.errorIndex = -1;
-					errorInfo.errorLength = -1;
+			if (nextIndex < length) {
+				if (nextIndex != length - 1) {
+					throw new IllegalStateException();
 				}
+				char next = string.charAt(nextIndex);
+				if (string.charAt(0) != next) {
+					result.append(next);
+					if (errorMessage == null) {
+						if (next == '\\') {
+							errorMessage = getInvalidEscapeSequenceMessage();
+							errorIndex = nextIndex;
+							errorLength = 1;
+						} else {
+							errorMessage = getStringNotClosedMessage();
+						}
+					} else {
+						errorMessage = getStringNotClosedMessage();
+						errorIndex = -1;
+						errorLength = -1;
+					}
+				}
+			} else if (nextIndex == length) {
+				errorMessage = getStringNotClosedMessage();
 			}
-		} else if (nextIndex == length) {
-			errorInfo.errorMessage = getStringNotClosedMessage();
+			return result.toString();
 		}
-		if (errorInfo.errorMessage != null) {
-			throw new ValueConverterWithValueException(errorInfo.errorMessage, node, result.toString(), errorInfo.errorIndex,
-					errorInfo.errorLength, null);
+		
+		@Override
+		protected boolean isHexSequence(char[] in, int off, int chars) {
+			// keep chance to use overridden methods by funneling it through STRINGValueConverter
+			return STRINGValueConverter.this.isHexSequence(in, off, chars);
 		}
-		return result.toString();
+		
+		@Override
+		protected boolean isInvalidUnicodeEscapeSequence(String string, int index) {
+			return super.isInvalidUnicodeEscapeSequence(string, index) || !isHexSequence(string, index, 4);
+		}
+		
+		@Override
+		protected int handleInvalidUnicodeEscapeSequnce(String string, int index, StringBuilder result) {
+			result.append('u');
+			errorMessage = "Invalid unicode";
+			errorIndex = index - 2;
+			errorLength = 2;
+			return index;
+		}
+		
+		@Override
+		protected int doUnescapeCharAndAppendTo(String string, boolean useUnicode, int index, StringBuilder result) {
+			if (string.length() == index) {
+				if (errorMessage == null) {
+					errorMessage = getInvalidEscapeSequenceMessage();
+					errorIndex = index - 1;
+					errorLength = 1;
+				}
+				return index;
+			}
+			return super.doUnescapeCharAndAppendTo(string, useUnicode, index, result);
+		}
+		
+		@Override
+		protected int handleUnknownEscapeSequence(String string, char c, boolean useUnicode, int index, StringBuilder result) {
+			if (errorMessage == null) {
+				errorMessage = getInvalidEscapeSequenceMessage();
+				errorIndex = index - 2;
+				errorLength = 2;
+			}
+			result.append(c);
+			return index;
+		}
+
 	}
 		
 	/**
@@ -99,150 +173,11 @@ public class STRINGValueConverter extends AbstractLexerBasedConverter<String> {
 		return "String literal is not properly closed";
 	}
 	
-	private static class ErrorInfo {
-		String errorMessage = null;
-		int errorIndex = -1;
-		int errorLength = -1;
-	}
-		
-	private int unescapeCharAndAppendTo(String string, int index, StringBuilder result, ErrorInfo errorInfo) {
-		char c = string.charAt(index++);
-		if (c == '\\') {
-			index = doUnescapeCharAndAppendTo(string, index, result, errorInfo);
-		} else {
-			result.append(c);
-		}
-		return index;
-	}
-	
-	private int doUnescapeCharAndAppendTo(String string, int index, StringBuilder result, ErrorInfo errorInfo) {
-		if (string.length() == index) {
-			if (errorInfo.errorMessage == null) {
-				errorInfo.errorMessage = getInvalidEscapeSequenceMessage();
-				errorInfo.errorIndex = index - 1;
-				errorInfo.errorLength = 1;
-			}
-			return index;
-		}
-		char c = string.charAt(index++);
-		switch(c) {
-			case 'b':
-				c = '\b';
-				break;	
-			case 't':
-				c = '\t';
-				break;
-			case 'n':
-				c = '\n';
-				break;
-			case 'f':
-				c = '\f';
-				break;
-			case 'r':
-				c = '\r';
-				break;
-			case '"':
-			case '\'':
-			case '\\':
-				break;
-			case 'u':
-				return unescapeUnicodeSequence(string, index, result, errorInfo);
-			default:
-				if (errorInfo.errorMessage == null) {
-					errorInfo.errorMessage = getInvalidEscapeSequenceMessage();
-					errorInfo.errorIndex = index - 2;
-					errorInfo.errorLength = 2;
-				}
-		}
-		result.append(c);
-		return index;
-	}
-	
-	private int unescapeUnicodeSequence(String string, int index, StringBuilder result, ErrorInfo errorInfo) {
-		try {
-			if (index+4 > string.length() || !isHexSequence(string, index, 4)) {
-				result.append('u');
-				errorInfo.errorMessage = "Invalid unicode";
-				errorInfo.errorIndex = index - 2;
-				errorInfo.errorLength = 2;
-				return index;
-			}
-			result.append((char) Integer.parseInt(string.substring(index, index + 4), 16));
-			return index + 4;
-		} catch (NumberFormatException e) {
-			throw new IllegalArgumentException("Illegal \\uxxxx encoding in " + string);
-		}
-	}
-	
-	private boolean isHexSequence(String in, int off, int chars) {
-		for (int i = off; i < in.length() && i < off + chars; i++) {
-			char c = in.charAt(i);
-			switch (c) {
-				case '0':
-				case '1':
-				case '2':
-				case '3':
-				case '4':
-				case '5':
-				case '6':
-				case '7':
-				case '8':
-				case '9':
-				case 'a':
-				case 'b':
-				case 'c':
-				case 'd':
-				case 'e':
-				case 'f':
-				case 'A':
-				case 'B':
-				case 'C':
-				case 'D':
-				case 'E':
-				case 'F':
-					continue;
-				default:
-					return false;
-			}
-		}
-		return true;
-	}
-
 	/**
 	 * @since 2.7
 	 */
 	protected boolean isHexSequence(char[] in, int off, int chars) {
-		for (int i = off; i < in.length && i < off + chars; i++) {
-			char c = in[i];
-			switch (c) {
-				case '0':
-				case '1':
-				case '2':
-				case '3':
-				case '4':
-				case '5':
-				case '6':
-				case '7':
-				case '8':
-				case '9':
-				case 'a':
-				case 'b':
-				case 'c':
-				case 'd':
-				case 'e':
-				case 'f':
-				case 'A':
-				case 'B':
-				case 'C':
-				case 'D':
-				case 'E':
-				case 'F':
-					continue;
-				default:
-					return false;
-			}
-		}
-		return true;
+		return Implementation.doIsHexSequence(in, off, chars);
 	}
 
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/DerivedStateAwareResource.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/DerivedStateAwareResource.java
@@ -248,8 +248,8 @@ public class DerivedStateAwareResource extends StorageAwareResource {
 							newFullyInitialized = false;
 							operationCanceledManager.propagateAsErrorIfCancelException(e);
 						}
-						// Needed for Guava 14-19
-						throw Throwables.propagate(e);
+						Throwables.throwIfUnchecked(e);
+						throw new RuntimeException(e);
 					}
 				}
 			} catch (RuntimeException e) {
@@ -280,8 +280,8 @@ public class DerivedStateAwareResource extends StorageAwareResource {
 			if (operationCanceledManager.isOperationCanceledException(e)) {
 				throw new IllegalStateException("IDerivedStateComputer#discardDerivedState should not check whether the current operation is canceled.", e);
 			}
-			// Needed for Guava 14-19
-			throw Throwables.propagate(e);
+			Throwables.throwIfUnchecked(e);
+			throw new RuntimeException(e);
 		}
 	}
 	

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -11,7 +11,7 @@
 		<tycho-version>1.2.0</tycho-version>
 		<root-dir>${basedir}/..</root-dir>
 		<JENKINS_URL>http://services.typefox.io/open-source/jenkins</JENKINS_URL>
-		<upstreamBranch>master</upstreamBranch>
+		<upstreamBranch>sz_strings_regression</upstreamBranch>
 	</properties>
 
 	<repositories>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -11,7 +11,7 @@
 		<tycho-version>1.2.0</tycho-version>
 		<root-dir>${basedir}/..</root-dir>
 		<JENKINS_URL>http://services.typefox.io/open-source/jenkins</JENKINS_URL>
-		<upstreamBranch>sz_strings_regression</upstreamBranch>
+		<upstreamBranch>master</upstreamBranch>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
This fixes a regression introduced with Xtext 2.15. The entire logic for String escaping does perform better now and is easier to reuse. This is achieved by introducing the JavaStringConverter.

The commit does also contain a bunch of fixed warnings.