### PR TITLE
Use mwe2version in POMs and target platform, instead of hard-coding

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full/pom.xml
@@ -39,7 +39,7 @@
 					<dependency>
 						<groupId>org.eclipse.emf</groupId>
 						<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-						<version>2.11.1</version>
+						<version>${mwe2Version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/pom.xml
@@ -8,6 +8,7 @@
 
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
+		<mwe2Version>2.11.1</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/pom.xml
@@ -8,6 +8,7 @@
 
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
+		<mwe2Version>2.11.1</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenFatjar/org.xtext.example.lsMavenFatjar.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenFatjar/org.xtext.example.lsMavenFatjar.parent/pom.xml
@@ -8,6 +8,7 @@
 
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
+		<mwe2Version>2.11.1</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp/pom.xml
@@ -39,7 +39,7 @@
 					<dependency>
 						<groupId>org.eclipse.emf</groupId>
 						<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-						<version>2.11.1</version>
+						<version>${mwe2Version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/pom.xml
@@ -8,6 +8,7 @@
 
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
+		<mwe2Version>2.11.1</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar/pom.xml
@@ -39,7 +39,7 @@
 					<dependency>
 						<groupId>org.eclipse.emf</groupId>
 						<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-						<version>2.11.1</version>
+						<version>${mwe2Version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/pom.xml
@@ -8,6 +8,7 @@
 
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
+		<mwe2Version>2.11.1</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho/pom.xml
@@ -39,7 +39,7 @@
 					<dependency>
 						<groupId>org.eclipse.emf</groupId>
 						<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-						<version>2.11.1</version>
+						<version>${mwe2Version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/pom.xml
@@ -8,6 +8,7 @@
 
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
+		<mwe2Version>2.11.1</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9/pom.xml
@@ -39,7 +39,7 @@
 					<dependency>
 						<groupId>org.eclipse.emf</groupId>
 						<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-						<version>2.11.1</version>
+						<version>${mwe2Version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/pom.xml
@@ -8,6 +8,7 @@
 
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
+		<mwe2Version>2.11.1</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>9</maven.compiler.source>
 		<maven.compiler.target>9</maven.compiler.target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2/pom.xml
@@ -39,7 +39,7 @@
 					<dependency>
 						<groupId>org.eclipse.emf</groupId>
 						<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-						<version>2.11.1</version>
+						<version>${mwe2Version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/pom.xml
@@ -8,6 +8,7 @@
 
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
+		<mwe2Version>2.11.1</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/pom.xml
@@ -8,6 +8,7 @@
 
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
+		<mwe2Version>2.11.1</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
@@ -203,6 +203,7 @@ class ParentProjectDescriptor extends ProjectDescriptor {
 			buildSection = '''
 				<properties>
 					<xtextVersion>«config.xtextVersion»</xtextVersion>
+					<mwe2Version>«config.xtextVersion.mweVersion»</mwe2Version>
 					<project.build.sourceEncoding>«config.encoding»</project.build.sourceEncoding>
 					<maven.compiler.source>«javaVersion»</maven.compiler.source>
 					<maven.compiler.target>«javaVersion»</maven.compiler.target>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
@@ -371,7 +371,7 @@ class RuntimeProjectDescriptor extends TestedProjectDescriptor {
 									<dependency>
 										<groupId>org.eclipse.emf</groupId>
 										<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-										<version>«config.xtextVersion.mweVersion»</version>
+										<version>${mwe2Version}</version>
 									</dependency>
 									<dependency>
 										<groupId>org.eclipse.xtext</groupId>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
@@ -68,7 +68,7 @@ class TargetPlatformProject extends ProjectDescriptor {
 				</location>
 				<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 					<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
-					<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.11.1/"/>
+					<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/«config.xtextVersion.mweVersion»/"/>
 				</location>
 				<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 					<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
@@ -539,6 +539,12 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append("</xtextVersion>");
       _builder.newLineIfNotEmpty();
       _builder.append("\t");
+      _builder.append("<mwe2Version>");
+      String _mweVersion = this.getConfig().getXtextVersion().getMweVersion();
+      _builder.append(_mweVersion, "\t");
+      _builder.append("</mwe2Version>");
+      _builder.newLineIfNotEmpty();
+      _builder.append("\t");
       _builder.append("<project.build.sourceEncoding>");
       Charset _encoding = this.getConfig().getEncoding();
       _builder.append(_encoding, "\t");

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
@@ -878,11 +878,8 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
           _builder.newLine();
           _builder.append("\t\t\t");
           _builder.append("\t\t");
-          _builder.append("<version>");
-          String _mweVersion = this.getConfig().getXtextVersion().getMweVersion();
-          _builder.append(_mweVersion, "\t\t\t\t\t");
-          _builder.append("</version>");
-          _builder.newLineIfNotEmpty();
+          _builder.append("<version>${mwe2Version}</version>");
+          _builder.newLine();
           _builder.append("\t\t\t");
           _builder.append("\t");
           _builder.append("</dependency>");

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
@@ -141,8 +141,11 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.append("<unit id=\"org.eclipse.emf.mwe2.launcher.feature.group\" version=\"0.0.0\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<repository location=\"https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.11.1/\"/>");
-    _builder.newLine();
+    _builder.append("<repository location=\"https://download.eclipse.org/modeling/emft/mwe/updates/releases/");
+    String _mweVersion = this.getConfig().getXtextVersion().getMweVersion();
+    _builder.append(_mweVersion, "\t\t\t");
+    _builder.append("/\"/>");
+    _builder.newLineIfNotEmpty();
     _builder.append("\t\t");
     _builder.append("</location>");
     _builder.newLine();


### PR DESCRIPTION
This PR generates in the POMs of the projects created by the wizard the mwe2Version variable that is used for running the MWE2 generator from Maven, instead of hardcoding the version. This way, the developer can simply update that variable when he/she also updates the Xtext version in the parent POM.

Similarly, the `.target` file is generated by using `config.xtextVersion.mweVersion`; this has no effect on the generated `.target` file but at least it should be easier to keep the generation of the `.target` file consistent.

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>