### PR TITLE
[eclipse/xtext-lib#224] Stable method order when using Delegate

### DIFF
--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/editor/hierarchy/DefaultHierarchyNodeReference.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/editor/hierarchy/DefaultHierarchyNodeReference.java
@@ -52,18 +52,6 @@ public class DefaultHierarchyNodeReference implements IHierarchyNodeReference {
     return this.navigationElement;
   }
   
-  public int getEndLineNumber() {
-    return this.textRegion.getEndLineNumber();
-  }
-  
-  public int getLineNumber() {
-    return this.textRegion.getLineNumber();
-  }
-  
-  public ITextRegionWithLineInformation merge(final ITextRegionWithLineInformation other) {
-    return this.textRegion.merge(other);
-  }
-  
   public boolean contains(final ITextRegion other) {
     return this.textRegion.contains(other);
   }
@@ -72,8 +60,16 @@ public class DefaultHierarchyNodeReference implements IHierarchyNodeReference {
     return this.textRegion.contains(offset);
   }
   
+  public int getEndLineNumber() {
+    return this.textRegion.getEndLineNumber();
+  }
+  
   public int getLength() {
     return this.textRegion.getLength();
+  }
+  
+  public int getLineNumber() {
+    return this.textRegion.getLineNumber();
   }
   
   public int getOffset() {
@@ -82,5 +78,9 @@ public class DefaultHierarchyNodeReference implements IHierarchyNodeReference {
   
   public ITextRegion merge(final ITextRegion region) {
     return this.textRegion.merge(region);
+  }
+  
+  public ITextRegionWithLineInformation merge(final ITextRegionWithLineInformation other) {
+    return this.textRegion.merge(other);
   }
 }

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/GeneratorNodeProcessor.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/trace/node/GeneratorNodeProcessor.java
@@ -254,18 +254,6 @@ public class GeneratorNodeProcessor {
         return this.delegate;
       }
       
-      public int getEndLineNumber() {
-        return this.getDelegate().getEndLineNumber();
-      }
-      
-      public int getLineNumber() {
-        return this.getDelegate().getLineNumber();
-      }
-      
-      public ITextRegionWithLineInformation merge(final ITextRegionWithLineInformation other) {
-        return this.getDelegate().merge(other);
-      }
-      
       public boolean contains(final ITextRegion other) {
         return this.getDelegate().contains(other);
       }
@@ -274,8 +262,16 @@ public class GeneratorNodeProcessor {
         return this.getDelegate().contains(offset);
       }
       
+      public int getEndLineNumber() {
+        return this.getDelegate().getEndLineNumber();
+      }
+      
       public int getLength() {
         return this.getDelegate().getLength();
+      }
+      
+      public int getLineNumber() {
+        return this.getDelegate().getLineNumber();
       }
       
       public int getOffset() {
@@ -284,6 +280,10 @@ public class GeneratorNodeProcessor {
       
       public ITextRegion merge(final ITextRegion region) {
         return this.getDelegate().merge(region);
+      }
+      
+      public ITextRegionWithLineInformation merge(final ITextRegionWithLineInformation other) {
+        return this.getDelegate().merge(other);
       }
     }
     


### PR DESCRIPTION
[eclipse/xtext-lib#224] Stable method order when using Delegate annotation