### PR TITLE
Use mwe2version in Tycho-based POMs instead of hard-coding

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenApp/org.xtext.example.lsMavenApp.parent/pom.xml
@@ -8,7 +8,6 @@
 
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
-		<mwe2Version>2.11.1</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenFatjar/org.xtext.example.lsMavenFatjar.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenFatjar/org.xtext.example.lsMavenFatjar.parent/pom.xml
@@ -8,7 +8,6 @@
 
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
-		<mwe2Version>2.11.1</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/pom.xml
@@ -8,7 +8,6 @@
 
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
-		<mwe2Version>2.11.1</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
@@ -203,7 +203,9 @@ class ParentProjectDescriptor extends ProjectDescriptor {
 			buildSection = '''
 				<properties>
 					<xtextVersion>«config.xtextVersion»</xtextVersion>
+					«IF config.needsTychoBuild»
 					<mwe2Version>«config.xtextVersion.mweVersion»</mwe2Version>
+					«ENDIF»
 					<project.build.sourceEncoding>«config.encoding»</project.build.sourceEncoding>
 					<maven.compiler.source>«javaVersion»</maven.compiler.source>
 					<maven.compiler.target>«javaVersion»</maven.compiler.target>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
@@ -538,12 +538,17 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append(_xtextVersion, "\t");
       _builder.append("</xtextVersion>");
       _builder.newLineIfNotEmpty();
-      _builder.append("\t");
-      _builder.append("<mwe2Version>");
-      String _mweVersion = this.getConfig().getXtextVersion().getMweVersion();
-      _builder.append(_mweVersion, "\t");
-      _builder.append("</mwe2Version>");
-      _builder.newLineIfNotEmpty();
+      {
+        boolean _needsTychoBuild = this.getConfig().needsTychoBuild();
+        if (_needsTychoBuild) {
+          _builder.append("\t");
+          _builder.append("<mwe2Version>");
+          String _mweVersion = this.getConfig().getXtextVersion().getMweVersion();
+          _builder.append(_mweVersion, "\t");
+          _builder.append("</mwe2Version>");
+          _builder.newLineIfNotEmpty();
+        }
+      }
       _builder.append("\t");
       _builder.append("<project.build.sourceEncoding>");
       Charset _encoding = this.getConfig().getEncoding();
@@ -563,8 +568,8 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append("</maven.compiler.target>");
       _builder.newLineIfNotEmpty();
       {
-        boolean _needsTychoBuild = this.getConfig().needsTychoBuild();
-        if (_needsTychoBuild) {
+        boolean _needsTychoBuild_1 = this.getConfig().needsTychoBuild();
+        if (_needsTychoBuild_1) {
           _builder.append("\t");
           _builder.append("<!-- Tycho settings -->");
           _builder.newLine();
@@ -652,8 +657,8 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append("<build>");
       _builder.newLine();
       {
-        boolean _needsTychoBuild_1 = this.getConfig().needsTychoBuild();
-        if (_needsTychoBuild_1) {
+        boolean _needsTychoBuild_2 = this.getConfig().needsTychoBuild();
+        if (_needsTychoBuild_2) {
           _builder.append("\t");
           _builder.append("<plugins>");
           _builder.newLine();
@@ -1217,8 +1222,8 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append("</plugin>");
       _builder.newLine();
       {
-        boolean _needsTychoBuild_2 = this.getConfig().needsTychoBuild();
-        boolean _not = (!_needsTychoBuild_2);
+        boolean _needsTychoBuild_3 = this.getConfig().needsTychoBuild();
+        boolean _not = (!_needsTychoBuild_3);
         if (_not) {
           _builder.append("\t\t\t");
           _builder.append("<plugin>");
@@ -1404,8 +1409,8 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append("</pluginExecution>");
       _builder.newLine();
       {
-        boolean _needsTychoBuild_3 = this.getConfig().needsTychoBuild();
-        if (_needsTychoBuild_3) {
+        boolean _needsTychoBuild_4 = this.getConfig().needsTychoBuild();
+        if (_needsTychoBuild_4) {
           _builder.append("\t\t\t\t\t\t\t");
           _builder.append("<pluginExecution>");
           _builder.newLine();
@@ -1581,8 +1586,8 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append("</plugin>");
       _builder.newLine();
       {
-        boolean _needsTychoBuild_4 = this.getConfig().needsTychoBuild();
-        if (_needsTychoBuild_4) {
+        boolean _needsTychoBuild_5 = this.getConfig().needsTychoBuild();
+        if (_needsTychoBuild_5) {
           _builder.append("\t\t\t");
           _builder.append("<plugin>");
           _builder.newLine();


### PR DESCRIPTION
This PR generates in the POMs of the projects created by the wizard the mwe2Version variable that is used for running the MWE2 generator from Maven, instead of hardcoding the version. It does so only on Tycho-based projects.

I think it's better to generate the property right after the property for the xtext version (instead of later in the Tycho section).

see also #1305 

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>