### PR TITLE
[eclipse/xtext#1283] Remove mavenCentral again

### DIFF
--- a/gradle/upstream-repositories.gradle
+++ b/gradle/upstream-repositories.gradle
@@ -24,7 +24,6 @@ def jenkinsPipelineRepo = { jobName, branch ->
 }
 
 repositories {
-  mavenCentral()
   jcenter()
   if (findProperty('useJenkinsSnapshots') == 'true') {
     maven { url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/$MVN_REPOPATH" }


### PR DESCRIPTION
MWE is now available on JCenter

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>