### PR TITLE
[https://github.com/eclipse/xtext/issues/1486]

### DIFF
--- a/org.eclipse.xtext/build.gradle
+++ b/org.eclipse.xtext/build.gradle
@@ -26,6 +26,6 @@ sourceSets.main {
 
 jar {
 	from('.') {
-		include 'org/**', 'modeling32.png'
+		include 'org/**', 'modeling32.png', 'xtext32.png'
 	}
 }


### PR DESCRIPTION
- Add xtext32.png to the build.gradle file.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>