### PR TITLE
GH-1067: Exposed the Xtext index to the LS access.

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/LspExtensionTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/LspExtensionTest.xtend
@@ -42,5 +42,23 @@ class LspExtensionTest extends AbstractTestLangLanguageServerTest {
 		Assert.assertEquals("baz test", result.text)
 		Assert.assertEquals(2, notifications.map[value].filter(BuildNotification).size)
 	}
-	
+
+	@Test def void testExtension_readIndex() {
+		'model.testlang'.writeFile('''
+			type C {
+			  op baz() { }
+			}
+			type A {
+			  op foo() { }
+			}
+			type B {
+			  op bar() { }
+			}
+		''')
+		initialize
+		val ext = ServiceEndpoints.toServiceObject(languageServer, TestLangLSPExtension)
+		val actual = ext.allOpNames.get.toList.sort
+		Assert.assertEquals(#['bar', 'baz', 'foo'], actual)
+	}
+
 }

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/TestLangLSPExtension.xtend
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/TestLangLSPExtension.xtend
@@ -9,6 +9,7 @@ package org.eclipse.xtext.ide.tests.testlanguage.ide
 
 import com.google.inject.ImplementedBy
 import java.util.List
+import java.util.Set
 import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.jsonrpc.Endpoint
@@ -16,11 +17,12 @@ import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethodProvider
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
 import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints
+import org.eclipse.xtend.lib.annotations.ToString
 import org.eclipse.xtext.ide.server.ILanguageServerAccess
 import org.eclipse.xtext.ide.server.ILanguageServerAccess.IBuildListener
 import org.eclipse.xtext.ide.server.ILanguageServerExtension
 import org.eclipse.xtext.resource.IResourceDescription.Delta
-import org.eclipse.xtend.lib.annotations.ToString
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.TestLanguagePackage
 
 /**
  * @author efftinge - Initial contribution and API
@@ -30,6 +32,9 @@ interface TestLangLSPExtension extends ILanguageServerExtension {
 	
 	@JsonRequest
 	def CompletableFuture<TextOfLineResult> getTextOfLine(TextOfLineParam param)
+
+	@JsonRequest
+	def CompletableFuture<Set<String>> getAllOpNames()
 
 	static class TextOfLineResult {
 		public String text
@@ -84,6 +89,14 @@ interface TestLangLSPExtension extends ILanguageServerExtension {
 			result.putAll(ServiceEndpoints.getSupportedMethods(CustomClient))
 			return result
 		}
-		
+
+		override getAllOpNames() {
+			return access.doReadIndex([ context |
+				context.index.allResourceDescriptions.map[exportedObjects].flatten.filter [
+					EClass === TestLanguagePackage.Literals.OPERATION
+				].map[name.lastSegment].toSet
+			])
+		}
+
 	}
 }

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/LspExtensionTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/LspExtensionTest.java
@@ -8,12 +8,15 @@
 package org.eclipse.xtext.ide.tests.server;
 
 import com.google.common.collect.Iterables;
+import java.util.Collections;
+import java.util.List;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
 import org.eclipse.xtext.ide.tests.testlanguage.ide.TestLangLSPExtension;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
@@ -67,6 +70,41 @@ public class LspExtensionTest extends AbstractTestLangLanguageServerTest {
         return it.getValue();
       };
       Assert.assertEquals(2, IterableExtensions.size(Iterables.<TestLangLSPExtension.BuildNotification>filter(ListExtensions.<Pair<String, Object>, Object>map(this.notifications, _function_2), TestLangLSPExtension.BuildNotification.class)));
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testExtension_readIndex() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("type C {");
+      _builder.newLine();
+      _builder.append("  ");
+      _builder.append("op baz() { }");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      _builder.append("type A {");
+      _builder.newLine();
+      _builder.append("  ");
+      _builder.append("op foo() { }");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      _builder.append("type B {");
+      _builder.newLine();
+      _builder.append("  ");
+      _builder.append("op bar() { }");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      this.writeFile("model.testlang", _builder);
+      this.initialize();
+      final TestLangLSPExtension ext = ServiceEndpoints.<TestLangLSPExtension>toServiceObject(this.languageServer, TestLangLSPExtension.class);
+      final List<String> actual = IterableExtensions.<String>sort(IterableExtensions.<String>toList(ext.getAllOpNames().get()));
+      Assert.assertEquals(Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("bar", "baz", "foo")), actual);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ILanguageServerAccess.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ILanguageServerAccess.xtend
@@ -18,6 +18,7 @@ import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.xtend.lib.annotations.Data
 import org.eclipse.xtext.ide.serializer.IChangeSerializer
 import org.eclipse.xtext.resource.IResourceDescription
+import org.eclipse.xtext.resource.IResourceDescriptions
 import org.eclipse.xtext.util.CancelIndicator
 
 /**
@@ -35,11 +36,24 @@ interface ILanguageServerAccess {
 		CancelIndicator cancelChecker
 	}
 
+	@Data
+	static class IndexContext {
+		IResourceDescriptions index
+		CancelIndicator cancelChecker
+	}
+
 	/**
 	 * provides read access to a fully resolved resource and Document.
 	 */
 	def <T> CompletableFuture<T> doRead(String uri, Function<Context, T> function)
-	
+
+	/**
+	 * Provides read access to the Xtext index.
+	 * 
+	 * @since 2.18
+	 */
+	def <T> CompletableFuture<T> doReadIndex(Function<? super IndexContext, ? extends T> function)
+
 	static interface IBuildListener {
 		def void afterBuild(List<IResourceDescription.Delta> deltas)
 	}
@@ -62,9 +76,9 @@ interface ILanguageServerAccess {
 	 * In order not to mess up the originals, the resp. models should be loaded into a
 	 * new resource set which this method provides.
 	 * 
-	 * @param uri a file URI used to detect the project to configure the scoüpe of the resource set.
+	 * @param uri a file URI used to detect the project to configure the scope of the resource set.
 	 * @return a new empty resource set, configured with the project the <code>uri</code>
-	 *   belongs to and the {@link ResourceDescriptionsProvider.LIVE_SCOPE} in order to
+	 *   belongs to and the {@link ResourceDescriptionsProvider.LIVE_SCOPE} in order to
 	 *   reflect model changes immediately.
 	 * @since 2.18
 	 */

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.xtend
@@ -712,12 +712,12 @@ import static org.eclipse.xtext.diagnostics.Severity.*
 	ILanguageServerAccess access = new ILanguageServerAccess () {
 		
 		override <T> doRead(String uri, Function<Context, T> function) {
-				requestManager.runRead [ cancelIndicator |
-					workspaceManager.doRead(uri.toUri) [ document, resource |
-						val ctx = new Context(resource, document, workspaceManager.isDocumentOpen(resource.URI), cancelIndicator)
-						return function.apply(ctx)
-					]
+			requestManager.runRead [ cancelIndicator |
+				workspaceManager.doRead(uri.toUri) [ document, resource |
+					val ctx = new Context(resource, document, workspaceManager.isDocumentOpen(resource.URI), cancelIndicator)
+					return function.apply(ctx)
 				]
+			]
 		}
 		
 		override addBuildListener(IBuildListener listener) {
@@ -738,6 +738,14 @@ import static org.eclipse.xtext.diagnostics.Severity.*
 		override getInitializeParams() {
 			params
 		}
+
+		override <T> doReadIndex(Function<? super IndexContext, ? extends T> function) {
+			requestManager.runRead[ cancelIndicator |
+				val ctx = new IndexContext(workspaceManager.index, cancelIndicator)
+				return function.apply(ctx)
+			]
+		}
+
 	}
 	
 	override afterBuild(List<Delta> deltas) {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/ILanguageServerAccess.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/ILanguageServerAccess.java
@@ -19,6 +19,7 @@ import org.eclipse.xtend.lib.annotations.Data;
 import org.eclipse.xtext.ide.serializer.IChangeSerializer;
 import org.eclipse.xtext.ide.server.Document;
 import org.eclipse.xtext.resource.IResourceDescription;
+import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -121,6 +122,70 @@ public interface ILanguageServerAccess {
     }
   }
   
+  @Data
+  public static class IndexContext {
+    private final IResourceDescriptions index;
+    
+    private final CancelIndicator cancelChecker;
+    
+    public IndexContext(final IResourceDescriptions index, final CancelIndicator cancelChecker) {
+      super();
+      this.index = index;
+      this.cancelChecker = cancelChecker;
+    }
+    
+    @Override
+    @Pure
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((this.index== null) ? 0 : this.index.hashCode());
+      return prime * result + ((this.cancelChecker== null) ? 0 : this.cancelChecker.hashCode());
+    }
+    
+    @Override
+    @Pure
+    public boolean equals(final Object obj) {
+      if (this == obj)
+        return true;
+      if (obj == null)
+        return false;
+      if (getClass() != obj.getClass())
+        return false;
+      ILanguageServerAccess.IndexContext other = (ILanguageServerAccess.IndexContext) obj;
+      if (this.index == null) {
+        if (other.index != null)
+          return false;
+      } else if (!this.index.equals(other.index))
+        return false;
+      if (this.cancelChecker == null) {
+        if (other.cancelChecker != null)
+          return false;
+      } else if (!this.cancelChecker.equals(other.cancelChecker))
+        return false;
+      return true;
+    }
+    
+    @Override
+    @Pure
+    public String toString() {
+      ToStringBuilder b = new ToStringBuilder(this);
+      b.add("index", this.index);
+      b.add("cancelChecker", this.cancelChecker);
+      return b.toString();
+    }
+    
+    @Pure
+    public IResourceDescriptions getIndex() {
+      return this.index;
+    }
+    
+    @Pure
+    public CancelIndicator getCancelChecker() {
+      return this.cancelChecker;
+    }
+  }
+  
   public interface IBuildListener {
     public abstract void afterBuild(final List<IResourceDescription.Delta> deltas);
   }
@@ -129,6 +194,13 @@ public interface ILanguageServerAccess {
    * provides read access to a fully resolved resource and Document.
    */
   public abstract <T extends Object> CompletableFuture<T> doRead(final String uri, final Function<ILanguageServerAccess.Context, T> function);
+  
+  /**
+   * Provides read access to the Xtext index.
+   * 
+   * @since 2.18
+   */
+  public abstract <T extends Object> CompletableFuture<T> doReadIndex(final Function<? super ILanguageServerAccess.IndexContext, ? extends T> function);
   
   /**
    * registers a build listener on the this language server
@@ -148,9 +220,9 @@ public interface ILanguageServerAccess {
    * In order not to mess up the originals, the resp. models should be loaded into a
    * new resource set which this method provides.
    * 
-   * @param uri a file URI used to detect the project to configure the scoüpe of the resource set.
+   * @param uri a file URI used to detect the project to configure the scope of the resource set.
    * @return a new empty resource set, configured with the project the <code>uri</code>
-   *   belongs to and the {@link ResourceDescriptionsProvider.LIVE_SCOPE} in order to
+   *   belongs to and the {@link ResourceDescriptionsProvider.LIVE_SCOPE} in order to
    *   reflect model changes immediately.
    * @since 2.18
    */

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/LanguageServerImpl.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/LanguageServerImpl.java
@@ -1145,6 +1145,16 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
     public InitializeParams getInitializeParams() {
       return LanguageServerImpl.this.params;
     }
+    
+    @Override
+    public <T extends Object> CompletableFuture<T> doReadIndex(final Function<? super ILanguageServerAccess.IndexContext, ? extends T> function) {
+      final Function1<CancelIndicator, T> _function = (CancelIndicator cancelIndicator) -> {
+        IResourceDescriptions _index = LanguageServerImpl.this.workspaceManager.getIndex();
+        final ILanguageServerAccess.IndexContext ctx = new ILanguageServerAccess.IndexContext(_index, cancelIndicator);
+        return function.apply(ctx);
+      };
+      return LanguageServerImpl.this.requestManager.<T>runRead(_function);
+    }
   };
   
   @Override


### PR DESCRIPTION
From now on, it is possible to read the content of the Xtext
index from a LS access.

Closes #1067.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>