### PR TITLE
[LS] overhauled rename service

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/RenameTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/RenameTest.xtend
@@ -39,13 +39,24 @@ class RenameTest extends AbstractTestLangLanguageServerTest {
 	}
 	
 	@Test
-	def void testRenameOnDeclaration() {
-		doTest(firstFile, new Position(0,5))
+	def void testRenameBeforeDeclaration() {
+		doTest(firstFile, new Position(0, 4))
 	}
 
 	@Test
+	def void testRenameOnDeclaration() {
+		doTest(firstFile, new Position(0, 5))
+	}
+
+	@Test
+	def void testRenameAfterDeclaration() {
+		doTest(firstFile, new Position(0, 8))
+	}
+
+
+	@Test
 	def void testRenameOnReference() {
-		doTest(firstFile, new Position(1,5))
+		doTest(firstFile, new Position(1, 5))
 	}
 	
 	@Test

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/RenameTest2.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/RenameTest2.xtend
@@ -12,6 +12,9 @@ import org.eclipse.lsp4j.RenameParams
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.xtext.testing.AbstractLanguageServerTest
 import org.junit.Test
+import org.eclipse.lsp4j.ClientCapabilities
+import org.eclipse.lsp4j.WorkspaceClientCapabilities
+import org.eclipse.lsp4j.WorkspaceEditCapabilities
 
 /**
  * @author koehnlein - Initial contribution and API
@@ -38,9 +41,9 @@ class RenameTest2 extends AbstractLanguageServerTest {
         val workspaceEdit = languageServer.rename(params).get
         assertEquals('''
 			changes :
-			    Foo.fileawaretestlanguage : Bar [[2, 8] .. [2, 11]]
-			    Bar [[3, 5] .. [3, 8]]
 			documentChanges : 
+			    Foo.fileawaretestlanguage <1> : Bar [[2, 8] .. [2, 11]]
+			    Bar [[3, 5] .. [3, 8]]
         '''.toString, toExpectation(workspaceEdit))
 	}
 	
@@ -64,11 +67,21 @@ class RenameTest2 extends AbstractLanguageServerTest {
         val workspaceEdit = languageServer.rename(params).get
         assertEquals('''
 			changes :
-			    Foo.fileawaretestlanguage : Baz [[2, 8] .. [2, 11]]
+			documentChanges : 
+			    Foo.fileawaretestlanguage <1> : Baz [[2, 8] .. [2, 11]]
 			    Bar [[5, 5] .. [5, 16]]
 			    Bar [[6, 5] .. [6, 12]]
-			documentChanges : 
         '''.toString, toExpectation(workspaceEdit))
 	}
 	
+	
+	override protected initialize() {
+		super.initialize([params | params.capabilities = new ClientCapabilities => [
+			workspace = new WorkspaceClientCapabilities => [
+				workspaceEdit = new WorkspaceEditCapabilities => [
+					documentChanges = true
+				]
+			]
+		]])
+ 	}
 }

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/CompletionTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/CompletionTest.java
@@ -28,7 +28,9 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticHighlightingInformation;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtend2.lib.StringConcatenation;
@@ -334,6 +336,8 @@ public class CompletionTest extends AbstractTestLangLanguageServerTest {
       return _toExpectation((DocumentHighlightKind)it);
     } else if (it instanceof String) {
       return _toExpectation((String)it);
+    } else if (it instanceof VersionedTextDocumentIdentifier) {
+      return _toExpectation((VersionedTextDocumentIdentifier)it);
     } else if (it instanceof Pair) {
       return _toExpectation((Pair<SemanticHighlightingInformation, List<List<String>>>)it);
     } else if (it == null) {
@@ -366,6 +370,8 @@ public class CompletionTest extends AbstractTestLangLanguageServerTest {
       return _toExpectation((SignatureHelp)it);
     } else if (it instanceof SymbolInformation) {
       return _toExpectation((SymbolInformation)it);
+    } else if (it instanceof TextDocumentEdit) {
+      return _toExpectation((TextDocumentEdit)it);
     } else if (it instanceof TextEdit) {
       return _toExpectation((TextEdit)it);
     } else if (it instanceof WorkspaceEdit) {

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/RenameTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/RenameTest.java
@@ -52,8 +52,20 @@ public class RenameTest extends AbstractTestLangLanguageServerTest {
   }
   
   @Test
+  public void testRenameBeforeDeclaration() {
+    Position _position = new Position(0, 4);
+    this.doTest(this.firstFile, _position);
+  }
+  
+  @Test
   public void testRenameOnDeclaration() {
     Position _position = new Position(0, 5);
+    this.doTest(this.firstFile, _position);
+  }
+  
+  @Test
+  public void testRenameAfterDeclaration() {
+    Position _position = new Position(0, 8);
     this.doTest(this.firstFile, _position);
   }
   

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/RenameTest2.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/RenameTest2.java
@@ -7,13 +7,20 @@
  */
 package org.eclipse.xtext.ide.tests.server;
 
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.WorkspaceEditCapabilities;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.testing.AbstractLanguageServerTest;
 import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Test;
 
 /**
@@ -49,13 +56,13 @@ public class RenameTest2 extends AbstractLanguageServerTest {
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("changes :");
       _builder_1.newLine();
+      _builder_1.append("documentChanges : ");
+      _builder_1.newLine();
       _builder_1.append("    ");
-      _builder_1.append("Foo.fileawaretestlanguage : Bar [[2, 8] .. [2, 11]]");
+      _builder_1.append("Foo.fileawaretestlanguage <1> : Bar [[2, 8] .. [2, 11]]");
       _builder_1.newLine();
       _builder_1.append("    ");
       _builder_1.append("Bar [[3, 5] .. [3, 8]]");
-      _builder_1.newLine();
-      _builder_1.append("documentChanges : ");
       _builder_1.newLine();
       this.assertEquals(_builder_1.toString(), this.toExpectation(workspaceEdit));
     } catch (Throwable _e) {
@@ -99,8 +106,10 @@ public class RenameTest2 extends AbstractLanguageServerTest {
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("changes :");
       _builder_1.newLine();
+      _builder_1.append("documentChanges : ");
+      _builder_1.newLine();
       _builder_1.append("    ");
-      _builder_1.append("Foo.fileawaretestlanguage : Baz [[2, 8] .. [2, 11]]");
+      _builder_1.append("Foo.fileawaretestlanguage <1> : Baz [[2, 8] .. [2, 11]]");
       _builder_1.newLine();
       _builder_1.append("    ");
       _builder_1.append("Bar [[5, 5] .. [5, 16]]");
@@ -108,11 +117,32 @@ public class RenameTest2 extends AbstractLanguageServerTest {
       _builder_1.append("    ");
       _builder_1.append("Bar [[6, 5] .. [6, 12]]");
       _builder_1.newLine();
-      _builder_1.append("documentChanges : ");
-      _builder_1.newLine();
       this.assertEquals(_builder_1.toString(), this.toExpectation(workspaceEdit));
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
+  }
+  
+  @Override
+  protected InitializeResult initialize() {
+    final Procedure1<InitializeParams> _function = (InitializeParams params) -> {
+      ClientCapabilities _clientCapabilities = new ClientCapabilities();
+      final Procedure1<ClientCapabilities> _function_1 = (ClientCapabilities it) -> {
+        WorkspaceClientCapabilities _workspaceClientCapabilities = new WorkspaceClientCapabilities();
+        final Procedure1<WorkspaceClientCapabilities> _function_2 = (WorkspaceClientCapabilities it_1) -> {
+          WorkspaceEditCapabilities _workspaceEditCapabilities = new WorkspaceEditCapabilities();
+          final Procedure1<WorkspaceEditCapabilities> _function_3 = (WorkspaceEditCapabilities it_2) -> {
+            it_2.setDocumentChanges(Boolean.valueOf(true));
+          };
+          WorkspaceEditCapabilities _doubleArrow = ObjectExtensions.<WorkspaceEditCapabilities>operator_doubleArrow(_workspaceEditCapabilities, _function_3);
+          it_1.setWorkspaceEdit(_doubleArrow);
+        };
+        WorkspaceClientCapabilities _doubleArrow = ObjectExtensions.<WorkspaceClientCapabilities>operator_doubleArrow(_workspaceClientCapabilities, _function_2);
+        it.setWorkspace(_doubleArrow);
+      };
+      ClientCapabilities _doubleArrow = ObjectExtensions.<ClientCapabilities>operator_doubleArrow(_clientCapabilities, _function_1);
+      params.setCapabilities(_doubleArrow);
+    };
+    return super.initialize(_function);
   }
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/ChangeConverter.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/ChangeConverter.xtend
@@ -14,10 +14,14 @@ import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.emf.ecore.xmi.XMLResource
 import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextDocumentEdit
 import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
 import org.eclipse.lsp4j.WorkspaceEdit
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.xtext.ide.serializer.IEmfResourceChange
 import org.eclipse.xtext.ide.serializer.ITextDocumentChange
+import org.eclipse.xtext.ide.server.Document
 import org.eclipse.xtext.ide.server.WorkspaceManager
 import org.eclipse.xtext.parser.IEncodingProvider
 import org.eclipse.xtext.resource.IResourceServiceProvider
@@ -31,21 +35,35 @@ class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 
 	static class Factory {
 
-		@Inject IResourceServiceProvider.Registry registry
+		@Inject protected IResourceServiceProvider.Registry registry
 
+		/**
+		 * @deprecated use {@link #create(WorkspaceManager, WorkspaceEdit, boolean} instead.
+		 */
+		@Deprecated
 		def ChangeConverter create(WorkspaceManager workspaceManager, WorkspaceEdit edit) {
-			new ChangeConverter(workspaceManager, registry, edit)
+			new ChangeConverter(workspaceManager, registry, edit, null)
+		}
+
+		def ChangeConverter create(WorkspaceManager workspaceManager, WorkspaceEdit edit, IRenameServiceExtension.Options options) {
+			new ChangeConverter(workspaceManager, registry, edit, options)
 		}
 	}
 
 	val WorkspaceManager workspaceManager
 	val IResourceServiceProvider.Registry registry
 	val WorkspaceEdit edit
+	val IRenameServiceExtension.Options options
 	
-	protected new(WorkspaceManager workspaceManager, IResourceServiceProvider.Registry registry, WorkspaceEdit edit) {
+	protected new(WorkspaceManager workspaceManager, IResourceServiceProvider.Registry registry, WorkspaceEdit edit, IRenameServiceExtension.Options options) {
 		this.workspaceManager = workspaceManager
 		this.registry = registry
 		this.edit = edit
+		this.options = options
+		if (options?.clientSupportsVerisonedDocuments)
+			this.edit.documentChanges = newArrayList 
+		else
+			this.edit.changes = newLinkedHashMap
 	}
 
 	override accept(IEmfResourceChange change) {
@@ -61,7 +79,7 @@ class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 			workspaceManager.doRead(uri) [ document, resource |
 				val range = new Range(document.getPosition(0), document.getPosition(document.contents.length))
 				val textEdit = new TextEdit(range, newContent)
-				addTextEdit(uri, textEdit)
+				addTextEdit(uri, document, textEdit)
 			]
 		} finally {
 			outputStream.close
@@ -88,12 +106,24 @@ class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 					val range = new Range(start, end)
 					new TextEdit(range, replacement.replacementText)
 				]
-				addTextEdit(uri, textEdits)
+				addTextEdit(uri, document, textEdits)
 			]
 		}
 	}
 	
-	protected def addTextEdit(URI uri, TextEdit... textEdit) {
-		edit.changes.put(uri.toString, textEdit)
+	protected def addTextEdit(URI theUri, Document document, TextEdit... textEdits) {
+		if (options?.clientSupportsVerisonedDocuments) {
+			edit.documentChanges +=  
+				Either.forLeft(new TextDocumentEdit => [
+					textDocument = new VersionedTextDocumentIdentifier => [
+						uri = theUri.toString
+						version = document.version
+					]
+					edits = textEdits
+				])			
+		} else {
+			edit.changes.put(theUri.toString, textEdits)
+		}
 	}
+	
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/IRenameService.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/IRenameService.xtend
@@ -9,13 +9,34 @@ package org.eclipse.xtext.ide.server.rename
 
 import org.eclipse.lsp4j.RenameParams
 import org.eclipse.lsp4j.WorkspaceEdit
+import org.eclipse.xtend.lib.annotations.Data
 import org.eclipse.xtext.ide.server.WorkspaceManager
 import org.eclipse.xtext.util.CancelIndicator
 
 /**
  * @author koehnlein - Initial contribution and API
  * @since 2.13
+ * @deprectated implement IRenameService2 instead.
  */
+@Deprecated
 interface IRenameService {
 	def WorkspaceEdit rename(WorkspaceManager workspaceManager, RenameParams renameParams, CancelIndicator cancelIndicator) 
+}
+
+/**
+ * The implementation of rename refactoring for a language.
+ * 
+ * As opposed to {@link IRenameService} this returns {@link TextDocumentChanges} if the 
+ * client supports versioned documents.
+ * 
+ * @author koehnlein - Initial contribution and API
+ * @since 2.17
+ */
+interface IRenameServiceExtension {
+	def WorkspaceEdit rename(WorkspaceManager workspaceManager, RenameParams renameParams, Options options, CancelIndicator cancelIndicator)
+
+	@Data
+	class Options {
+		boolean clientSupportsVerisonedDocuments
+	}
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/RenameService.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/RenameService.xtend
@@ -9,59 +9,86 @@ package org.eclipse.xtext.ide.server.rename
 
 import com.google.inject.Inject
 import com.google.inject.Provider
+import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.util.EcoreUtil
+import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.RenameParams
 import org.eclipse.lsp4j.WorkspaceEdit
+import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtext.TerminalRule
+import org.eclipse.xtext.ide.refactoring.IRenameStrategy2
 import org.eclipse.xtext.ide.refactoring.RenameChange
 import org.eclipse.xtext.ide.refactoring.RenameContext
 import org.eclipse.xtext.ide.serializer.IChangeSerializer
+import org.eclipse.xtext.ide.server.Document
 import org.eclipse.xtext.ide.server.UriExtensions
 import org.eclipse.xtext.ide.server.WorkspaceManager
+import org.eclipse.xtext.nodemodel.ILeafNode
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils
+import org.eclipse.xtext.parsetree.reconstr.impl.TokenUtil
 import org.eclipse.xtext.resource.EObjectAtOffsetHelper
+import org.eclipse.xtext.resource.IResourceServiceProvider
 import org.eclipse.xtext.resource.XtextResource
-import org.eclipse.xtext.util.CancelIndicator
-import static org.eclipse.xtext.ide.refactoring.RefactoringIssueAcceptor.Severity.*
-import org.eclipse.xtext.ide.refactoring.IRenameStrategy2
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsProvider
+import org.eclipse.xtext.util.CancelIndicator
+
+import static org.eclipse.xtext.ide.refactoring.RefactoringIssueAcceptor.Severity.*
 
 /**
  * @author koehnlein - Initial contribution and API
  * @since 2.13
  */
-class RenameService implements IRenameService {
+@Accessors(PROTECTED_GETTER)
+class RenameService implements IRenameService, IRenameServiceExtension {
 	
-	@Inject extension EObjectAtOffsetHelper
+	@Inject extension EObjectAtOffsetHelper eObjectAtOffsetHelper
 	
 	@Inject IRenameStrategy2 renameStrategy 
 	
 	@Inject ChangeConverter.Factory converterFactory
 	
-	@Inject extension UriExtensions
+	@Inject extension UriExtensions uriExtensions
 	
 	@Inject Provider<IChangeSerializer> changeSerializerProvider
 	
 	@Inject Provider<ServerRefactoringIssueAcceptor> issueProvider
 	
+	@Inject IResourceServiceProvider.Registry serviceProviderRegistry
+	
+	@Inject TokenUtil tokenUtil
+	
+	/**
+	 * @deprecated use {@link #rename(WorkspaceManager, RenameParams, Options, CancelIndicator)} 
+	 *    instead.
+	 */
+	@Deprecated
 	override rename(WorkspaceManager workspaceManager, RenameParams renameParams, CancelIndicator cancelIndicator) {
+		rename(workspaceManager, renameParams, new Options(false), cancelIndicator)
+	}
+	
+	override rename(WorkspaceManager workspaceManager, RenameParams renameParams, Options options, CancelIndicator cancelIndicator) {
 		val uri = renameParams.textDocument.uri.toUri
 		val issueAcceptor = issueProvider.get
-		workspaceManager.doRead(uri) [ document, resource | 
+		workspaceManager.doRead(uri) [ document, resource |
 			val projectManager = workspaceManager.getProjectManager(uri)
 			val resourceSet = projectManager.createNewResourceSet(projectManager.indexState.resourceDescriptions)
 			resourceSet.loadOptions.put(ResourceDescriptionsProvider.LIVE_SCOPE, true)
-			val offset = document.getOffSet(renameParams.position)
 			val workspaceEdit = new WorkspaceEdit
 			val xtextResource = resourceSet.getResource(resource.URI, true)
 			if (xtextResource instanceof XtextResource) {
-				val element = xtextResource.resolveElementAt(offset)
+				val element = xtextResource.getElementAtOffset(document, renameParams.position)
 				if (element === null || element.eIsProxy) {
-					issueAcceptor.add(FATAL, '''No element found at position line:«renameParams.position.line» column:«renameParams.position.character»''')
+					issueAcceptor.add(
+						FATAL, '''No element found at position line:«renameParams.position.line» column:«renameParams.position.character»''')
 				} else {
+					val services = serviceProviderRegistry.getResourceServiceProvider(element.eResource.URI)
+					val changeSerializer = services.get(IChangeSerializer)
 					val change = new RenameChange(renameParams.newName, EcoreUtil.getURI(element))
-					val changeSerializer = changeSerializerProvider.get
 					val context = new RenameContext(#[change], resourceSet, changeSerializer, issueAcceptor)
+					val renameStrategy = services.get(IRenameStrategy2)
 					renameStrategy.applyRename(context)
-					val changeConverter = converterFactory.create(workspaceManager, workspaceEdit)
+					val converterFactory = services.get(ChangeConverter.Factory)
+					val changeConverter = converterFactory.create(workspaceManager, workspaceEdit, options)
 					changeSerializer.applyModifications(changeConverter)
 				}
 			} else {
@@ -69,5 +96,20 @@ class RenameService implements IRenameService {
 			}
 			return workspaceEdit
 		]
+	}
+
+	protected def EObject getElementAtOffset(XtextResource xtextResource, Document document, Position caretPosition) {
+		val caretOffset = document.getOffSet(caretPosition)
+		val leafNode = NodeModelUtils.findLeafNodeAtOffset(xtextResource.parseResult.rootNode, caretOffset)
+		val offset = if (caretOffset > 0 && leafNode.offset === caretOffset && !isIdentifier(leafNode)) 
+				caretOffset - 1
+			else 
+				caretOffset
+		return xtextResource.resolveElementAt(offset)
+	}
+	
+	protected def isIdentifier(ILeafNode leafNode) {
+		return leafNode.grammarElement instanceof TerminalRule
+			&& !tokenUtil.isWhitespaceOrCommentNode(leafNode) 
 	}
 }

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/LanguageServerImpl.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/LanguageServerImpl.java
@@ -83,6 +83,7 @@ import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.WorkspaceEditCapabilities;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.jsonrpc.Endpoint;
 import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod;
@@ -120,6 +121,7 @@ import org.eclipse.xtext.ide.server.formatting.FormattingService;
 import org.eclipse.xtext.ide.server.hover.IHoverService;
 import org.eclipse.xtext.ide.server.occurrences.IDocumentHighlightService;
 import org.eclipse.xtext.ide.server.rename.IRenameService;
+import org.eclipse.xtext.ide.server.rename.IRenameServiceExtension;
 import org.eclipse.xtext.ide.server.semanticHighlight.SemanticHighlightingRegistry;
 import org.eclipse.xtext.ide.server.signatureHelp.ISignatureHelpService;
 import org.eclipse.xtext.ide.server.symbol.DocumentSymbolService;
@@ -925,11 +927,11 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
   }
   
   @Override
-  public CompletableFuture<WorkspaceEdit> rename(final RenameParams params) {
+  public CompletableFuture<WorkspaceEdit> rename(final RenameParams renameParams) {
     final Function1<CancelIndicator, WorkspaceEdit> _function = (CancelIndicator cancelIndicator) -> {
       WorkspaceEdit _xblockexpression = null;
       {
-        final URI uri = this._uriExtensions.toUri(params.getTextDocument().getUri());
+        final URI uri = this._uriExtensions.toUri(renameParams.getTextDocument().getUri());
         final IResourceServiceProvider resourceServiceProvider = this.languagesRegistry.getResourceServiceProvider(uri);
         IRenameService _get = null;
         if (resourceServiceProvider!=null) {
@@ -939,7 +941,35 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
         if ((renameService == null)) {
           return new WorkspaceEdit();
         }
-        _xblockexpression = renameService.rename(this.workspaceManager, params, cancelIndicator);
+        WorkspaceEdit _xifexpression = null;
+        if ((renameService instanceof IRenameServiceExtension)) {
+          WorkspaceEdit _xblockexpression_1 = null;
+          {
+            ClientCapabilities _capabilities = null;
+            if (this.params!=null) {
+              _capabilities=this.params.getCapabilities();
+            }
+            WorkspaceClientCapabilities _workspace = null;
+            if (_capabilities!=null) {
+              _workspace=_capabilities.getWorkspace();
+            }
+            WorkspaceEditCapabilities _workspaceEdit = null;
+            if (_workspace!=null) {
+              _workspaceEdit=_workspace.getWorkspaceEdit();
+            }
+            Boolean _documentChanges = null;
+            if (_workspaceEdit!=null) {
+              _documentChanges=_workspaceEdit.getDocumentChanges();
+            }
+            boolean _tripleEquals = (_documentChanges == Boolean.TRUE);
+            final IRenameServiceExtension.Options options = new IRenameServiceExtension.Options(_tripleEquals);
+            _xblockexpression_1 = ((IRenameServiceExtension)renameService).rename(this.workspaceManager, renameParams, options, cancelIndicator);
+          }
+          _xifexpression = _xblockexpression_1;
+        } else {
+          _xifexpression = renameService.rename(this.workspaceManager, renameParams, cancelIndicator);
+        }
+        _xblockexpression = _xifexpression;
       }
       return _xblockexpression;
     };

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/rename/IRenameService.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/rename/IRenameService.java
@@ -15,7 +15,9 @@ import org.eclipse.xtext.util.CancelIndicator;
 /**
  * @author koehnlein - Initial contribution and API
  * @since 2.13
+ * @deprectated implement IRenameService2 instead.
  */
+@Deprecated
 @SuppressWarnings("all")
 public interface IRenameService {
   public abstract WorkspaceEdit rename(final WorkspaceManager workspaceManager, final RenameParams renameParams, final CancelIndicator cancelIndicator);

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/rename/IRenameServiceExtension.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/rename/IRenameServiceExtension.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.server.rename;
+
+import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.xtend.lib.annotations.Data;
+import org.eclipse.xtext.ide.server.WorkspaceManager;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * The implementation of rename refactoring for a language.
+ * 
+ * As opposed to {@link IRenameService} this returns {@link TextDocumentChanges} if the
+ * client supports versioned documents.
+ * 
+ * @author koehnlein - Initial contribution and API
+ * @since 2.17
+ */
+@SuppressWarnings("all")
+public interface IRenameServiceExtension {
+  @Data
+  public static class Options {
+    private final boolean clientSupportsVerisonedDocuments;
+    
+    public Options(final boolean clientSupportsVerisonedDocuments) {
+      super();
+      this.clientSupportsVerisonedDocuments = clientSupportsVerisonedDocuments;
+    }
+    
+    @Override
+    @Pure
+    public int hashCode() {
+      return 31 * 1 + (this.clientSupportsVerisonedDocuments ? 1231 : 1237);
+    }
+    
+    @Override
+    @Pure
+    public boolean equals(final Object obj) {
+      if (this == obj)
+        return true;
+      if (obj == null)
+        return false;
+      if (getClass() != obj.getClass())
+        return false;
+      IRenameServiceExtension.Options other = (IRenameServiceExtension.Options) obj;
+      if (other.clientSupportsVerisonedDocuments != this.clientSupportsVerisonedDocuments)
+        return false;
+      return true;
+    }
+    
+    @Override
+    @Pure
+    public String toString() {
+      ToStringBuilder b = new ToStringBuilder(this);
+      b.add("clientSupportsVerisonedDocuments", this.clientSupportsVerisonedDocuments);
+      return b.toString();
+    }
+    
+    @Pure
+    public boolean isClientSupportsVerisonedDocuments() {
+      return this.clientSupportsVerisonedDocuments;
+    }
+  }
+  
+  public abstract WorkspaceEdit rename(final WorkspaceManager workspaceManager, final RenameParams renameParams, final IRenameServiceExtension.Options options, final CancelIndicator cancelIndicator);
+}

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
@@ -54,10 +54,12 @@ import org.eclipse.lsp4j.SemanticHighlightingInformation
 import org.eclipse.lsp4j.SemanticHighlightingParams
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.SymbolInformation
+import org.eclipse.lsp4j.TextDocumentEdit
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentItem
 import org.eclipse.lsp4j.TextDocumentPositionParams
 import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.WorkspaceSymbolParams
 import org.eclipse.lsp4j.jsonrpc.Endpoint
@@ -418,6 +420,15 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		«IF !diagnostics.nullOrEmpty»codes : «diagnostics.map[code].join(',')»«ENDIF»
 		edit : «edit.toExpectation»
 	'''
+	
+	protected def dispatch String toExpectation(TextDocumentEdit e) '''
+		«e.textDocument.toExpectation» : «e.edits.toExpectation»
+	'''
+
+	protected def dispatch String toExpectation(VersionedTextDocumentIdentifier v) 
+		'''«org.eclipse.emf.common.util.URI.createURI(v.uri).lastSegment» <«v.version»>'''
+	
+	
 	
 	@Accessors static class TestCodeActionConfiguration extends TextDocumentPositionConfiguration {
 		String expectedCodeActions = ''

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
@@ -67,6 +67,7 @@ import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.SignatureInformation;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
@@ -936,6 +937,28 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
     return _builder.toString();
   }
   
+  protected String _toExpectation(final TextDocumentEdit e) {
+    StringConcatenation _builder = new StringConcatenation();
+    String _expectation = this.toExpectation(e.getTextDocument());
+    _builder.append(_expectation);
+    _builder.append(" : ");
+    String _expectation_1 = this.toExpectation(e.getEdits());
+    _builder.append(_expectation_1);
+    _builder.newLineIfNotEmpty();
+    return _builder.toString();
+  }
+  
+  protected String _toExpectation(final VersionedTextDocumentIdentifier v) {
+    StringConcatenation _builder = new StringConcatenation();
+    String _lastSegment = org.eclipse.emf.common.util.URI.createURI(v.getUri()).lastSegment();
+    _builder.append(_lastSegment);
+    _builder.append(" <");
+    Integer _version = v.getVersion();
+    _builder.append(_version);
+    _builder.append(">");
+    return _builder.toString();
+  }
+  
   protected void testCodeAction(final Procedure1<? super AbstractLanguageServerTest.TestCodeActionConfiguration> configurator) {
     try {
       @Extension
@@ -1459,6 +1482,8 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
       return _toExpectation((DocumentHighlightKind)it);
     } else if (it instanceof String) {
       return _toExpectation((String)it);
+    } else if (it instanceof VersionedTextDocumentIdentifier) {
+      return _toExpectation((VersionedTextDocumentIdentifier)it);
     } else if (it instanceof Pair) {
       return _toExpectation((Pair<SemanticHighlightingInformation, List<List<String>>>)it);
     } else if (it == null) {
@@ -1491,6 +1516,8 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
       return _toExpectation((SignatureHelp)it);
     } else if (it instanceof SymbolInformation) {
       return _toExpectation((SymbolInformation)it);
+    } else if (it instanceof TextDocumentEdit) {
+      return _toExpectation((TextDocumentEdit)it);
     } else if (it instanceof TextEdit) {
       return _toExpectation((TextEdit)it);
     } else if (it instanceof WorkspaceEdit) {


### PR DESCRIPTION
- delegate to rename language of the declaration of the renamed target
- allow to trigger rename with caret right after the identifier
- support versioned documents

Closes #917, closes #916 and closes #1072