### PR TITLE
[performance] Improve isInstantiatableSubType

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/linking/lazy/LazyLinker.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/linking/lazy/LazyLinker.java
@@ -218,10 +218,9 @@ public class LazyLinker extends AbstractCleaningLinker {
 	}
 
 	protected EClass findInstantiableCompatible(EClass eType) {
-		if (!isInstantiatableSubType(eType, eType)) {
+		if (eType.isAbstract() || eType.isInterface()) {
 			// check local Package
-			EPackage ePackage = eType.getEPackage();
-			EClass eClass = findSubTypeInEPackage(ePackage, eType);
+			EClass eClass = findSubTypeInEPackage(eType.getEPackage(), eType);
 			if (eClass != null)
 				return eClass;
 			return globalFindInstantiableCompatible(eType);


### PR DESCRIPTION
Check the case that c == superType, which is always the case when called
from findInstantiableCompatible, and occasionally for calls from
findSubTypeInEPackage

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>