### PR TITLE
log deprecation warning if xtend based postprocessor is used

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/xtext/ecoreInference/XtendXtext2EcorePostProcessor.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/xtext/ecoreInference/XtendXtext2EcorePostProcessor.java
@@ -49,6 +49,7 @@ public class XtendXtext2EcorePostProcessor implements IXtext2EcorePostProcessor 
 	public void process(GeneratedMetamodel metamodel) {
 		Resource xtendFile = loadXtendFile(metamodel);
 		if (xtendFile != null) {
+			logger.warn("You are using an old xtend(1)-based IXtext2EcorePostProcessor. This features is deprecated and will be dropped in a future release of Xtext.");
 			ExecutionContext ctx = getExecutionContext(metamodel);
 			ctx = ctx.cloneWithResource(xtendFile);
 			ResourceLoader currentThreadResourceLoader = null;


### PR DESCRIPTION
log deprecation warning if xtend based postprocessor is used
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>