### PR TITLE
Fix ui tests

### DIFF
--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
@@ -59,7 +59,7 @@ abstract class TestProjectDescriptor extends ProjectDescriptor {
 		if (config.junitVersion == JUnitVersion.JUNIT_5) {
 			deps += new ExternalDependency()=>[
 				p2.bundleId = "org.junit.jupiter.api"
-				p2.version = "[5.0.0,6.0.0)"
+				p2.version = "[5.1.0,6.0.0)"
 				maven.groupId = "org.junit.jupiter"
 				maven.artifactId = "junit-jupiter-api"
 				maven.scope = Scope.TESTCOMPILE

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
@@ -59,7 +59,7 @@ abstract class TestProjectDescriptor extends ProjectDescriptor {
 		if (config.junitVersion == JUnitVersion.JUNIT_5) {
 			deps += new ExternalDependency()=>[
 				p2.bundleId = "org.junit.jupiter.api"
-				p2.version = "[5.1.0,6.0.0)"
+				p2.version = "[5.0.0,6.0.0)"
 				maven.groupId = "org.junit.jupiter"
 				maven.artifactId = "junit-jupiter-api"
 				maven.scope = Scope.TESTCOMPILE

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
@@ -108,7 +108,7 @@ public abstract class TestProjectDescriptor extends ProjectDescriptor {
         ExternalDependency.P2Coordinates _p2 = it.getP2();
         _p2.setBundleId("org.junit.jupiter.api");
         ExternalDependency.P2Coordinates _p2_1 = it.getP2();
-        _p2_1.setVersion("[5.1.0,6.0.0)");
+        _p2_1.setVersion("[5.0.0,6.0.0)");
         ExternalDependency.MavenCoordinates _maven = it.getMaven();
         _maven.setGroupId("org.junit.jupiter");
         ExternalDependency.MavenCoordinates _maven_1 = it.getMaven();

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
@@ -108,7 +108,7 @@ public abstract class TestProjectDescriptor extends ProjectDescriptor {
         ExternalDependency.P2Coordinates _p2 = it.getP2();
         _p2.setBundleId("org.junit.jupiter.api");
         ExternalDependency.P2Coordinates _p2_1 = it.getP2();
-        _p2_1.setVersion("[5.0.0,6.0.0)");
+        _p2_1.setVersion("[5.1.0,6.0.0)");
         ExternalDependency.MavenCoordinates _maven = it.getMaven();
         _maven.setGroupId("org.junit.jupiter");
         ExternalDependency.MavenCoordinates _maven_1 = it.getMaven();


### PR DESCRIPTION
Needed to fix failing UI tests (Actually the JUnit 5 minimal version is 5.0.0 instead of 5.1.0 for eclipse oxygen).