### PR TITLE
[gitpod] removed .gitpod.yml again

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,0 @@
-tasks:
-- init: ./1-gradle-build.sh


### PR DESCRIPTION
Seems like the Java LS is not ready to handle our mix of Xtend and
Java, even when we build with Gradle. Having a Java-only build
doesn't make to much sense.

Signed-off-by: Jan Koehnlein <jan.koehnlein@typefox.io>