### PR TITLE
[eclipse/xtext-core#1161] Added configurable issue for generated java package names not conforming to Java package naming conventions (Default: Ignore)

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/Issue1161Test.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/Issue1161Test.xtend
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Malardalen University (http://www.mdh.se) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xtext
+
+import com.google.inject.Guice
+import com.google.inject.Inject
+import org.eclipse.xtext.Grammar
+import org.eclipse.xtext.XtextPackage
+import org.eclipse.xtext.XtextRuntimeModule
+import org.eclipse.xtext.XtextStandaloneSetup
+import org.eclipse.xtext.diagnostics.Severity
+import org.eclipse.xtext.preferences.IPreferenceValuesProvider
+import org.eclipse.xtext.preferences.IPreferenceValuesProvider.SingletonPreferenceValuesProvider
+import org.eclipse.xtext.preferences.MapBasedPreferenceValues
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.util.ParseHelper
+import org.eclipse.xtext.testing.validation.ValidationTestHelper
+import org.eclipse.xtext.tests.AbstractXtextTests
+import org.eclipse.xtext.tests.XtextInjectorProvider
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author Lorenzo Addazi - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(XtextInjectorProvider)
+class Issue1161Test extends AbstractXtextTests {
+
+	@Inject extension ValidationTestHelper
+	@Inject extension ParseHelper<Grammar> 
+	
+	@Inject MapBasedPreferenceValues preferences
+
+	override setUp() throws Exception {
+		super.setUp();
+		with(Issue1161StandaloneSetup)
+	}
+
+	@Before def void setPreferences() {
+		preferences = get(SingletonPreferenceValuesProvider).getPreferenceValues(null)
+	}
+
+	@After def void clearPreferences() {
+		preferences.clear
+	}
+
+	@Test def void testValidJavaPackageNamingConventionsWithIgnoreSeverity() {
+		grammarWithValidJavaPackageNamingConventions.assertNoIssue
+	}
+
+	@Test def void testInvalidJavaPackageNamingConventionsWithIgnoreSeverity() {
+		grammarWithInvalidJavaPackageNamingConventions.assertNoIssue
+	}
+
+	@Test def void testValidJavaPackageNamingConventionsWithErrorSeverity() {
+		severity = "error"
+		grammarWithValidJavaPackageNamingConventions.assertNoIssue
+
+	}
+
+	@Test def void testInvalidJavaPackageNamingConventionsWithErrorSeverity() {
+		severity = "error"
+		grammarWithInvalidJavaPackageNamingConventions.assertError
+	}
+
+	@Test def void testValidJavaPackageNamingConventionsWithWarningSeverity() {
+		severity = "warning"
+		grammarWithValidJavaPackageNamingConventions.assertNoIssue
+
+	}
+
+	@Test def void testInvalidJavaPackageNamingConventionsWithWarningSeverity() {
+		severity = "warning"
+		grammarWithInvalidJavaPackageNamingConventions.assertWarning
+	}
+
+	@Test def void testValidJavaPackageNamingConventionsWithInfoSeverity() {
+		severity = "info"
+		grammarWithValidJavaPackageNamingConventions.assertNoIssue
+
+	}
+
+	@Test def void testInvalidJavaPackageNamingConventionsWithInfoSeverity() {
+		severity = "info"
+		grammarWithInvalidJavaPackageNamingConventions.assertInfo
+	}
+
+	private def assertError(CharSequence grammar) {
+		grammar.assertIssue(Severity.ERROR)
+	}
+
+	private def assertWarning(CharSequence grammar) {
+		grammar.assertIssue(Severity.WARNING)
+	}
+
+	private def assertInfo(CharSequence grammar) {
+		grammar.assertIssue(Severity.INFO)
+	}
+
+	private def assertIssue(CharSequence grammar, Severity severity) {
+		grammar.parse.assertIssue(XtextPackage.Literals.GENERATED_METAMODEL,
+			XtextConfigurableIssueCodes.INVALID_JAVAPACKAGE_NAME, severity)
+	}
+
+	private def assertNoIssue(CharSequence grammar) {
+		grammar.parse.assertNoIssue(XtextPackage.Literals.GENERATED_METAMODEL,
+			XtextConfigurableIssueCodes.INVALID_JAVAPACKAGE_NAME)
+	}
+
+	private def grammarWithValidJavaPackageNamingConventions() {
+		grammarWithGeneratedMetamodelName("testissue1161")
+	}
+
+	private def grammarWithInvalidJavaPackageNamingConventions() {
+		grammarWithGeneratedMetamodelName("testIssue1161")
+	}
+
+	private def grammarWithGeneratedMetamodelName(String generatedMetamodelName) '''
+		grammar test.Issue1161 with org.eclipse.xtext.common.Terminals
+		generate �generatedMetamodelName� "http://issue1161"
+		A : {A};
+	'''
+
+	private def setSeverity(String severity) {
+		preferences.put(XtextConfigurableIssueCodes.INVALID_JAVAPACKAGE_NAME, severity)
+	}
+
+	/**
+	 * @author Lorenzo Addazi - Initial contribution and API
+	 */
+	static class Issue1161StandaloneSetup extends XtextStandaloneSetup {
+		override createInjector() {
+			return Guice.createInjector(new XtextRuntimeModule() {
+				def Class<? extends IPreferenceValuesProvider> bindIPreferenceValuesProvider() {
+					SingletonPreferenceValuesProvider
+				}
+			});
+		}
+	}
+
+}

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/Issue1161Test.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/Issue1161Test.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2019 Malardalen University (http://www.mdh.se) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xtext;
+
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.Grammar;
+import org.eclipse.xtext.XtextPackage;
+import org.eclipse.xtext.XtextRuntimeModule;
+import org.eclipse.xtext.XtextStandaloneSetup;
+import org.eclipse.xtext.diagnostics.Severity;
+import org.eclipse.xtext.preferences.IPreferenceValuesProvider;
+import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.util.ParseHelper;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.eclipse.xtext.tests.AbstractXtextTests;
+import org.eclipse.xtext.tests.XtextInjectorProvider;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xtext.XtextConfigurableIssueCodes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Lorenzo Addazi - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(XtextInjectorProvider.class)
+@SuppressWarnings("all")
+public class Issue1161Test extends AbstractXtextTests {
+  /**
+   * @author Lorenzo Addazi - Initial contribution and API
+   */
+  public static class Issue1161StandaloneSetup extends XtextStandaloneSetup {
+    @Override
+    public Injector createInjector() {
+      abstract class __Issue1161StandaloneSetup_1 extends XtextRuntimeModule {
+        public abstract Class<? extends IPreferenceValuesProvider> bindIPreferenceValuesProvider();
+      }
+      
+      __Issue1161StandaloneSetup_1 ___Issue1161StandaloneSetup_1 = new __Issue1161StandaloneSetup_1() {
+        public Class<? extends IPreferenceValuesProvider> bindIPreferenceValuesProvider() {
+          return IPreferenceValuesProvider.SingletonPreferenceValuesProvider.class;
+        }
+      };
+      return Guice.createInjector(___Issue1161StandaloneSetup_1);
+    }
+  }
+  
+  @Inject
+  @Extension
+  private ValidationTestHelper _validationTestHelper;
+  
+  @Inject
+  @Extension
+  private ParseHelper<Grammar> _parseHelper;
+  
+  @Inject
+  private MapBasedPreferenceValues preferences;
+  
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    this.with(Issue1161Test.Issue1161StandaloneSetup.class);
+  }
+  
+  @Before
+  public void setPreferences() {
+    this.preferences = this.<IPreferenceValuesProvider.SingletonPreferenceValuesProvider>get(IPreferenceValuesProvider.SingletonPreferenceValuesProvider.class).getPreferenceValues(null);
+  }
+  
+  @After
+  public void clearPreferences() {
+    this.preferences.clear();
+  }
+  
+  @Test
+  public void testValidJavaPackageNamingConventionsWithIgnoreSeverity() {
+    this.assertNoIssue(this.grammarWithValidJavaPackageNamingConventions());
+  }
+  
+  @Test
+  public void testInvalidJavaPackageNamingConventionsWithIgnoreSeverity() {
+    this.assertNoIssue(this.grammarWithInvalidJavaPackageNamingConventions());
+  }
+  
+  @Test
+  public void testValidJavaPackageNamingConventionsWithErrorSeverity() {
+    this.setSeverity("error");
+    this.assertNoIssue(this.grammarWithValidJavaPackageNamingConventions());
+  }
+  
+  @Test
+  public void testInvalidJavaPackageNamingConventionsWithErrorSeverity() {
+    this.setSeverity("error");
+    this.assertError(this.grammarWithInvalidJavaPackageNamingConventions());
+  }
+  
+  @Test
+  public void testValidJavaPackageNamingConventionsWithWarningSeverity() {
+    this.setSeverity("warning");
+    this.assertNoIssue(this.grammarWithValidJavaPackageNamingConventions());
+  }
+  
+  @Test
+  public void testInvalidJavaPackageNamingConventionsWithWarningSeverity() {
+    this.setSeverity("warning");
+    this.assertWarning(this.grammarWithInvalidJavaPackageNamingConventions());
+  }
+  
+  @Test
+  public void testValidJavaPackageNamingConventionsWithInfoSeverity() {
+    this.setSeverity("info");
+    this.assertNoIssue(this.grammarWithValidJavaPackageNamingConventions());
+  }
+  
+  @Test
+  public void testInvalidJavaPackageNamingConventionsWithInfoSeverity() {
+    this.setSeverity("info");
+    this.assertInfo(this.grammarWithInvalidJavaPackageNamingConventions());
+  }
+  
+  private void assertError(final CharSequence grammar) {
+    this.assertIssue(grammar, Severity.ERROR);
+  }
+  
+  private void assertWarning(final CharSequence grammar) {
+    this.assertIssue(grammar, Severity.WARNING);
+  }
+  
+  private void assertInfo(final CharSequence grammar) {
+    this.assertIssue(grammar, Severity.INFO);
+  }
+  
+  private void assertIssue(final CharSequence grammar, final Severity severity) {
+    try {
+      this._validationTestHelper.assertIssue(this._parseHelper.parse(grammar), XtextPackage.Literals.GENERATED_METAMODEL, 
+        XtextConfigurableIssueCodes.INVALID_JAVAPACKAGE_NAME, severity);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  private void assertNoIssue(final CharSequence grammar) {
+    try {
+      this._validationTestHelper.assertNoIssue(this._parseHelper.parse(grammar), XtextPackage.Literals.GENERATED_METAMODEL, 
+        XtextConfigurableIssueCodes.INVALID_JAVAPACKAGE_NAME);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  private CharSequence grammarWithValidJavaPackageNamingConventions() {
+    return this.grammarWithGeneratedMetamodelName("testissue1161");
+  }
+  
+  private CharSequence grammarWithInvalidJavaPackageNamingConventions() {
+    return this.grammarWithGeneratedMetamodelName("testIssue1161");
+  }
+  
+  private CharSequence grammarWithGeneratedMetamodelName(final String generatedMetamodelName) {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("grammar test.Issue1161 with org.eclipse.xtext.common.Terminals");
+    _builder.newLine();
+    _builder.append("generate �generatedMetamodelName� \"http://issue1161\"");
+    _builder.newLine();
+    _builder.append("A : {A};");
+    _builder.newLine();
+    return _builder;
+  }
+  
+  private void setSeverity(final String severity) {
+    this.preferences.put(XtextConfigurableIssueCodes.INVALID_JAVAPACKAGE_NAME, severity);
+  }
+}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextConfigurableIssueCodes.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextConfigurableIssueCodes.java
@@ -36,6 +36,7 @@ public class XtextConfigurableIssueCodes extends ConfigurableIssueCodesProvider 
 	public static final String INVALID_PACKAGE_REFERENCE_INHERITED = ISSUE_CODE_PREFIX + "InvalidPackageReference.inherited";
 	public static final String INVALID_PACKAGE_REFERENCE_EXTERNAL = ISSUE_CODE_PREFIX + "InvalidPackageReference.external";
 	public static final String INVALID_PACKAGE_REFERENCE_NOT_ON_CLASSPATH = ISSUE_CODE_PREFIX + "InvalidPackageReference.notOnClasspath";
+	public static final String INVALID_JAVAPACKAGE_NAME = ISSUE_CODE_PREFIX + "InvalidJavaPackageName";
 	public static final String INVALID_TERMINALRULE_NAME = ISSUE_CODE_PREFIX + "InvalidTerminalRuleName";
 	public static final String DISCOURAGED_RULE_NAME = ISSUE_CODE_PREFIX + "DiscouragedName";
 	public static final String DUPLICATE_ENUM_LITERAL = ISSUE_CODE_PREFIX + "DuplicateEnumLiteral";
@@ -47,7 +48,7 @@ public class XtextConfigurableIssueCodes extends ConfigurableIssueCodesProvider 
 	public static final String EXPLICIT_OVERRIDE_INVALID = ISSUE_CODE_PREFIX + "ExplicitOverrideInvalid";
 	public static final String INVALID_ANNOTAION = ISSUE_CODE_PREFIX + "InvalidAnnotation";
 	public static final String USAGE_OF_DEPRECATED_RULE = ISSUE_CODE_PREFIX + "UsageOfDeprecatedRule";
-	
+
 	@Override
 	protected void initialize(IAcceptor<PreferenceKey> acceptor) {
 		acceptor.accept(create(INVALID_ACTION_USAGE, SeverityConverter.SEVERITY_ERROR));
@@ -63,6 +64,7 @@ public class XtextConfigurableIssueCodes extends ConfigurableIssueCodesProvider 
 		acceptor.accept(create(INVALID_METAMODEL_NAME, SeverityConverter.SEVERITY_WARNING));
 		acceptor.accept(create(INVALID_PACKAGE_REFERENCE_EXTERNAL, SeverityConverter.SEVERITY_WARNING));
 		acceptor.accept(create(INVALID_PACKAGE_REFERENCE_NOT_ON_CLASSPATH, SeverityConverter.SEVERITY_WARNING));
+		acceptor.accept(create(INVALID_JAVAPACKAGE_NAME, SeverityConverter.SEVERITY_IGNORE));
 		acceptor.accept(create(INVALID_TERMINALRULE_NAME, SeverityConverter.SEVERITY_WARNING));
 		acceptor.accept(create(DUPLICATE_ENUM_LITERAL, SeverityConverter.SEVERITY_WARNING));
 		acceptor.accept(create(BIDIRECTIONAL_REFERENCE, SeverityConverter.SEVERITY_WARNING));

--- a/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextValidator.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextValidator.java
@@ -1220,6 +1220,20 @@ public class XtextValidator extends AbstractDeclarativeValidator {
 	}
 	
 	@Check
+	public void checkJavaPackageNamingConventions(GeneratedMetamodel metamodel){
+		Severity severity = getIssueSeverities(getContext(), getCurrentObject()).getSeverity(INVALID_JAVAPACKAGE_NAME);
+		if (severity == null || severity == Severity.IGNORE) {
+			// Don't perform any check if the result is ignored
+			return;
+		}
+		final String metamodelName = Strings.emptyIfNull(metamodel.getName());
+		if (!Strings.equal(metamodelName, metamodelName.toLowerCase())) {
+			addIssue("The generated metamodel name must not contain uppercase characters", metamodel, XtextPackage.eINSTANCE.getGeneratedMetamodel_Name(),
+				INVALID_JAVAPACKAGE_NAME, metamodel.getName());
+		}
+	}
+
+	@Check
 	public void checkTerminalRuleNamingConventions(TerminalRule terminalRule){
 		if(!terminalRule.getName().equals(terminalRule.getName().toUpperCase()))
 			addIssue("TerminalRule must be written in uppercase.", terminalRule, XtextPackage.eINSTANCE.getAbstractRule_Name(),


### PR DESCRIPTION
Signed-off-by: Lorenzo Addazi <lorenzo.addazi@mdh.se>