### PR TITLE
Use try read only

### DIFF
--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/concurrent/WrappingCancelableUnitOfWork.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/concurrent/WrappingCancelableUnitOfWork.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Sigasi N.V. (http://www.sigasi.com) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.util.concurrent;
+
+import java.util.function.Supplier;
+
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.util.concurrent.IReadAccess.Priority;
+
+/**
+ * <p>
+ * Wraps a CancelableUnitOfWork in a CancelableUnitOfWork instead of a lambda.
+ * </p>
+ *
+ * <p>
+ * It is used in the try* methods of {@link IReadAccess}, {@link Priority} and
+ * {@link IWriteAccess} to make sure that {@code work} can still be checked to
+ * be cancelable. It does so by delegating
+ * {@link #setCancelIndicator(CancelIndicator)} to {@code work}.
+ * </p>
+ * 
+ * <p>
+ * As it is meant to be used with the try... methods it also makes sure that the
+ * {@code Resource} passed to {@code work}'s {@code exec} method is
+ * never null. If the {@code Resource} would be null, it returns the value
+ * supplied by {@code defaultResult}.
+ * </p>
+ * 
+ * @author Titouan Vervack - Initial contribution and API
+ */
+final class WrappingCancelableUnitOfWork<Result, State> extends CancelableUnitOfWork<Result, State> {
+
+	private final Supplier<? extends Result> defaultResult;
+	private final IUnitOfWork<Result, State> work;
+
+	WrappingCancelableUnitOfWork(Supplier<? extends Result> defaultResult, IUnitOfWork<Result, State> work) {
+		this.defaultResult = defaultResult;
+		this.work = work;
+	}
+
+	@Override
+	public void setCancelIndicator(final CancelIndicator cancelIndicator) {
+		super.setCancelIndicator(cancelIndicator);
+		((CancelableUnitOfWork<Result, State>) work).setCancelIndicator(cancelIndicator);
+	}
+
+	@Override
+	public Result exec(final State state, final CancelIndicator cancelIndicator) throws Exception {
+		if (state == null) {
+			return defaultResult.get();
+		}
+		return work.exec(state);
+	}
+}


### PR DESCRIPTION
The suggested type for `readOnly()` is a `CancelableUnitOfWork` and several places ([here](https://github.com/eclipse/xtext-core/blob/master/org.eclipse.xtext/src/org/eclipse/xtext/resource/OutdatedStateManager.xtend#L63) and [here](https://github.com/eclipse/xtext-eclipse/blob/master/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocument.java#L506)) check if the `IUnitOfWork` is a `CancelableUnitOfWork`. It isn't because `tryReadOnly()` wraps the `IUnitOfWork` in a lambda.

This patch modifies `tryReadOnly()`, `tryPriorityReadOnly()` and `tryModify()` so that they wraps `work` in a `CancelableUnitOfWork` if work is a `CancelableUnitOfWork`.

A prettier way would be to add an overloaded `try...` that takes a `CancelableUnitOfWork` as argument instead of a `IUnitOfWork`, but that would require us to overload 9 methods.