### PR TITLE
Make DiagnosticTreeIterator return a new iterator every time

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/AssertableDiagnostics.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/AssertableDiagnostics.java
@@ -38,9 +38,11 @@ public class AssertableDiagnostics {
 	protected class DiagnosticTreeIterator implements Iterable<Diagnostic>, Iterator<Diagnostic> {
 
 		private ArrayList<Iterator<Diagnostic>> iteratorStack = new ArrayList<Iterator<Diagnostic>>();
+		private final Diagnostic root;
 
 		public DiagnosticTreeIterator(Diagnostic root) {
 			super();
+			this.root = root;
 			iteratorStack.add(root.getChildren().iterator());
 		}
 
@@ -53,7 +55,7 @@ public class AssertableDiagnostics {
 
 		@Override
 		public Iterator<Diagnostic> iterator() {
-			return this;
+			return new DiagnosticTreeIterator(root);
 		}
 
 		@Override

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/DiagnosticTreeIterableTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/DiagnosticTreeIterableTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Sigasi N.V. (http://www.sigasi.com) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.validation;
+
+import java.util.Iterator;
+
+import org.eclipse.emf.common.util.BasicDiagnostic;
+import org.eclipse.emf.common.util.Diagnostic;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DiagnosticTreeIterableTest {
+
+	@Test
+	public void testIteratorIsNotConsumed() {
+		BasicDiagnostic root = new BasicDiagnostic();
+		root.add(new BasicDiagnostic());
+		AssertableDiagnostics diagnostics = new AssertableDiagnostics(root);
+		Iterable<Diagnostic> allDiagnostics = diagnostics.getAllDiagnostics();
+		Iterator<Diagnostic> first = allDiagnostics.iterator();
+		while (first.hasNext()) {
+			first.next();
+		}
+
+		Assert.assertTrue(allDiagnostics.iterator().hasNext());
+	}
+}


### PR DESCRIPTION
DiagnosticTreeIterator always returns the same iterator when you call
iterator(). This means it can't be iterated twice.

The Iterable interface does not force you to return a new Iterator every time but this is common practice. If this change doesn't get accepted because of this reason, it would be nice to at least have a comment on iterator().