### PR TITLE
Intern grammar elements when nodes are created from the cache

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/GrammarElementsInterner.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/GrammarElementsInterner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2019 Sigasi NV (http://www.sigasi.com) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,7 +37,7 @@ public class GrammarElementsInterner {
 			this.grammarElements = grammarElements;
 		}
 		
-		EObject[] prefixElement() {
+		EObject[] prependedGrammarElements() {
 			if(grammarElements instanceof EObject) {
 				return new EObject[] {grammarElement, (EObject) grammarElements};
 			} else {
@@ -45,7 +45,7 @@ public class GrammarElementsInterner {
 			}
 		}
 		
-		EObject[] postfixElement() {
+		EObject[] appendedGrammarElements() {
 			if(grammarElements instanceof EObject) {
 				return new EObject[] {(EObject) grammarElements, grammarElement };
 			} else {
@@ -73,7 +73,7 @@ public class GrammarElementsInterner {
 		}
 	}
 
-	Map<GrammarElementsInterner.InternKey, EObject[]> interningMap = Maps.newHashMap();
+	private final Map<GrammarElementsInterner.InternKey, EObject[]> interningMap = Maps.newHashMap();
 	
 	/**
 	 * Take a list of grammar elements and add an additional grammar element to the front.  If this
@@ -83,7 +83,7 @@ public class GrammarElementsInterner {
 	 */
 	EObject[] prependAndIntern(EObject grammarElement, Object grammarElements) {
 		GrammarElementsInterner.InternKey internKey = new InternKey(grammarElement, grammarElements);
-		return interningMap.computeIfAbsent(internKey, key -> key.prefixElement());
+		return interningMap.computeIfAbsent(internKey, key -> key.prependedGrammarElements());
 	}
 	
 	/**
@@ -94,7 +94,7 @@ public class GrammarElementsInterner {
 	 */
 	EObject[] appendAndIntern(Object grammarElements, EObject grammarElement) {
 		GrammarElementsInterner.InternKey internKey = new InternKey(grammarElement, grammarElements);
-		return interningMap.computeIfAbsent(internKey, key -> key.postfixElement());
+		return interningMap.computeIfAbsent(internKey, key -> key.appendedGrammarElements());
 	}
 	
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/GrammarElementsInterner.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/GrammarElementsInterner.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.nodemodel.impl;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.emf.ecore.EObject;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.ObjectArrays;
+
+/**
+ * Interner of arrays of grammar elements stored in the node model.
+ * 
+ * The node model contains nodes derived from {@link AbstractNode}.  An {@link AbstractNode} has an array describing its grammar 
+ * elements.  This array is often identical for many {@link AbstractNode}s.  There can be millions of nodes in a node model
+ * so it makes sense to remove the duplicate arrays.  This {@link GrammarElementsInterner} tries to reuse an interned version of such an array
+ * wherever possible
+ */
+
+public class GrammarElementsInterner {
+
+	private static class InternKey {
+		final EObject grammarElement;
+		final Object grammarElements;
+		
+		int hashCode = -1;
+
+		InternKey(EObject grammarElement, Object grammarElements) {
+			this.grammarElement = grammarElement;
+			this.grammarElements = grammarElements;
+		}
+		
+		EObject[] prefixElement() {
+			if(grammarElements instanceof EObject) {
+				return new EObject[] {grammarElement, (EObject) grammarElements};
+			} else {
+				return ObjectArrays.concat(grammarElement, (EObject[]) grammarElements);
+			}
+		}
+		
+		EObject[] postfixElement() {
+			if(grammarElements instanceof EObject) {
+				return new EObject[] {(EObject) grammarElements, grammarElement };
+			} else {
+				return ObjectArrays.concat((EObject[]) grammarElements, grammarElement);
+			}
+		}
+
+
+		@Override
+		public int hashCode() {
+			if (hashCode == -1)
+				hashCode = Objects.hash(grammarElement, grammarElements);
+			return hashCode;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if(o instanceof GrammarElementsInterner.InternKey) {
+				GrammarElementsInterner.InternKey interned = (GrammarElementsInterner.InternKey) o;
+				return Objects.equals(this.grammarElement, interned.grammarElement) 
+						&& Objects.equals(this.grammarElements, interned.grammarElements);
+			}
+			
+			return false;
+		}
+	}
+
+	Map<GrammarElementsInterner.InternKey, EObject[]> interningMap = Maps.newHashMap();
+	
+	/**
+	 * Take a list of grammar elements and add an additional grammar element to the front.  If this
+	 * list has already been produced in the past, return an interned version.  Note that 
+	 * this code will only function efficiently if repeated invocation uses the same grammar element
+	 * objects and arrays or else a new concatenated array will be created every time.
+	 */
+	EObject[] prependAndIntern(EObject grammarElement, Object grammarElements) {
+		GrammarElementsInterner.InternKey internKey = new InternKey(grammarElement, grammarElements);
+		return interningMap.computeIfAbsent(internKey, key -> key.prefixElement());
+	}
+	
+	/**
+	 * Take a list of grammar elements and add an additional grammar element at the back.  If this
+	 * list has already been produced in the past, return an interned version.  Note that 
+	 * this code will only function efficiently if repeated invocation uses the same grammar element
+	 * objects and arrays or else a new concatenated array will be created every time.
+	 */
+	EObject[] appendAndIntern(Object grammarElements, EObject grammarElement) {
+		GrammarElementsInterner.InternKey internKey = new InternKey(grammarElement, grammarElements);
+		return interningMap.computeIfAbsent(internKey, key -> key.postfixElement());
+	}
+	
+}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/serialization/DeserializationConversionContext.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/serialization/DeserializationConversionContext.java
@@ -14,6 +14,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtext.IGrammarAccess;
+import org.eclipse.xtext.nodemodel.impl.GrammarElementsInterner;
 import org.eclipse.xtext.resource.XtextResource;
 
 import com.google.common.collect.Lists;
@@ -29,6 +30,8 @@ public class DeserializationConversionContext {
 	final private List<EObject> idToEObjectMap;
 
 	final private IGrammarAccess grammarAccess;
+	
+	final private GrammarElementsInterner arrayInterner;
 
 	final private String completeContent;
 
@@ -38,6 +41,7 @@ public class DeserializationConversionContext {
 		this.grammarAccess = xr.getResourceServiceProvider().get(IGrammarAccess.class);
 		this.idToEObjectMap = Lists.newArrayList();
 		this.completeContent = completeContent;
+		this.arrayInterner = new GrammarElementsInterner();
 		this.hasErrors = false;
 		fillIdToEObjectMap(xr);
 	}
@@ -71,6 +75,10 @@ public class DeserializationConversionContext {
 
 		return result;
 	}
+	
+	public int getGrammarElementMapSize () {
+		return grammarIdToGrammarElementMap.length;
+	}
 
 	public void fillIdToEObjectMap(Resource resource) {
 		SerializationUtil.fillIdToEObjectMap(resource, idToEObjectMap);
@@ -98,5 +106,9 @@ public class DeserializationConversionContext {
 
 	public String getCompleteContent() {
 		return completeContent;
+	}
+	
+	public GrammarElementsInterner getArrayInterner() {
+		return arrayInterner;
 	}
 }


### PR DESCRIPTION
The node model contains nodes derived from AbstractNode.  An
AbstractNode has an array describing its grammar elements.  This array
is often identical for many AbstractNodes.  There can be millions of
nodes in a node model so it makes sense to remove the duplicate arrays.
This GrammarElementsInterner tries to reuse an interned version of
such an array wherever possible.  In particular, now we also intern
grammar elements when they are created during the load of a node model
from the node model cache.

Testing this modification on a largisch project showed that the
execution time of a clean build that accesses the node model cache
reduces by around 10%.