### PR TITLE
[eclipse/xtext-core#1252] filter for contained resource descriptions

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainer.java
@@ -12,7 +12,6 @@ import static java.util.Collections.*;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.function.Function;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
@@ -46,24 +45,19 @@ public class StateBasedContainer extends ResourceDescriptionsBasedContainer {
 	
 	@Override
 	protected Iterable<IEObjectDescription> filterByURI(Iterable<IEObjectDescription> unfiltered) {
-		Predicate<IEObjectDescription> predicate = getStateContainsPredicate(input -> input.getEObjectURI().trimFragment());
-		return Iterables.filter(unfiltered, predicate);
-	}
-	
-	protected <T> Predicate<T> getStateContainsPredicate(Function<T, URI> uriProvider) {
-		return new Predicate<T>() {
+		return Iterables.filter(unfiltered, new Predicate<IEObjectDescription>() {
 			private Collection<URI> contents = null;
 
 			@Override
-			public boolean apply(T input) {
+			public boolean apply(IEObjectDescription input) {
 				if(contents == null) {
 					contents = state.getContents();
 				}
-				URI resourceURI = uriProvider.apply(input);
+				URI resourceURI = input.getEObjectURI().trimFragment();
 				final boolean contains = contents.contains(resourceURI);
 				return contains;
 			}
-		};
+		});
 	}
 
 	@Override
@@ -118,9 +112,7 @@ public class StateBasedContainer extends ResourceDescriptionsBasedContainer {
 		if (isEmpty())
 			return emptyList();
 
-		Predicate<IResourceDescription> isResourceDescritptionInState = getStateContainsPredicate(input -> input.getURI());
-		Iterable<IResourceDescription> resourceDescriptionsInState = Iterables.filter(getDescriptions().getAllResourceDescriptions(), isResourceDescritptionInState);
-		return IterableExtensions.flatMap(resourceDescriptionsInState, desc -> desc.getExportedObjectsByType(type));
+		return IterableExtensions.flatMap(getResourceDescriptions(), desc -> desc.getExportedObjectsByType(type));
 	}
 	
 	@Override

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainer.java
@@ -42,6 +42,10 @@ public class StateBasedContainer extends ResourceDescriptionsBasedContainer {
 		super(descriptions);
 		this.state = state;
 	}
+
+	protected IContainerState getState() {
+		return state;
+	}
 	
 	@Override
 	protected Iterable<IEObjectDescription> filterByURI(Iterable<IEObjectDescription> unfiltered) {
@@ -51,7 +55,7 @@ public class StateBasedContainer extends ResourceDescriptionsBasedContainer {
 			@Override
 			public boolean apply(IEObjectDescription input) {
 				if(contents == null) {
-					contents = state.getContents();
+					contents = getState().getContents();
 				}
 				URI resourceURI = input.getEObjectURI().trimFragment();
 				final boolean contains = contents.contains(resourceURI);
@@ -62,22 +66,22 @@ public class StateBasedContainer extends ResourceDescriptionsBasedContainer {
 
 	@Override
 	public boolean hasResourceDescription(URI uri) {
-		return state.contains(uri);
+		return getState().contains(uri);
 	}
 	
 	@Override
 	public int getResourceDescriptionCount() {
-		return state.getContents().size();
+		return getState().getContents().size();
 	}
 
 	@Override
 	public boolean isEmpty() {
-		return state.isEmpty();
+		return getState().isEmpty();
 	}
 	
 	@Override
 	public IResourceDescription getResourceDescription(URI uri) {
-		if (state.contains(uri))
+		if (getState().contains(uri))
 			return getDescriptions().getResourceDescription(uri);
 		return null;
 	}
@@ -92,7 +96,7 @@ public class StateBasedContainer extends ResourceDescriptionsBasedContainer {
 	@Override
 	protected Map<URI, IResourceDescription> doGetUriToDescription() {
 		Map<URI, IResourceDescription> result = Maps.newLinkedHashMap();
-		for(URI uri: state.getContents()) {
+		for(URI uri: getState().getContents()) {
 			IResourceDescription description = getDescriptions().getResourceDescription(uri);
 			if (description != null)
 				result.put(uri, description);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainer.java
@@ -43,7 +43,7 @@ public class StateBasedContainer extends ResourceDescriptionsBasedContainer {
 		this.state = state;
 	}
 
-	protected IContainerState getState() {
+	protected final IContainerState getState() {
 		return state;
 	}
 	
@@ -115,8 +115,7 @@ public class StateBasedContainer extends ResourceDescriptionsBasedContainer {
 	public Iterable<IEObjectDescription> getExportedObjectsByType(EClass type) {
 		if (isEmpty())
 			return emptyList();
-
-		return IterableExtensions.flatMap(getResourceDescriptions(), desc -> desc.getExportedObjectsByType(type));
+		return super.getExportedObjectsByType(type);
 	}
 	
 	@Override

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainer.java
@@ -43,6 +43,9 @@ public class StateBasedContainer extends ResourceDescriptionsBasedContainer {
 		this.state = state;
 	}
 
+	/**
+	 * @since 2.20
+	 */
 	protected final IContainerState getState() {
 		return state;
 	}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainerManager.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainerManager.java
@@ -85,15 +85,16 @@ public class StateBasedContainerManager implements IContainer.Manager {
 		IAllContainersState state = getState(resourceDescriptions);
 		IContainerState containerState = new ContainerState(handle, state);
 		
-		StateBasedContainer result = createStateBasedContainer(resourceDescriptions, containerState);
-		if (state instanceof FlatResourceSetBasedAllContainersState)
+		return createContainer(resourceDescriptions, state, containerState);
+	}
+
+	protected IContainer createContainer(IResourceDescriptions resourceDescriptions, IAllContainersState allContainerState, IContainerState containerState) {
+		StateBasedContainer result = new StateBasedContainer(resourceDescriptions, containerState);
+		
+		if (allContainerState instanceof FlatResourceSetBasedAllContainersState)
 			result.setUriToDescriptionCacheEnabled(false);
 		
 		return result;
-	}
-
-	protected StateBasedContainer createStateBasedContainer(IResourceDescriptions resourceDescriptions, IContainerState containerState) {
-		return new StateBasedContainer(resourceDescriptions, containerState);
 	}
 
 	protected List<IContainer> getVisibleContainers(List<String> handles, IResourceDescriptions resourceDescriptions) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainerManager.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainerManager.java
@@ -84,10 +84,16 @@ public class StateBasedContainerManager implements IContainer.Manager {
 	protected IContainer createContainer(String handle, IResourceDescriptions resourceDescriptions) {
 		IAllContainersState state = getState(resourceDescriptions);
 		IContainerState containerState = new ContainerState(handle, state);
-		StateBasedContainer result = new StateBasedContainer(resourceDescriptions, containerState);
+		
+		StateBasedContainer result = createStateBasedContainer(resourceDescriptions, containerState);
 		if (state instanceof FlatResourceSetBasedAllContainersState)
 			result.setUriToDescriptionCacheEnabled(false);
+		
 		return result;
+	}
+
+	protected StateBasedContainer createStateBasedContainer(IResourceDescriptions resourceDescriptions, IContainerState containerState) {
+		return new StateBasedContainer(resourceDescriptions, containerState);
 	}
 
 	protected List<IContainer> getVisibleContainers(List<String> handles, IResourceDescriptions resourceDescriptions) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainerManager.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainerManager.java
@@ -88,6 +88,9 @@ public class StateBasedContainerManager implements IContainer.Manager {
 		return createContainer(resourceDescriptions, state, containerState);
 	}
 
+	/**
+	 * @since 2.20
+	 */
 	protected IContainer createContainer(IResourceDescriptions resourceDescriptions, IAllContainersState allContainerState, IContainerState containerState) {
 		StateBasedContainer result = new StateBasedContainer(resourceDescriptions, containerState);
 		


### PR DESCRIPTION
before any other filter operation

there is a performance benefit, when first exclude all irrelevant
resources before considering their IEObjectDescriptions

Signed-off-by: gabrield <d.gabriel@bachmann.info>