### PR TITLE
[eclipse/xtext#1279] use orbit simrel alias directly

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.target/org.xtext.example.full.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.target/org.xtext.example.full.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 			<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 		</location>
 	</locations>
 </target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.target/org.xtext.example.lsMavenTychoApp.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.target/org.xtext.example.lsMavenTychoApp.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 			<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 		</location>
 	</locations>
 </target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.target/org.xtext.example.lsMavenTychoFatjar.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.target/org.xtext.example.lsMavenTychoFatjar.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 			<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 		</location>
 	</locations>
 </target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.target/org.xtext.example.mavenTycho.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.target/org.xtext.example.mavenTycho.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 			<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 		</location>
 	</locations>
 </target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9.target/org.xtext.example.mavenTychoJ9.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9.target/org.xtext.example.mavenTychoJ9.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 			<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 		</location>
 	</locations>
 </target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.target/org.xtext.example.mavenTychoP2.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.target/org.xtext.example.mavenTychoP2.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 			<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 		</location>
 	</locations>
 </target>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
@@ -96,7 +96,7 @@ class TargetPlatformProject extends ProjectDescriptor {
 					<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 					<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 					<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-					<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+					<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 				</location>
 			</locations>
 		</target>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
@@ -226,7 +226,7 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.append("<unit id=\"io.github.classgraph\" version=\"4.8.35.v20190528-1517\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<repository location=\"https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09\"/>");
+    _builder.append("<repository location=\"https://download.eclipse.org/tools/orbit/downloads/2019-09\"/>");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("</location>");

--- a/releng/releng-target/xtext-core.target.target
+++ b/releng/releng-target/xtext-core.target.target
@@ -14,7 +14,7 @@
 			<repository location="https://download.eclipse.org/releases/oxygen/201804111000"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 			<unit id="org.junit" version="0.0.0"/>
 			<unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
 		</location>


### PR DESCRIPTION
[eclipse/xtext#1279] use orbit simrel alias directly
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>