### PR TITLE
Added removeBuildListener to WorkspaceManager

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/WorkspaceManager.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/WorkspaceManager.xtend
@@ -56,6 +56,15 @@ import org.eclipse.xtext.workspace.IWorkspaceConfig
 		this.buildListeners += listener
 	}
 
+	/**
+	 * Removes a build listener if it was previously registered
+	 * 
+	 * @since 2.18
+	 */
+	def void removeBuildListener(IBuildListener listener) {
+		buildListeners.remove(listener)
+	}
+
 	Map<String, ResourceDescriptionsData> fullIndex = newHashMap()
 
 	Map<URI, Document> openDocuments = newHashMap()

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/WorkspaceManager.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/WorkspaceManager.java
@@ -79,6 +79,15 @@ public class WorkspaceManager {
     this.buildListeners.add(listener);
   }
   
+  /**
+   * Removes a build listener if it was previously registered
+   * 
+   * @since 2.18
+   */
+  public void removeBuildListener(final ILanguageServerAccess.IBuildListener listener) {
+    this.buildListeners.remove(listener);
+  }
+  
   private Map<String, ResourceDescriptionsData> fullIndex = CollectionLiterals.<String, ResourceDescriptionsData>newHashMap();
   
   private Map<URI, Document> openDocuments = CollectionLiterals.<URI, Document>newHashMap();


### PR DESCRIPTION
There was an add, but no remove effectively creating a memory leak by
keeping dead listeners around.