### PR TITLE
Improve ResourceSetBasedAllContainersStateProvider.getResourc…

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/IResourceDescriptions.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/IResourceDescriptions.java
@@ -13,6 +13,7 @@ import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsProvider;
 
@@ -42,6 +43,16 @@ public interface IResourceDescriptions extends ISelectable {
 	interface IContextAware extends IResourceDescriptions {
 
 		void setContext(Notifier ctx);
+	}
+	
+	/**
+	 * A resource set aware instance {@link IResourceDescriptions}.
+	 * 
+	 * @since 2.17
+	 */
+	interface IResourceSetAware extends IResourceDescriptions {
+
+		ResourceSet getResourceSet();
 	}
 
 	class NullImpl implements IResourceDescriptions {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/ResourceSetBasedAllContainersStateProvider.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/ResourceSetBasedAllContainersStateProvider.java
@@ -11,8 +11,7 @@ import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.resource.IResourceDescriptions;
-import org.eclipse.xtext.resource.impl.EagerResourceSetBasedResourceDescriptions;
-import org.eclipse.xtext.resource.impl.ResourceSetBasedResourceDescriptions;
+import org.eclipse.xtext.resource.IResourceDescriptions.IResourceSetAware;
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -36,10 +35,8 @@ public class ResourceSetBasedAllContainersStateProvider implements IAllContainer
 	 * @since 2.4
 	 */
 	protected ResourceSet getResourceSet(IResourceDescriptions context) {
-		if (context instanceof ResourceSetBasedResourceDescriptions) 
-			return ((ResourceSetBasedResourceDescriptions) context).getResourceSet();
-		else if (context instanceof EagerResourceSetBasedResourceDescriptions) 
-			return ((EagerResourceSetBasedResourceDescriptions) context).getResourceSet();
+		if (context instanceof IResourceSetAware)
+			return ((IResourceSetAware) context).getResourceSet();
 		String contextType = context == null ? "null" : context.getClass().getName();
 		throw new IllegalStateException("Passed " + contextType + " is not based on a resource set");
 	}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/impl/EagerResourceSetBasedResourceDescriptions.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/impl/EagerResourceSetBasedResourceDescriptions.java
@@ -38,7 +38,7 @@ import com.google.inject.Inject;
  * @since 2.4
  */
 public class EagerResourceSetBasedResourceDescriptions extends AbstractCompoundSelectable implements
-		IResourceDescriptions.IContextAware {
+		IResourceDescriptions.IContextAware, IResourceDescriptions.IResourceSetAware {
 	
 	static class Descriptions extends AdapterImpl {
 		Map<URI, IResourceDescription> map = newHashMap();

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/impl/ResourceSetBasedResourceDescriptions.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/impl/ResourceSetBasedResourceDescriptions.java
@@ -37,7 +37,7 @@ import com.google.inject.Inject;
  * @since 2.5
  */
 public class ResourceSetBasedResourceDescriptions extends AbstractCompoundSelectable implements
-		IResourceDescriptions.IContextAware {
+		IResourceDescriptions.IContextAware, IResourceDescriptions.IResourceSetAware {
 
 	private ResourceSet resourceSet;
 	private ResourceDescriptionsData data;


### PR DESCRIPTION
https://bugs.eclipse.org/bugs/show_bug.cgi?id=427770

Short:
    Implement solution mentioned in above BUG report.

Longer:
    Bug (?) can be triggered by e.g.:

    IResourceServiceProvider sp = IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(fileUri);
    IResourceSetProvider provider = sp.get(IResourceSetProvider.class);
    IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
    // ... file etc
    IProject project = file.getProject();
    // Use the provider to get the resource set for the given project
    // FIXME how to get the existing XtextResourceSet? Below just creates a new rs. :-(
    ResourceSet rs = provider.get(project);
    // ... run build to generate index used by namespace etc
    BuildRequest request = new BuildRequest();
    request.setResourceSet(rs);
    request.setBaseDir(UriUtil.createFolderURI(new File(baseDir)));
    request.setDirtyFiles(allFiles);
    // ... copy paste code ...
    indexState = incrementalBuilder.build(request, languages).getIndexState();

    Hints for doing this correctly/cleaner is highly appreciated!

    After the code above has been triggered doing a Project Clean will
    trigger method from title to be called with a CurrentDescriptions.

Note that this commit goes together with a commit in xtext-eclipse (see
https://github.com/eclipse/xtext-eclipse/pull/947/commits/8c30394d3bb904c2370d81afad9657575b361cd3).

Signed-off-by: Anders Dahlberg <anders.xb.dahlberg@ericsson.com>