### PR TITLE
update to guava 27.1

### DIFF
--- a/org.eclipse.xtext.util/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.util/META-INF/MANIFEST.MF
@@ -41,7 +41,7 @@ Export-Package: org.eclipse.xtext.util;
    org.eclipse.xtext.ui,
    org.eclipse.xtext.xbase"
 Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.10.2",
- com.google.guava;bundle-version="[21.0.0,22.0.0)";visibility:=reexport,
+ com.google.guava;bundle-version="[27.1.0,28.0.0)";visibility:=reexport,
  com.google.inject;bundle-version="3.0.0";visibility:=reexport,
  javax.inject;bundle-version="1.0.0";resolution:=optional;visibility:=reexport;x-installation:=greedy,
  org.eclipse.xtend.lib


### PR DESCRIPTION
Fixes eclipse/xtext#1398 and eclipse/xtext-lib#111

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>