### PR TITLE
Cleanup WS formatting in package org.eclipse.xtext.build

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/build/BuildContext.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/build/BuildContext.xtend
@@ -37,12 +37,12 @@ class BuildContext {
 	}
 	
 	protected def boolean canHandle(URI uri) {
-        val resourceServiceProvider = resourceServiceProviderProvider.apply(uri)
-        if (resourceServiceProvider === null)
-            return false
+		val resourceServiceProvider = resourceServiceProviderProvider.apply(uri)
+		if (resourceServiceProvider === null)
+			return false
 
-        return resourceServiceProvider.canHandle(uri)
-    }
+		return resourceServiceProvider.canHandle(uri)
+	}
 	
 	def getResourceServiceProvider(URI uri) {
 		val resourceServiceProvider = resourceServiceProviderProvider.apply(uri)

--- a/org.eclipse.xtext/src/org/eclipse/xtext/build/BuildRequest.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/build/BuildRequest.xtend
@@ -79,9 +79,9 @@ class BuildRequest {
 						LOG.debug(issue.toString())
 				}
 			}
-			return errorFree;	
+			return errorFree;
 		}
 		
 	}
 }
-	
+

--- a/org.eclipse.xtext/src/org/eclipse/xtext/build/IncrementalBuilder.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/build/IncrementalBuilder.xtend
@@ -58,26 +58,26 @@ class IncrementalBuilder {
 		@Inject extension OperationCanceledManager
 		
 		protected def void unloadResource(URI uri) {
-		    val resource = request.resourceSet.getResource(uri, false)
-            if (resource !== null) {
-                request.resourceSet.resources.remove(resource)
-                resource.unload
-            }
+			val resource = request.resourceSet.getResource(uri, false)
+			if (resource !== null) {
+				request.resourceSet.resources.remove(resource)
+				resource.unload
+			}
 		}
 		
 		def Result launch() {
 			val newSource2GeneratedMapping = request.state.fileMappings
 			val unloaded = newHashSet()
-		    for (deleted : request.deletedFiles) {
-                if (unloaded.add(deleted)) {
-                    unloadResource(deleted)
-                }
-            }
-            for (dirty : request.dirtyFiles) {
-                if (unloaded.add(dirty)) {
-                    unloadResource(dirty)
-                }
-            }
+			for (deleted : request.deletedFiles) {
+				if (unloaded.add(deleted)) {
+					unloadResource(deleted)
+				}
+			}
+			for (dirty : request.dirtyFiles) {
+				if (unloaded.add(dirty)) {
+					unloadResource(dirty)
+				}
+			}
 			request.deletedFiles.forEach [ source |
 				request.afterValidate.afterValidate(source, newArrayList)
 				newSource2GeneratedMapping.deleteSource(source).forEach [ generated |
@@ -93,11 +93,11 @@ class IncrementalBuilder {
 			]
 			val result = indexer.computeAndIndexAffected(request, context)
 			request.cancelIndicator.checkCanceled
-		    for (delta : result.resourceDeltas) {
-                if (unloaded.add(delta.uri)) {
-                    unloadResource(delta.uri)
-                }
-		    }
+			for (delta : result.resourceDeltas) {
+				if (unloaded.add(delta.uri)) {
+					unloadResource(delta.uri)
+				}
+			}
 			
 			val resolvedDeltas = newArrayList
 			// add deleted deltas
@@ -113,9 +113,9 @@ class IncrementalBuilder {
 					val serviceProvider = resource.resourceServiceProvider
 					val manager = serviceProvider.resourceDescriptionManager
 					val description = manager.getResourceDescription(resource);
-                    val copiedDescription = SerializableResourceDescription.createCopy(description);
-                    result.newIndex.addDescription(resource.getURI, copiedDescription)
-                    request.cancelIndicator.checkCanceled
+					val copiedDescription = SerializableResourceDescription.createCopy(description);
+					result.newIndex.addDescription(resource.getURI, copiedDescription)
+					request.cancelIndicator.checkCanceled
 					if (!request.indexOnly 
 						&& resource.validate 
 						&& serviceProvider.get(IShouldGenerate).shouldGenerate(resource, CancelIndicator.NullImpl)

--- a/org.eclipse.xtext/src/org/eclipse/xtext/build/Indexer.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/build/Indexer.xtend
@@ -143,9 +143,9 @@ class Indexer {
 			this.URI = original.getURI
 			this.exported = ImmutableList.copyOf(
 				original.exportedObjects.map [ IEObjectDescription from |
-				    if (from instanceof SerializableEObjectDescriptionProvider) {
-				        return from.toSerializableEObjectDescription()
-				    }
+					if (from instanceof SerializableEObjectDescriptionProvider) {
+						return from.toSerializableEObjectDescription()
+					}
 					if (from.getEObjectOrProxy.eIsProxy)
 						return from
 					var result = EcoreUtil.create(from.getEClass()) as InternalEObject
@@ -182,4 +182,4 @@ class Indexer {
 		}
 	}
 }
-				
+

--- a/org.eclipse.xtext/src/org/eclipse/xtext/build/Source2GeneratedMapping.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/build/Source2GeneratedMapping.xtend
@@ -35,7 +35,7 @@ import org.eclipse.xtext.generator.IFileSystemAccess
 	new() {
 		this(HashMultimap.create, HashMultimap.create, newHashMap)
 	}
-	  
+	
 	def copy() {
 		new Source2GeneratedMapping(HashMultimap.create(source2generated), HashMultimap.create(generated2source), new HashMap(generated2OutputConfigName))
 	}
@@ -109,6 +109,6 @@ import org.eclipse.xtext.generator.IFileSystemAccess
 				out.writeUTF(toString)
 				out.writeUTF(generated2OutputConfigName.get(it)?:IFileSystemAccess.DEFAULT_OUTPUT)
 			]
-		]		
+		]
 	}
 }


### PR DESCRIPTION
Mainly replace spaces by tabs. Sources are to a high grade already tab-indented.