### PR TITLE
[eclipse/xtext-eclipse#1102] [wizard] eclipse launch - set "Clear Configuration" to true

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin/.launch/Launch Runtime Eclipse.launch
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin/.launch/Launch Runtime Eclipse.launch
@@ -7,7 +7,7 @@
 <stringAttribute key="bad_container_name" value="/org.xtext.example.eclipsePlugin/.launch/"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearConfig" value="true"/>
 <booleanAttribute key="clearws" value="false"/>
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/Launch Runtime Eclipse"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2/.launch/Launch Runtime Eclipse.launch
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2/.launch/Launch Runtime Eclipse.launch
@@ -7,7 +7,7 @@
 <stringAttribute key="bad_container_name" value="/org.xtext.example.eclipsePluginP2/.launch/"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearConfig" value="true"/>
 <booleanAttribute key="clearws" value="false"/>
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/Launch Runtime Eclipse"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full/.launch/Launch Runtime Eclipse.launch
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full/.launch/Launch Runtime Eclipse.launch
@@ -7,7 +7,7 @@
 <stringAttribute key="bad_container_name" value="/org.xtext.example.full/.launch/"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearConfig" value="true"/>
 <booleanAttribute key="clearws" value="false"/>
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/Launch Runtime Eclipse"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp/.launch/Launch Runtime Eclipse.launch
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp/.launch/Launch Runtime Eclipse.launch
@@ -7,7 +7,7 @@
 <stringAttribute key="bad_container_name" value="/org.xtext.example.lsMavenTychoApp/.launch/"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearConfig" value="true"/>
 <booleanAttribute key="clearws" value="false"/>
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/Launch Runtime Eclipse"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar/.launch/Launch Runtime Eclipse.launch
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar/.launch/Launch Runtime Eclipse.launch
@@ -7,7 +7,7 @@
 <stringAttribute key="bad_container_name" value="/org.xtext.example.lsMavenTychoFatjar/.launch/"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearConfig" value="true"/>
 <booleanAttribute key="clearws" value="false"/>
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/Launch Runtime Eclipse"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho/.launch/Launch Runtime Eclipse.launch
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho/.launch/Launch Runtime Eclipse.launch
@@ -7,7 +7,7 @@
 <stringAttribute key="bad_container_name" value="/org.xtext.example.mavenTycho/.launch/"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearConfig" value="true"/>
 <booleanAttribute key="clearws" value="false"/>
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/Launch Runtime Eclipse"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9/.launch/Launch Runtime Eclipse.launch
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9/.launch/Launch Runtime Eclipse.launch
@@ -7,7 +7,7 @@
 <stringAttribute key="bad_container_name" value="/org.xtext.example.mavenTychoJ9/.launch/"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearConfig" value="true"/>
 <booleanAttribute key="clearws" value="false"/>
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/Launch Runtime Eclipse"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2/.launch/Launch Runtime Eclipse.launch
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2/.launch/Launch Runtime Eclipse.launch
@@ -7,7 +7,7 @@
 <stringAttribute key="bad_container_name" value="/org.xtext.example.mavenTychoP2/.launch/"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearConfig" value="true"/>
 <booleanAttribute key="clearws" value="false"/>
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/Launch Runtime Eclipse"/>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
@@ -670,7 +670,7 @@ class RuntimeProjectDescriptor extends TestedProjectDescriptor {
 			<stringAttribute key="bad_container_name" value="/«config.runtimeProject.name»/.launch/"/>
 			<stringAttribute key="bootstrap" value=""/>
 			<stringAttribute key="checked" value="[NONE]"/>
-			<booleanAttribute key="clearConfig" value="false"/>
+			<booleanAttribute key="clearConfig" value="true"/>
 			<booleanAttribute key="clearws" value="false"/>
 			<booleanAttribute key="clearwslog" value="false"/>
 			<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/Launch Runtime Eclipse"/>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
@@ -1813,7 +1813,7 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
     _builder.newLine();
     _builder.append("<stringAttribute key=\"checked\" value=\"[NONE]\"/>");
     _builder.newLine();
-    _builder.append("<booleanAttribute key=\"clearConfig\" value=\"false\"/>");
+    _builder.append("<booleanAttribute key=\"clearConfig\" value=\"true\"/>");
     _builder.newLine();
     _builder.append("<booleanAttribute key=\"clearws\" value=\"false\"/>");
     _builder.newLine();


### PR DESCRIPTION
[eclipse/xtext-eclipse#1102] [wizard] eclipse launch - set "Clear Configuration" to true

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>