### PR TITLE
[#1304] Refactor retrieval of the own manifest URL

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/XtextVersionTests.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/XtextVersionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,12 +9,15 @@ package org.eclipse.xtext.util;
 
 import static org.junit.Assert.*;
 
+import java.util.regex.Pattern;
+
 import org.junit.Test;
 
 /**
  * @author dhuebner - Initial contribution and API
  */
 public class XtextVersionTests {
+	private static Pattern VERSION_MATCHER = Pattern.compile("\\d\\.\\d+\\.\\d+(?:-SNAPSHOT)?");
 
 	@Test
 	public void testVersionKinds() {
@@ -46,5 +49,21 @@ public class XtextVersionTests {
 		assertFalse(version.isSnapshot());
 		assertFalse(version.isStable());
 		
+	}
+
+	@Test
+	public void test_getCurrent() {
+		// just to show what the pattern matches
+		assertTrue(VERSION_MATCHER.matcher("2.20.0").matches());
+		assertTrue(VERSION_MATCHER.matcher("2.20.0-SNAPSHOT").matches());
+		
+		assertFalse(VERSION_MATCHER.matcher("2.20.0.qualifier").matches());
+		assertFalse(VERSION_MATCHER.matcher("2.20.0.vSomething").matches());
+		assertFalse(VERSION_MATCHER.matcher("2.20").matches());
+		
+		XtextVersion xtextVersion = XtextVersion.getCurrent();
+		assertNotNull(xtextVersion);
+		String version = xtextVersion.getVersion();
+		assertTrue(VERSION_MATCHER.matcher(version).matches());
 	}
 }


### PR DESCRIPTION
This changes the way the MANIFEST.MF for org.eclipse.xtext.util is
located. It uses the classloader to locate the class resource of
XtextVersion and resolves the URL relative to the resource. It considers
the case that the class resource can be either on file system or
packaged in an archive, which varies the relative location.

Add a test case for XtextVersion#getCurrent() to cover the regression
that arised by the recent refactoring from Xtend to Java.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>