### PR TITLE
Extend IProjectConfig and related interfaces

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/SourceFolderCustomImplTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/SourceFolderCustomImplTest.xtend
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.server
+
+import com.google.inject.AbstractModule
+import com.google.inject.Inject
+import com.google.inject.Module
+import com.google.inject.Scopes
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.ide.server.IWorkspaceConfigFactory
+import org.eclipse.xtext.ide.server.ProjectWorkspaceConfigFactory
+import org.eclipse.xtext.ide.server.WorkspaceManager
+import org.eclipse.xtext.util.IFileSystemScanner
+import org.eclipse.xtext.util.Modules2
+import org.eclipse.xtext.workspace.FileProjectConfig
+import org.eclipse.xtext.workspace.FileSourceFolder
+import org.eclipse.xtext.workspace.WorkspaceConfig
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+/**
+ * Tests customized version of default methods ISourceFolder#contains(URI) and ISourceFolder#getAllResources(IFileSystemScanner)
+ */
+class SourceFolderCustomImplTest extends AbstractTestLangLanguageServerTest {
+	@Inject
+	WorkspaceManager workspaceManager;
+	@Inject
+	IFileSystemScanner scanner;
+
+	
+	/** Asserts that the custom implementation returns not all files of the configured source folder */
+	@Test
+	def void testCustomSourceFolderImplementation() {
+		'sample.testlang'.writeFile("MyContent")
+		initialize
+		
+		val projectManager = workspaceManager.getProjectManager("")
+		val sourceFolders = projectManager.projectConfig.sourceFolders
+		
+		assertTrue(sourceFolders.size == 1);
+		val sourceFolder = sourceFolders.get(0);
+		val allResources = sourceFolder.getAllResources(scanner);
+
+		assertTrue(allResources.exists[uri|uri.toString.endsWith("test-data/test-project/")]);
+		assertFalse(allResources.exists[uri|uri.toString.endsWith("test-data/test-project/sample.testlang")]);
+		assertEquals(allResources.size, 1);
+	}
+
+	static class CustomWorkspaceConfigFactory extends ProjectWorkspaceConfigFactory {
+
+		override findProjects(WorkspaceConfig workspaceConfig, URI uri) {
+			if (uri !== null) {
+				val project = new CustomFileProjectConfig(uri, workspaceConfig)
+				project.addSourceFolder('.')
+				workspaceConfig.addProject(project)
+			}
+		}
+	}
+
+	static class CustomFileProjectConfig extends FileProjectConfig {
+	
+		new(URI uri, WorkspaceConfig workspaceConfig) {
+			super(uri, workspaceConfig)
+		}
+	
+		override FileSourceFolder addSourceFolder(String relativePath) {
+			val sourceFolder = new CustomFileSourceFolder(this, relativePath)
+			sourceFolders += sourceFolder
+			sourceFolder
+		}
+	}
+
+	static class CustomFileSourceFolder extends FileSourceFolder {
+		
+		new(FileProjectConfig parent, String name) {
+			super(parent, name)
+		}
+		
+		def boolean filterTheFile(URI uri) {
+			return uri.toFileString.endsWith("sample.testlang");
+		}
+		
+		override contains(URI uri) {
+			if (filterTheFile(uri)) {
+				return false;
+			}
+			super.contains(uri)
+		}
+		
+		override getAllResources(IFileSystemScanner scanner) {
+			val allResources = super.getAllResources(scanner);
+			allResources.removeIf(uri| filterTheFile(uri));
+			return allResources;
+		}
+	}
+
+	
+	override protected getServerModule() {
+		val defaultModule = super.getServerModule()
+		val Module customModule = new AbstractModule() {
+			
+			override protected configure() {
+				bind(IWorkspaceConfigFactory).to(CustomWorkspaceConfigFactory)
+				bind(WorkspaceManager).in(Scopes.SINGLETON);
+			}
+			
+		}
+		
+		return Modules2.mixin(defaultModule, customModule)
+	}
+}

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/SourceFolderDefaultImplTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/SourceFolderDefaultImplTest.xtend
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.server
+
+import com.google.inject.AbstractModule
+import com.google.inject.Inject
+import com.google.inject.Module
+import com.google.inject.Scopes
+import org.eclipse.xtext.ide.server.WorkspaceManager
+import org.eclipse.xtext.util.IFileSystemScanner
+import org.eclipse.xtext.util.Modules2
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+/**
+ * Tests default methods ISourceFolder#contains(URI) and ISourceFolder#getAllResources(IFileSystemScanner)
+ */
+class SourceFolderDefaultImplTest extends AbstractTestLangLanguageServerTest {
+	@Inject
+	WorkspaceManager workspaceManager;
+	@Inject
+	IFileSystemScanner scanner;
+	
+	/** Asserts that the default implementation returns all files in the configured source folder */
+	@Test
+	def void testDefaultSourceFolderImplementation() {
+		'sample.testlang'.writeFile("MyContent")
+		initialize
+		
+		val projectManager = workspaceManager.getProjectManager("")
+		val sourceFolders = projectManager.projectConfig.sourceFolders
+		
+		assertTrue(sourceFolders.size == 1);
+		val sourceFolder = sourceFolders.get(0);
+		val allResources = sourceFolder.getAllResources(scanner);
+
+		assertTrue(allResources.exists[uri|uri.toString.endsWith("test-data/test-project/")]);
+		assertTrue(allResources.exists[uri|uri.toString.endsWith("test-data/test-project/sample.testlang")]);
+		assertEquals(allResources.size, 2);
+	}
+
+	
+	override protected getServerModule() {
+		val defaultModule = super.getServerModule()
+		val Module customModule = new AbstractModule() {
+			
+			override protected configure() {
+				bind(WorkspaceManager).in(Scopes.SINGLETON);
+			}
+		}
+		
+		return Modules2.mixin(defaultModule, customModule)
+	}
+	
+}

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/SourceFolderCustomImplTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/SourceFolderCustomImplTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.tests.server;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Scopes;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtext.ide.server.IWorkspaceConfigFactory;
+import org.eclipse.xtext.ide.server.ProjectManager;
+import org.eclipse.xtext.ide.server.ProjectWorkspaceConfigFactory;
+import org.eclipse.xtext.ide.server.WorkspaceManager;
+import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
+import org.eclipse.xtext.util.IFileSystemScanner;
+import org.eclipse.xtext.util.Modules2;
+import org.eclipse.xtext.workspace.FileProjectConfig;
+import org.eclipse.xtext.workspace.FileSourceFolder;
+import org.eclipse.xtext.workspace.ISourceFolder;
+import org.eclipse.xtext.workspace.WorkspaceConfig;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests customized version of default methods ISourceFolder#contains(URI) and ISourceFolder#getAllResources(IFileSystemScanner)
+ */
+@SuppressWarnings("all")
+public class SourceFolderCustomImplTest extends AbstractTestLangLanguageServerTest {
+  public static class CustomWorkspaceConfigFactory extends ProjectWorkspaceConfigFactory {
+    @Override
+    public void findProjects(final WorkspaceConfig workspaceConfig, final URI uri) {
+      if ((uri != null)) {
+        final SourceFolderCustomImplTest.CustomFileProjectConfig project = new SourceFolderCustomImplTest.CustomFileProjectConfig(uri, workspaceConfig);
+        project.addSourceFolder(".");
+        workspaceConfig.addProject(project);
+      }
+    }
+  }
+  
+  public static class CustomFileProjectConfig extends FileProjectConfig {
+    public CustomFileProjectConfig(final URI uri, final WorkspaceConfig workspaceConfig) {
+      super(uri, workspaceConfig);
+    }
+    
+    @Override
+    public FileSourceFolder addSourceFolder(final String relativePath) {
+      SourceFolderCustomImplTest.CustomFileSourceFolder _xblockexpression = null;
+      {
+        final SourceFolderCustomImplTest.CustomFileSourceFolder sourceFolder = new SourceFolderCustomImplTest.CustomFileSourceFolder(this, relativePath);
+        Set<FileSourceFolder> _sourceFolders = this.getSourceFolders();
+        _sourceFolders.add(sourceFolder);
+        _xblockexpression = sourceFolder;
+      }
+      return _xblockexpression;
+    }
+  }
+  
+  public static class CustomFileSourceFolder extends FileSourceFolder {
+    public CustomFileSourceFolder(final FileProjectConfig parent, final String name) {
+      super(parent, name);
+    }
+    
+    public boolean filterTheFile(final URI uri) {
+      return uri.toFileString().endsWith("sample.testlang");
+    }
+    
+    @Override
+    public boolean contains(final URI uri) {
+      boolean _xblockexpression = false;
+      {
+        boolean _filterTheFile = this.filterTheFile(uri);
+        if (_filterTheFile) {
+          return false;
+        }
+        _xblockexpression = super.contains(uri);
+      }
+      return _xblockexpression;
+    }
+    
+    @Override
+    public List<URI> getAllResources(final IFileSystemScanner scanner) {
+      final List<URI> allResources = super.getAllResources(scanner);
+      final Predicate<URI> _function = (URI uri) -> {
+        return this.filterTheFile(uri);
+      };
+      allResources.removeIf(_function);
+      return allResources;
+    }
+  }
+  
+  @Inject
+  private WorkspaceManager workspaceManager;
+  
+  @Inject
+  private IFileSystemScanner scanner;
+  
+  /**
+   * Asserts that the custom implementation returns not all files of the configured source folder
+   */
+  @Test
+  public void testCustomSourceFolderImplementation() {
+    this.writeFile("sample.testlang", "MyContent");
+    this.initialize();
+    final ProjectManager projectManager = this.workspaceManager.getProjectManager("");
+    final Set<? extends ISourceFolder> sourceFolders = projectManager.getProjectConfig().getSourceFolders();
+    int _size = sourceFolders.size();
+    boolean _equals = (_size == 1);
+    Assert.assertTrue(_equals);
+    final ISourceFolder sourceFolder = ((ISourceFolder[])Conversions.unwrapArray(sourceFolders, ISourceFolder.class))[0];
+    final List<URI> allResources = sourceFolder.getAllResources(this.scanner);
+    final Function1<URI, Boolean> _function = (URI uri) -> {
+      return Boolean.valueOf(uri.toString().endsWith("test-data/test-project/"));
+    };
+    Assert.assertTrue(IterableExtensions.<URI>exists(allResources, _function));
+    final Function1<URI, Boolean> _function_1 = (URI uri) -> {
+      return Boolean.valueOf(uri.toString().endsWith("test-data/test-project/sample.testlang"));
+    };
+    Assert.assertFalse(IterableExtensions.<URI>exists(allResources, _function_1));
+    Assert.assertEquals(allResources.size(), 1);
+  }
+  
+  @Override
+  protected com.google.inject.Module getServerModule() {
+    final com.google.inject.Module defaultModule = super.getServerModule();
+    final com.google.inject.Module customModule = new AbstractModule() {
+      @Override
+      protected void configure() {
+        this.<IWorkspaceConfigFactory>bind(IWorkspaceConfigFactory.class).to(SourceFolderCustomImplTest.CustomWorkspaceConfigFactory.class);
+        this.<WorkspaceManager>bind(WorkspaceManager.class).in(Scopes.SINGLETON);
+      }
+    };
+    return Modules2.mixin(defaultModule, customModule);
+  }
+}

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/SourceFolderDefaultImplTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/SourceFolderDefaultImplTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.tests.server;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Scopes;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtext.ide.server.ProjectManager;
+import org.eclipse.xtext.ide.server.WorkspaceManager;
+import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
+import org.eclipse.xtext.util.IFileSystemScanner;
+import org.eclipse.xtext.util.Modules2;
+import org.eclipse.xtext.workspace.ISourceFolder;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests default methods ISourceFolder#contains(URI) and ISourceFolder#getAllResources(IFileSystemScanner)
+ */
+@SuppressWarnings("all")
+public class SourceFolderDefaultImplTest extends AbstractTestLangLanguageServerTest {
+  @Inject
+  private WorkspaceManager workspaceManager;
+  
+  @Inject
+  private IFileSystemScanner scanner;
+  
+  /**
+   * Asserts that the default implementation returns all files in the configured source folder
+   */
+  @Test
+  public void testDefaultSourceFolderImplementation() {
+    this.writeFile("sample.testlang", "MyContent");
+    this.initialize();
+    final ProjectManager projectManager = this.workspaceManager.getProjectManager("");
+    final Set<? extends ISourceFolder> sourceFolders = projectManager.getProjectConfig().getSourceFolders();
+    int _size = sourceFolders.size();
+    boolean _equals = (_size == 1);
+    Assert.assertTrue(_equals);
+    final ISourceFolder sourceFolder = ((ISourceFolder[])Conversions.unwrapArray(sourceFolders, ISourceFolder.class))[0];
+    final List<URI> allResources = sourceFolder.getAllResources(this.scanner);
+    final Function1<URI, Boolean> _function = (URI uri) -> {
+      return Boolean.valueOf(uri.toString().endsWith("test-data/test-project/"));
+    };
+    Assert.assertTrue(IterableExtensions.<URI>exists(allResources, _function));
+    final Function1<URI, Boolean> _function_1 = (URI uri) -> {
+      return Boolean.valueOf(uri.toString().endsWith("test-data/test-project/sample.testlang"));
+    };
+    Assert.assertTrue(IterableExtensions.<URI>exists(allResources, _function_1));
+    Assert.assertEquals(allResources.size(), 2);
+  }
+  
+  @Override
+  protected com.google.inject.Module getServerModule() {
+    final com.google.inject.Module defaultModule = super.getServerModule();
+    final com.google.inject.Module customModule = new AbstractModule() {
+      @Override
+      protected void configure() {
+        this.<WorkspaceManager>bind(WorkspaceManager.class).in(Scopes.SINGLETON);
+      }
+    };
+    return Modules2.mixin(defaultModule, customModule);
+  }
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ProjectManager.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ProjectManager.xtend
@@ -76,8 +76,8 @@ class ProjectManager {
     def Result doInitialBuild(CancelIndicator cancelIndicator) {
         val uris = newArrayList
         projectConfig.sourceFolders.forEach [
-            fileSystemScanner.scan(path) [uris += it]
-        ] 
+        	uris += it.getAllResources(fileSystemScanner)
+        ]
         return doBuild(uris, emptyList, emptyList, cancelIndicator)        
     } 
 

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/ProjectManager.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/ProjectManager.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.xtext.ide.server;
 
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import java.util.ArrayList;
@@ -32,7 +33,6 @@ import org.eclipse.xtext.resource.impl.ChunkedResourceDescriptions;
 import org.eclipse.xtext.resource.impl.ProjectDescription;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsData;
 import org.eclipse.xtext.util.CancelIndicator;
-import org.eclipse.xtext.util.IAcceptor;
 import org.eclipse.xtext.util.IFileSystemScanner;
 import org.eclipse.xtext.validation.Issue;
 import org.eclipse.xtext.workspace.IProjectConfig;
@@ -102,10 +102,8 @@ public class ProjectManager {
   public IncrementalBuilder.Result doInitialBuild(final CancelIndicator cancelIndicator) {
     final ArrayList<URI> uris = CollectionLiterals.<URI>newArrayList();
     final Consumer<ISourceFolder> _function = (ISourceFolder it) -> {
-      final IAcceptor<URI> _function_1 = (URI it_1) -> {
-        uris.add(it_1);
-      };
-      this.fileSystemScanner.scan(it.getPath(), _function_1);
+      List<URI> _allResources = it.getAllResources(this.fileSystemScanner);
+      Iterables.<URI>addAll(uris, _allResources);
     };
     this.projectConfig.getSourceFolders().forEach(_function);
     return this.doBuild(uris, CollectionLiterals.<URI>emptyList(), CollectionLiterals.<IResourceDescription.Delta>emptyList(), cancelIndicator);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/workspace/FileProjectConfig.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/workspace/FileProjectConfig.xtend
@@ -14,8 +14,6 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import org.eclipse.xtext.util.UriUtil
 
-import static extension org.eclipse.xtext.util.UriUtil.*
-
 @Accessors
 class FileProjectConfig implements IProjectConfig {
 	val URI path
@@ -64,7 +62,7 @@ class FileProjectConfig implements IProjectConfig {
 	}
 
 	override FileSourceFolder findSourceFolderContaining(URI member) {
-		sourceFolders.findFirst[source|source.path.isPrefixOf(member)]
+		sourceFolders.findFirst[sourceFolder|sourceFolder.contains(member)]
 	}
 
 	override equals(Object obj) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/workspace/IProjectConfig.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/workspace/IProjectConfig.java
@@ -25,6 +25,7 @@ public interface IProjectConfig {
 	 */
 	URI getPath();
 
+	/** @return a set of all source folders */
 	Set<? extends ISourceFolder> getSourceFolders();
 
 	/**

--- a/org.eclipse.xtext/src/org/eclipse/xtext/workspace/ISourceFolder.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/workspace/ISourceFolder.java
@@ -7,9 +7,19 @@
  *******************************************************************************/
 package org.eclipse.xtext.workspace;
 
-import org.eclipse.emf.common.util.URI;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtext.util.IAcceptor;
+import org.eclipse.xtext.util.IFileSystemScanner;
+import org.eclipse.xtext.util.UriUtil;
+
+/**
+ * Describes directories that contain source files of a project.
+ */
 public interface ISourceFolder {
+
 	/**
 	 * The logical name of the source folder, like "src/main/java"
 	 */
@@ -20,4 +30,23 @@ public interface ISourceFolder {
 	 * separator. It will never be null.
 	 */
 	URI getPath();
+
+	/**
+	 * @param uri
+	 *            to check
+	 * @return true iff the given {@link URI} is a sub element of the {@link URI} of this {@link ISourceFolder}.
+	 */
+	default boolean contains(URI uri) {
+		URI path = getPath();
+		return UriUtil.isPrefixOf(path, uri);
+	}
+
+	/** @return a list of all URIs that are passed to the acceptor of {@link #scan(URI, IAcceptor)} */
+	default List<URI> getAllResources(IFileSystemScanner scanner) {
+		List<URI> uris = new ArrayList<>();
+		scanner.scan(getPath(), uri -> uris.add(uri));
+
+		return uris;
+	}
+
 }

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/workspace/FileProjectConfig.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/workspace/FileProjectConfig.java
@@ -87,8 +87,8 @@ public class FileProjectConfig implements IProjectConfig {
   
   @Override
   public FileSourceFolder findSourceFolderContaining(final URI member) {
-    final Function1<FileSourceFolder, Boolean> _function = (FileSourceFolder source) -> {
-      return Boolean.valueOf(UriUtil.isPrefixOf(source.getPath(), member));
+    final Function1<FileSourceFolder, Boolean> _function = (FileSourceFolder sourceFolder) -> {
+      return Boolean.valueOf(sourceFolder.contains(member));
     };
     return IterableExtensions.<FileSourceFolder>findFirst(this.sourceFolders, _function);
   }


### PR DESCRIPTION
While implementing LSP support for our Xtext language based on xtext.ide packages, we found some issues. Some of those we would like to address in this PR, regarding IProjectConfig and ISourceFolder:
* missing output folders in IProjectConfig (actually, we only need one, but others might need more)
* excluding some files within source folders (happens e.g. when source and output folders are the same, see e.g. TypeScript)

Notes:
* I am not sure whether the new interface `IOutputFolder` is the best choice. Actually, I would prefer to rename `ISourceFolder`, but I guess this wouldn't be a good idea for xtext API continuity.
* The method `ResourceStorageFacade#computeOutputPath(StorageAwareResource)` sounds like it does something with output paths, although it looks like it is computing a relative path only. Please let me know whether I should adjust some other place to use the method `getOutputFolder` (or alike) somewhere. Right now, it is used nowhere in the xtext code base.
* Mind the related PR in repo `xtext-eclipse`.
