### PR TITLE
Fixes an IllegalStateException during MWE execution

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/xtext/RuleNames.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/xtext/RuleNames.java
@@ -146,13 +146,15 @@ public class RuleNames {
 			String uniqueName = name;
 			String antlrRuleName;
 			if (names.containsKey(name)) {
+				names.put(name, rule);
 				name = qualifiedName;
 				uniqueName = getInheritedUniqueName(rule, usedUniqueNames);
 				antlrRuleName = getInheritedAntlrRuleName(rule, usedAntlrNames);
 			} else {
+				names.put(name, rule);
 				antlrRuleName = getDefaultAntlrRuleName(rule);
 			}
-			names.put(name, rule);
+
 			if (!usedUniqueNames.add(uniqueName)) {
 				throw new IllegalStateException(uniqueName);
 			}


### PR DESCRIPTION
In some cases when a super grammar is used, MWE fails with an
IllegalStateException. The name used to check agains the names
administration is overwritten with the qualified name, leading to an
attempt to add the same "uniqueName" twice.

Signed-off-by: Jelle Schuhmacher <jelle.schuhmacher@altran.com>