### PR TITLE
[eclipse/xtext#1182] added support for java 11 as target

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/JavaVersionTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/JavaVersionTest.java
@@ -17,15 +17,19 @@ import org.junit.Test;
 public class JavaVersionTest {
 	@Test
 	public void test_fromBree() {
+		assertEquals(JavaVersion.JAVA11, JavaVersion.fromBree("JavaSE-11"));
 		assertEquals(JavaVersion.JAVA10, JavaVersion.fromBree("JavaSE-10"));
 		assertEquals(JavaVersion.JAVA9, JavaVersion.fromBree("JavaSE-9"));
 		assertEquals(JavaVersion.JAVA8, JavaVersion.fromBree("JavaSE-1.8"));
+		assertNull(JavaVersion.fromBree("JavaSE-1.11"));
 		assertNull(JavaVersion.fromBree("JavaSE-1.10"));
 		assertNull(JavaVersion.fromBree(null));
 	}
 	
 	@Test
 	public void testFromQualifier() {
+		assertEquals(JavaVersion.JAVA11, JavaVersion.fromQualifier("11"));
+		assertEquals(JavaVersion.JAVA11, JavaVersion.fromQualifier("1.11"));
 		assertEquals(JavaVersion.JAVA10, JavaVersion.fromQualifier("10"));
 		assertEquals(JavaVersion.JAVA10, JavaVersion.fromQualifier("1.10"));
 		assertEquals(JavaVersion.JAVA9, JavaVersion.fromQualifier("9"));
@@ -44,6 +48,7 @@ public class JavaVersionTest {
 	
 	@Test
 	public void test_getQualifier() {
+		assertEquals("11", JavaVersion.JAVA11.getQualifier());
 		assertEquals("10", JavaVersion.JAVA10.getQualifier());
 		assertEquals("9", JavaVersion.JAVA9.getQualifier());
 		assertEquals("1.8", JavaVersion.JAVA8.getQualifier());

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.web/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.web/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 	compile "org.webjars:requirejs:2.3.6"
 	compile "org.webjars:jquery:3.3.1-1"
 	compile "org.webjars:ace:1.3.3"
-	providedCompile "org.eclipse.jetty:jetty-annotations:9.4.9.v20180320"
+	providedCompile "org.eclipse.jetty:jetty-annotations:9.4.14.v20181114"
 	providedCompile "org.slf4j:slf4j-simple:1.7.21"
 }
 task jettyRun(type:JavaExec) {

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.gradle/org.xtext.example.gradle.parent/org.xtext.example.gradle.web/build.gradle
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.gradle/org.xtext.example.gradle.parent/org.xtext.example.gradle.web/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 	compile "org.webjars:requirejs:2.3.6"
 	compile "org.webjars:jquery:3.3.1-1"
 	compile "org.webjars:ace:1.3.3"
-	providedCompile "org.eclipse.jetty:jetty-annotations:9.4.9.v20180320"
+	providedCompile "org.eclipse.jetty:jetty-annotations:9.4.14.v20181114"
 	providedCompile "org.slf4j:slf4j-simple:1.7.21"
 }
 task jettyRun(type:JavaExec) {

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.web/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.web/pom.xml
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.4.9.v20180320</version>
+				<version>9.4.14.v20181114</version>
 				<configuration>
 					<webAppSourceDirectory>WebRoot</webAppSourceDirectory>
 				</configuration>
@@ -116,7 +116,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-annotations</artifactId>
-			<version>9.4.9.v20180320</version>
+			<version>9.4.14.v20181114</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9.web/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9.web/pom.xml
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.4.9.v20180320</version>
+				<version>9.4.14.v20181114</version>
 				<configuration>
 					<webAppSourceDirectory>WebRoot</webAppSourceDirectory>
 				</configuration>
@@ -116,7 +116,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-annotations</artifactId>
-			<version>9.4.9.v20180320</version>
+			<version>9.4.14.v20181114</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.web/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.web/pom.xml
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.4.9.v20180320</version>
+				<version>9.4.14.v20181114</version>
 				<configuration>
 					<webAppSourceDirectory>WebRoot</webAppSourceDirectory>
 				</configuration>
@@ -116,7 +116,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-annotations</artifactId>
-			<version>9.4.9.v20180320</version>
+			<version>9.4.14.v20181114</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/org.xtext.example.plainMaven.web/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/org.xtext.example.plainMaven.web/pom.xml
@@ -26,7 +26,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.4.9.v20180320</version>
+				<version>9.4.14.v20181114</version>
 				<configuration>
 					<webAppSourceDirectory>src/main/webapp</webAppSourceDirectory>
 				</configuration>
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-annotations</artifactId>
-			<version>9.4.9.v20180320</version>
+			<version>9.4.14.v20181114</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaVersion.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaVersion.java
@@ -48,7 +48,11 @@ public enum JavaVersion {
 	/**
 	 * Java 10 language enhancements: local variable type inference (keyword 'var') (10 is favored over 1.10).
 	 */
-	JAVA10("Java 10", new String[] {"10", "1.10"}, "JavaSE-10", "-1.10", Constants.JAVA10)
+	JAVA10("Java 10", new String[] {"10", "1.10"}, "JavaSE-10", "-1.10", Constants.JAVA10),
+	/**
+	 * Well, Java 11
+	 */
+	JAVA11("Java 11", new String[] {"11", "1.11"}, "JavaSE-11", "-1.11", Constants.JAVA11)
 	;
 
 	private static final class Constants {
@@ -60,6 +64,7 @@ public enum JavaVersion {
 		private static final long JAVA8 = ((long)(MAJOR_VERSION_1_5 + 3) << 16) + MINOR_VERSION_0;
 		private static final long JAVA9 = ((long)(MAJOR_VERSION_1_5 + 4) << 16) + MINOR_VERSION_0;
 		private static final long JAVA10 = ((long)(MAJOR_VERSION_1_5 + 5) << 16) + MINOR_VERSION_0;
+		private static final long JAVA11 = ((long)(MAJOR_VERSION_1_5 + 6) << 16) + MINOR_VERSION_0;
 	}
 
 	//	 if you introduce a new JavaVersion don't forget to adapt

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/WebProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/WebProjectDescriptor.xtend
@@ -17,7 +17,7 @@ class WebProjectDescriptor extends ProjectDescriptor {
 	static val REQUIREJS_VERSION = '2.3.6'
 //	static val REQUIREJS_TEXT_VERSION = '2.0.15'
 	static val JQUERY_VERSION = '3.3.1-1'
-	static val JETTY_VERSION = '9.4.9.v20180320'
+	static val JETTY_VERSION = '9.4.14.v20181114'
 	static val SLF4J_VERSION = '1.7.21'
 	static val ACE_VERSION = '1.3.3'
 	

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/WebProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/WebProjectDescriptor.java
@@ -33,7 +33,7 @@ public class WebProjectDescriptor extends ProjectDescriptor {
   
   private static final String JQUERY_VERSION = "3.3.1-1";
   
-  private static final String JETTY_VERSION = "9.4.9.v20180320";
+  private static final String JETTY_VERSION = "9.4.14.v20181114";
   
   private static final String SLF4J_VERSION = "1.7.21";
   


### PR DESCRIPTION
[eclipse/xtext#1182] added support for java 11 as target

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>