### PR TITLE
[#1066] get rid of org.eclipse.xtext.ecore.EcoreSupport again

### DIFF
--- a/org.eclipse.xtext.tests/build.gradle
+++ b/org.eclipse.xtext.tests/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compile project(':org.eclipse.xtext.xtext.generator')
 	compile project(':org.eclipse.xtext.xtext.wizard')
 	compile project(':org.eclipse.xtext.testlanguages')
+	mwe2Compile project(':org.eclipse.xtext.testlanguages')
 	compile 'junit:junit'
 	compile 'org.eclipse.emf:org.eclipse.emf.common'
 	compile 'org.eclipse.emf:org.eclipse.emf.ecore.xmi'

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/GenerateAllTestLanguages.mwe2
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/GenerateAllTestLanguages.mwe2
@@ -44,7 +44,7 @@ Workflow {
 		registerGeneratedEPackage = "org.eclipse.emf.ecore.EcorePackage"
 	}
 	
-	bean = org.eclipse.xtext.ecore.EcoreSupport {}
+	bean = org.eclipse.xtext.testlanguages.ecore.EcoreSupport {}
 	
 	component = DirectoryCleaner {
 		directory = "${runtimeProject}/src-gen"


### PR DESCRIPTION
[#1066] get rid of org.eclipse.xtext.ecore.EcoreSupport again
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>