### PR TITLE
Set reference kind when we know it should be set

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/contentassist/IdeCrossrefProposalProvider.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/contentassist/IdeCrossrefProposalProvider.xtend
@@ -57,6 +57,7 @@ class IdeCrossrefProposalProvider {
 		proposalCreator.createProposal(qualifiedNameConverter.toString(candidate.name), context) [
 			source = candidate
 			description = candidate.getEClass?.name
+			kind = ContentAssistEntry.KIND_REFERENCE
 		]
 	}
 	

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/editor/contentassist/IdeCrossrefProposalProvider.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/editor/contentassist/IdeCrossrefProposalProvider.java
@@ -85,6 +85,7 @@ public class IdeCrossrefProposalProvider {
         _name=_eClass.getName();
       }
       it.setDescription(_name);
+      it.setKind(ContentAssistEntry.KIND_REFERENCE);
     };
     return this.proposalCreator.createProposal(this.qualifiedNameConverter.toString(candidate.getName()), context, _function);
   }


### PR DESCRIPTION
The reference kind can already be set when the proposal is created at this place because we know the proposal is created for a CrossReference.

This avoids having to do more complex checking later on in the auto complete flow to set the kind.