### PR TITLE
[#1076] Remove BOM managed versions

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.ide/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.ide/pom.xml
@@ -13,27 +13,22 @@
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
-			<version>1.2.16</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lsp4j</groupId>
 			<artifactId>org.eclipse.lsp4j</artifactId>
-			<version>0.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm</artifactId>
-			<version>7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm-commons</artifactId>
-			<version>7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm-tree</artifactId>
-			<version>7.0</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.ide/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.ide/pom.xml
@@ -13,27 +13,22 @@
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
-			<version>1.2.16</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lsp4j</groupId>
 			<artifactId>org.eclipse.lsp4j</artifactId>
-			<version>0.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm</artifactId>
-			<version>7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm-commons</artifactId>
-			<version>7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm-tree</artifactId>
-			<version>7.0</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/IdeProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/IdeProjectDescriptor.xtend
@@ -50,27 +50,22 @@ class IdeProjectDescriptor extends ProjectDescriptor {
 						<dependency>
 							<groupId>log4j</groupId>
 							<artifactId>log4j</artifactId>
-							<version>1.2.16</version>
 						</dependency>
 						<dependency>
 							<groupId>org.eclipse.lsp4j</groupId>
 							<artifactId>org.eclipse.lsp4j</artifactId>
-							<version>0.7.0</version>
 						</dependency>
 						<dependency>
 							<groupId>org.ow2.asm</groupId>
 							<artifactId>asm</artifactId>
-							<version>7.0</version>
 						</dependency>
 						<dependency>
 							<groupId>org.ow2.asm</groupId>
 							<artifactId>asm-commons</artifactId>
-							<version>7.0</version>
 						</dependency>
 						<dependency>
 							<groupId>org.ow2.asm</groupId>
 							<artifactId>asm-tree</artifactId>
-							<version>7.0</version>
 						</dependency>
 					</dependencies>
 				«ENDIF»

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/IdeProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/IdeProjectDescriptor.java
@@ -91,9 +91,6 @@ public class IdeProjectDescriptor extends ProjectDescriptor {
           _builder.append("\t\t");
           _builder.append("<artifactId>log4j</artifactId>");
           _builder.newLine();
-          _builder.append("\t\t");
-          _builder.append("<version>1.2.16</version>");
-          _builder.newLine();
           _builder.append("\t");
           _builder.append("</dependency>");
           _builder.newLine();
@@ -105,9 +102,6 @@ public class IdeProjectDescriptor extends ProjectDescriptor {
           _builder.newLine();
           _builder.append("\t\t");
           _builder.append("<artifactId>org.eclipse.lsp4j</artifactId>");
-          _builder.newLine();
-          _builder.append("\t\t");
-          _builder.append("<version>0.7.0</version>");
           _builder.newLine();
           _builder.append("\t");
           _builder.append("</dependency>");
@@ -121,9 +115,6 @@ public class IdeProjectDescriptor extends ProjectDescriptor {
           _builder.append("\t\t");
           _builder.append("<artifactId>asm</artifactId>");
           _builder.newLine();
-          _builder.append("\t\t");
-          _builder.append("<version>7.0</version>");
-          _builder.newLine();
           _builder.append("\t");
           _builder.append("</dependency>");
           _builder.newLine();
@@ -136,9 +127,6 @@ public class IdeProjectDescriptor extends ProjectDescriptor {
           _builder.append("\t\t");
           _builder.append("<artifactId>asm-commons</artifactId>");
           _builder.newLine();
-          _builder.append("\t\t");
-          _builder.append("<version>7.0</version>");
-          _builder.newLine();
           _builder.append("\t");
           _builder.append("</dependency>");
           _builder.newLine();
@@ -150,9 +138,6 @@ public class IdeProjectDescriptor extends ProjectDescriptor {
           _builder.newLine();
           _builder.append("\t\t");
           _builder.append("<artifactId>asm-tree</artifactId>");
-          _builder.newLine();
-          _builder.append("\t\t");
-          _builder.append("<version>7.0</version>");
           _builder.newLine();
           _builder.append("\t");
           _builder.append("</dependency>");


### PR DESCRIPTION
Dependency versions are obsolete since they are managed by the BOM.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>