### PR TITLE
[lsp] some build performance tuning

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/build/IncrementalBuilder.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/build/IncrementalBuilder.xtend
@@ -94,7 +94,7 @@ class IncrementalBuilder {
 			val result = indexer.computeAndIndexAffected(request, context)
 			request.cancelIndicator.checkCanceled
 			for (delta : result.resourceDeltas) {
-				if (unloaded.add(delta.uri)) {
+				if (delta.old !== null && unloaded.add(delta.uri)) {
 					unloadResource(delta.uri)
 				}
 			}

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/build/IncrementalBuilder.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/build/IncrementalBuilder.java
@@ -259,8 +259,7 @@ public class IncrementalBuilder {
       this._operationCanceledManager.checkCanceled(this.request.getCancelIndicator());
       List<IResourceDescription.Delta> _resourceDeltas = result.getResourceDeltas();
       for (final IResourceDescription.Delta delta : _resourceDeltas) {
-        boolean _add_2 = unloaded.add(delta.getUri());
-        if (_add_2) {
+        if (((delta.getOld() != null) && unloaded.add(delta.getUri()))) {
           this.unloadResource(delta.getUri());
         }
       }


### PR DESCRIPTION
When a resource is loaded for the first time, there is no need to unload it between pre-indexing and build