### PR TITLE
[eclipse/xtext#1431] Tweak resource constraints

### DIFF
--- a/CBI.Jenkinsfile
+++ b/CBI.Jenkinsfile
@@ -11,6 +11,13 @@ spec:
   - name: jnlp
     image: 'eclipsecbi/jenkins-jnlp-agent'
     args: ['\$(JENKINS_SECRET)', '\$(JENKINS_NAME)']
+    resources:
+      limits:
+        memory: "0.4Gi"
+        cpu: "0.2"
+      requests:
+        memory: "0.4Gi"
+        cpu: "0.2"
     volumeMounts:
     - mountPath: /home/jenkins/.ssh
       name: volume-known-hosts
@@ -19,11 +26,11 @@ spec:
     tty: true
     resources:
       limits:
-        memory: "2Gi"
-        cpu: "1"
+        memory: "3.6Gi"
+        cpu: "1.0"
       requests:
-        memory: "2Gi"
-        cpu: "1"
+        memory: "3.6Gi"
+        cpu: "1.0"
     volumeMounts:
     - name: settings-xml
       mountPath: /home/jenkins/.m2/settings.xml


### PR DESCRIPTION
Tests have shown that at most 2 executors will usually be available at
most and these resource configurations seem to make optimal usage of
available resources.
- Container 'jnlp' is working with 0.4Gi memory (default is 0.5Gi) and
0.2 cpu (this is the default, lower value leads to slower agent
provisioning)
- Build container can use at max 3.6Gi memory and 1.0 cpu. Higher values
will lead to only 1 executor.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>