### PR TITLE
[eclipse/xtext#1537] bootstrap against 2.19.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -6,7 +6,7 @@ version = '2.20.0-SNAPSHOT'
 
 ext.versions = [
 	'xtext': version,
-	'xtext_bootstrap': '2.19.0.M3',
+	'xtext_bootstrap': '2.19.0',
 	'gradle_plugins': '0.1.0',
 	'xtext_gradle_plugin': '2.0.7',
 	'dependency_management_plugin' : '1.0.8.RELEASE'

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/PartialSerializationTestLanguageStandaloneSetup.xtend
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/PartialSerializationTestLanguageStandaloneSetup.xtend
@@ -7,6 +7,9 @@
  */
 package org.eclipse.xtext.ide.tests.testlanguage
 
+import com.google.inject.Injector
+import org.eclipse.emf.ecore.EPackage
+import org.eclipse.xtext.ide.tests.testlanguage.withtransient.WithtransientPackage
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -16,4 +19,14 @@ class PartialSerializationTestLanguageStandaloneSetup extends PartialSerializati
 	def static void doSetup() {
 		new PartialSerializationTestLanguageStandaloneSetup().createInjectorAndDoEMFRegistration()
 	}
+	
+	override register(Injector injector) {
+		super.register(injector)
+		if (!EPackage.Registry.INSTANCE.containsKey(
+			"http://www.eclipse.org/xtext/ide/tests/testlanguage/mm/withtransient")) {
+			EPackage.Registry.INSTANCE.put("http://www.eclipse.org/xtext/ide/tests/testlanguage/mm/withtransient",
+				WithtransientPackage.eINSTANCE);
+		}
+	}
+	
 }

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/PartialSerializationTestLanguageStandaloneSetup.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/testlanguage/PartialSerializationTestLanguageStandaloneSetup.java
@@ -7,7 +7,10 @@
  */
 package org.eclipse.xtext.ide.tests.testlanguage;
 
+import com.google.inject.Injector;
+import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.xtext.ide.tests.testlanguage.PartialSerializationTestLanguageStandaloneSetupGenerated;
+import org.eclipse.xtext.ide.tests.testlanguage.withtransient.WithtransientPackage;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -16,5 +19,17 @@ import org.eclipse.xtext.ide.tests.testlanguage.PartialSerializationTestLanguage
 public class PartialSerializationTestLanguageStandaloneSetup extends PartialSerializationTestLanguageStandaloneSetupGenerated {
   public static void doSetup() {
     new PartialSerializationTestLanguageStandaloneSetup().createInjectorAndDoEMFRegistration();
+  }
+  
+  @Override
+  public void register(final Injector injector) {
+    super.register(injector);
+    boolean _containsKey = EPackage.Registry.INSTANCE.containsKey(
+      "http://www.eclipse.org/xtext/ide/tests/testlanguage/mm/withtransient");
+    boolean _not = (!_containsKey);
+    if (_not) {
+      EPackage.Registry.INSTANCE.put("http://www.eclipse.org/xtext/ide/tests/testlanguage/mm/withtransient", 
+        WithtransientPackage.eINSTANCE);
+    }
   }
 }


### PR DESCRIPTION
[eclipse/xtext#1537] bootstrap against 2.19.0
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>