### PR TITLE
Add end line and end column positions to Issue. Also initialise lines and columns with 0.

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/diagnostics/AbstractDiagnostic.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/diagnostics/AbstractDiagnostic.java
@@ -58,6 +58,25 @@ public abstract class AbstractDiagnostic implements Diagnostic {
 			return node.getStartLine();
 		return -1;
 	}
+	
+
+	@Override
+	public int getLineEnd() {
+		INode node = getNode();
+		if (node != null)
+			return node.getEndLine();
+		return -1;
+	}
+
+	@Override
+	public int getColumnEnd() {
+		INode node = getNode();
+		if (node != null) {
+			LineAndColumn lineAndColumn = NodeModelUtils.getLineAndColumn(node, getOffset() + getLength());
+			return lineAndColumn.getColumn();
+		}
+		return 0;
+	}
 
 	@Override
 	public String getLocation() {
@@ -86,5 +105,4 @@ public abstract class AbstractDiagnostic implements Diagnostic {
 		b.append(getMessage());
 		return b.toString();
 	}
-
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/diagnostics/Diagnostic.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/diagnostics/Diagnostic.java
@@ -58,6 +58,8 @@ public interface Diagnostic extends org.eclipse.emf.ecore.resource.Resource.Diag
      * Returns the end line location of the issue within the source.
      * Line <code>1</code> is the first line.
      * @return the end line location of the issue.
+	 * 
+	 * @since 2.21
      */
     int getLineEnd();
 
@@ -65,6 +67,8 @@ public interface Diagnostic extends org.eclipse.emf.ecore.resource.Resource.Diag
      * Returns the end column location of the issue within the source.
      * Column <code>1</code> is the first column.
      * @return the end column location of the issue.
+	 * 
+	 * @since 2.21
      */
     int getColumnEnd();
 

--- a/org.eclipse.xtext/src/org/eclipse/xtext/diagnostics/Diagnostic.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/diagnostics/Diagnostic.java
@@ -54,4 +54,18 @@ public interface Diagnostic extends org.eclipse.emf.ecore.resource.Resource.Diag
 	 */
 	int getLength();
 
+    /**
+     * Returns the end line location of the issue within the source.
+     * Line <code>1</code> is the first line.
+     * @return the end line location of the issue.
+     */
+    int getLineEnd();
+
+    /**
+     * Returns the end column location of the issue within the source.
+     * Column <code>1</code> is the first column.
+     * @return the end column location of the issue.
+     */
+    int getColumnEnd();
+
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/diagnostics/Diagnostic.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/diagnostics/Diagnostic.java
@@ -10,7 +10,8 @@ package org.eclipse.xtext.diagnostics;
 /**
  * A specialized {@link org.eclipse.emf.ecore.resource.Resource.Diagnostic} that knows 
  * about the region in the document, e.g. the {@link #getOffset()} and {@link #getLength()}
- * of the issue source.
+ * of the issue source. A region starts in a start line before a start column and ends in an end
+ * line before an end column.
  * 
  * Implementors should inherit from {@link AbstractDiagnostic} instead of implementing this 
  * interface directly.
@@ -54,22 +55,25 @@ public interface Diagnostic extends org.eclipse.emf.ecore.resource.Resource.Diag
 	 */
 	int getLength();
 
-    /**
-     * Returns the end line location of the issue within the source.
-     * Line <code>1</code> is the first line.
-     * @return the end line location of the issue.
+	/**
+	 * Returns the end line location of the issue within the source.
+	 * Line <code>1</code> is the first line of a document.
+	 * 
+	 * @return the end line location of the issue.
 	 * 
 	 * @since 2.21
-     */
-    int getLineEnd();
+	 */
+	int getLineEnd();
 
-    /**
-     * Returns the end column location of the issue within the source.
-     * Column <code>1</code> is the first column.
-     * @return the end column location of the issue.
+	/**
+	 * Returns the end column location of the issue within the source.
+	 * The region does not include the end column character itself.
+	 * Column <code>1</code> is the first column of a line.
+	 * 
+	 * @return the end column location of the issue.
 	 * 
 	 * @since 2.21
-     */
-    int getColumnEnd();
+	 */
+	int getColumnEnd();
 
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/diagnostics/ExceptionDiagnostic.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/diagnostics/ExceptionDiagnostic.java
@@ -39,6 +39,16 @@ public class ExceptionDiagnostic implements Diagnostic {
 	}
 
 	@Override
+	public int getColumnEnd() {
+		return 0;
+	}
+
+	@Override
+	public int getLineEnd() {
+		return 1;
+	}
+
+	@Override
 	public String getLocation() {
 		return null;
 	}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/validation/DiagnosticConverterImpl.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/validation/DiagnosticConverterImpl.java
@@ -256,6 +256,9 @@ public class DiagnosticConverterImpl implements IDiagnosticConverter {
 		return new IssueLocation();
 	}
 
+	/**
+	 * Computes {@link IssueLocation} for the given node.
+	 */
 	protected IssueLocation getLocationForNode(INode node) {
 		ITextRegionWithLineInformation nodeRegion = node.getTextRegionWithLineInformation();
 		int offset = nodeRegion.getOffset();
@@ -263,6 +266,11 @@ public class DiagnosticConverterImpl implements IDiagnosticConverter {
 		return getLocationForNode(node, offset, length);
 	}
 
+	/**
+	 * Computes {@link IssueLocation} for the given offset and length in the given node.
+	 * 
+	 * @since 2.21
+	 */
 	protected IssueLocation getLocationForNode(INode node, int offset, int length) {
 		IssueLocation result = new IssueLocation();
 		result.offset = offset;

--- a/org.eclipse.xtext/src/org/eclipse/xtext/validation/DiagnosticConverterImpl.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/validation/DiagnosticConverterImpl.java
@@ -244,6 +244,15 @@ public class DiagnosticConverterImpl implements IDiagnosticConverter {
 					containingFeature.isMany() ? ((EList<?>) container.eGet(containingFeature)).indexOf(obj)
 							: ValidationMessageAcceptor.INSIGNIFICANT_INDEX);
 		}
+		
+		// place issue at start of document since we lack location information
+		IssueLocation startOfDocumentLocation = new IssueLocation();
+		startOfDocumentLocation.offset = 0;
+		startOfDocumentLocation.length = 0;
+		startOfDocumentLocation.lineNumber = 1;
+		startOfDocumentLocation.column = 1;
+		startOfDocumentLocation.lineNumberEnd = 1;
+		startOfDocumentLocation.columnEnd = 1;
 		return new IssueLocation();
 	}
 

--- a/org.eclipse.xtext/src/org/eclipse/xtext/validation/DiagnosticConverterImpl.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/validation/DiagnosticConverterImpl.java
@@ -38,17 +38,25 @@ public class DiagnosticConverterImpl implements IDiagnosticConverter {
 		/**
 		 * 1-based line number.
 		 */
-		public Integer lineNumber;
+		public Integer lineNumber = 0;
 		/**
 		 * 1-based column.
 		 * @since 2.9
 		 */
-		public Integer column;
+		public Integer column = 0;
+		/**
+		 * 1-based line number end.
+		 */
+		public Integer lineNumberEnd = 0;
+		/**
+		 * 1-based column end.
+		 */
+		public Integer columnEnd = 0;
 		/**
 		 * 0-based offset.
 		 */
-		public Integer offset;
-		public Integer length;
+		public Integer offset = 0;
+		public Integer length = 0;
 	}
 	
 	@Override
@@ -70,6 +78,8 @@ public class DiagnosticConverterImpl implements IDiagnosticConverter {
 			issue.setUriToProblem(castedDiagnostic.getUriToProblem());
 			issue.setCode(castedDiagnostic.getCode());
 			issue.setData(castedDiagnostic.getData());
+			issue.setLineNumberEnd(castedDiagnostic.getLineEnd());
+			issue.setColumnEnd(castedDiagnostic.getColumnEnd());
 		}
 		issue.setType(CheckType.FAST);
 		acceptor.accept(issue);
@@ -90,6 +100,8 @@ public class DiagnosticConverterImpl implements IDiagnosticConverter {
 			issue.setColumn(locationData.column);
 			issue.setOffset(locationData.offset);
 			issue.setLength(locationData.length);
+			issue.setLineNumberEnd(locationData.lineNumberEnd);
+			issue.setColumnEnd(locationData.columnEnd);
 		}
 		final EObject causer = getCauser(diagnostic);
 		if (causer != null)
@@ -191,14 +203,7 @@ public class DiagnosticConverterImpl implements IDiagnosticConverter {
 			if (diagnostic instanceof RangeBasedDiagnostic) {
 				RangeBasedDiagnostic castedDiagnostic = (RangeBasedDiagnostic) diagnostic;
 				INode parserNode = NodeModelUtils.getNode(causer);
-				IssueLocation result = new IssueLocation();
-				if (parserNode != null) {
-					LineAndColumn lineAndColumn = NodeModelUtils.getLineAndColumn(parserNode, castedDiagnostic.getOffset());
-					result.lineNumber = lineAndColumn.getLine();
-					result.column = lineAndColumn.getColumn();
-				}
-				result.offset = castedDiagnostic.getOffset();
-				result.length = castedDiagnostic.getLength();
+				IssueLocation result = getLocationForNode(parserNode, castedDiagnostic.getOffset(), castedDiagnostic.getLength());
 				return result;
 			} else if (diagnostic instanceof FeatureBasedDiagnostic) {
 				 FeatureBasedDiagnostic castedDiagnostic = (FeatureBasedDiagnostic) diagnostic;
@@ -239,21 +244,28 @@ public class DiagnosticConverterImpl implements IDiagnosticConverter {
 					containingFeature.isMany() ? ((EList<?>) container.eGet(containingFeature)).indexOf(obj)
 							: ValidationMessageAcceptor.INSIGNIFICANT_INDEX);
 		}
-		IssueLocation result = new IssueLocation();
-		result.lineNumber = 1;
-		result.column = 1;
-		result.offset = 0;
-		result.length = 0;
-		return result;
+		return new IssueLocation();
 	}
 
 	protected IssueLocation getLocationForNode(INode node) {
 		ITextRegionWithLineInformation nodeRegion = node.getTextRegionWithLineInformation();
+		int offset = nodeRegion.getOffset();
+		int length = nodeRegion.getLength();
+		return getLocationForNode(node, offset, length);
+	}
+
+	protected IssueLocation getLocationForNode(INode node, int offset, int length) {
 		IssueLocation result = new IssueLocation();
-		result.lineNumber = nodeRegion.getLineNumber();
-		result.offset = nodeRegion.getOffset();
-		result.column = NodeModelUtils.getLineAndColumn(node, result.offset).getColumn();
-		result.length = nodeRegion.getLength();
+		result.offset = offset;
+		result.length = length;
+		
+		LineAndColumn lineAndColumnStart = NodeModelUtils.getLineAndColumn(node, offset);
+		result.lineNumber = lineAndColumnStart.getLine();
+		result.column = lineAndColumnStart.getColumn();
+		
+		LineAndColumn lineAndColumnEnd = NodeModelUtils.getLineAndColumn(node, offset + length);
+		result.lineNumberEnd = lineAndColumnEnd.getLine();
+		result.columnEnd = lineAndColumnEnd.getColumn();
 		return result;
 	}
 

--- a/org.eclipse.xtext/src/org/eclipse/xtext/validation/Issue.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/validation/Issue.java
@@ -43,17 +43,29 @@ public interface Issue {
 	 * Returns the one-based line number of the issue.
 	 */
 	Integer getLineNumber();
+
+	/**
+	 * Returns the one-based line number of the end of the issue.
+	 */
+	Integer getLineNumberEnd();
 	
 	/**
 	 * Returns the column in the line of the issue. It's not the virtual column but literally
 	 * the character offset in the column, e.g. tab ('\t') counts as one character.
 	 * The first char in a line has column number 1, the number is one-based.
 	 * 
-	 * If no column information is available, returns -1.
-	 * 
 	 * @since 2.9
 	 */
 	Integer getColumn();
+	
+	/**
+	 * Returns the end column in the line of the issue. It's not the virtual end column but literally
+	 * the character end offset in the column, e.g. tab ('\t') counts as one character.
+	 * The first char in a line has column number 1, the number is one-based.
+	 * 
+	 * @since 2.9
+	 */
+	Integer getColumnEnd();
 
 	Integer getOffset();
 
@@ -70,7 +82,9 @@ public interface Issue {
 		
 		private static Logger LOG = Logger.getLogger(IssueImpl.class);
 
-		private Integer length, lineNumber, offset, column;
+		private Integer offset = 0, length = 0;
+		private Integer lineNumber = 0, column = 0;
+		private Integer lineNumberEnd = 0, columnEnd = 0;
 		private String code, message;
 		private boolean isSyntaxError = false;
 		private URI uriToProblem;
@@ -101,6 +115,14 @@ public interface Issue {
 			this.lineNumber = lineNumber;
 		}
 		
+		public Integer getLineNumberEnd() {
+			return lineNumberEnd;
+		}
+		
+		public void setLineNumberEnd(Integer lineNumberEnd) {
+			this.lineNumberEnd = lineNumberEnd;
+		}
+		
 		/**
 		 * @since 2.9
 		 */
@@ -114,6 +136,14 @@ public interface Issue {
 		 */
 		public void setColumn(Integer column) {
 			this.column = column;
+		}
+
+		public Integer getColumnEnd() {
+			return columnEnd;
+		}
+		
+		public void setColumnEnd(Integer columnEnd) {
+			this.columnEnd = columnEnd;
 		}
 
 		@Override

--- a/org.eclipse.xtext/src/org/eclipse/xtext/validation/Issue.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/validation/Issue.java
@@ -46,6 +46,8 @@ public interface Issue {
 
 	/**
 	 * Returns the one-based line number of the end of the issue.
+	 * 
+	 * @since 2.21
 	 */
 	Integer getLineNumberEnd();
 	
@@ -63,7 +65,7 @@ public interface Issue {
 	 * the character end offset in the column, e.g. tab ('\t') counts as one character.
 	 * The first char in a line has column number 1, the number is one-based.
 	 * 
-	 * @since 2.9
+	 * @since 2.21
 	 */
 	Integer getColumnEnd();
 

--- a/org.eclipse.xtext/src/org/eclipse/xtext/validation/Issue.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/validation/Issue.java
@@ -41,13 +41,13 @@ public interface Issue {
 
 	/**
 	 * Returns the one-based line number of the issue.
-	 * Values smaller than 1 are invalid.
+	 * Values smaller than 1 and null values are invalid and indicate the absence of line information on this issue.
 	 */
 	Integer getLineNumber();
 
 	/**
 	 * Returns the one-based line number of the end of the issue.
-	 * Values smaller than 1 are invalid.
+	 * Values smaller than 1 and null values are invalid and indicate the absence of line information on this issue.
 	 * 
 	 * @since 2.21
 	 */
@@ -69,7 +69,7 @@ public interface Issue {
 	 * Returns the end column in the line of the issue. It's not the virtual end column but literally
 	 * the character end offset in the column, e.g. tab ('\t') counts as one character.
 	 * The first char in a line has column number 1, the number is one-based.
-	 * Values smaller than 1 and null values are invalid and indicate the absence of line information on this issue.
+	 * Values smaller than 1 and null values are invalid and indicate the absence of column information on this issue.
 	 * 
 	 * The region defined by line and column information does not include the character at the end column.
 	 * 

--- a/org.eclipse.xtext/src/org/eclipse/xtext/validation/Issue.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/validation/Issue.java
@@ -57,7 +57,7 @@ public interface Issue {
 	 * Returns the column in the line of the issue. It's not the virtual column but literally
 	 * the character offset in the column, e.g. tab ('\t') counts as one character.
 	 * The first char in a line has column number 1, the number is one-based.
-	 * Values smaller than 1 are invalid.
+	 * Values smaller than 1 and null values are invalid and indicate the absence of column information on this issue.
 	 * 
 	 * The region defined by line and column information includes the character at the start column.
 	 * 
@@ -69,7 +69,7 @@ public interface Issue {
 	 * Returns the end column in the line of the issue. It's not the virtual end column but literally
 	 * the character end offset in the column, e.g. tab ('\t') counts as one character.
 	 * The first char in a line has column number 1, the number is one-based.
-	 * Values smaller than 1 are invalid.
+	 * Values smaller than 1 and null values are invalid and indicate the absence of line information on this issue.
 	 * 
 	 * The region defined by line and column information does not include the character at the end column.
 	 * 

--- a/org.eclipse.xtext/src/org/eclipse/xtext/validation/Issue.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/validation/Issue.java
@@ -41,11 +41,13 @@ public interface Issue {
 
 	/**
 	 * Returns the one-based line number of the issue.
+	 * Values smaller than 1 are invalid.
 	 */
 	Integer getLineNumber();
 
 	/**
 	 * Returns the one-based line number of the end of the issue.
+	 * Values smaller than 1 are invalid.
 	 * 
 	 * @since 2.21
 	 */
@@ -55,6 +57,9 @@ public interface Issue {
 	 * Returns the column in the line of the issue. It's not the virtual column but literally
 	 * the character offset in the column, e.g. tab ('\t') counts as one character.
 	 * The first char in a line has column number 1, the number is one-based.
+	 * Values smaller than 1 are invalid.
+	 * 
+	 * The region defined by line and column information includes the character at the start column.
 	 * 
 	 * @since 2.9
 	 */
@@ -64,6 +69,9 @@ public interface Issue {
 	 * Returns the end column in the line of the issue. It's not the virtual end column but literally
 	 * the character end offset in the column, e.g. tab ('\t') counts as one character.
 	 * The first char in a line has column number 1, the number is one-based.
+	 * Values smaller than 1 are invalid.
+	 * 
+	 * The region defined by line and column information does not include the character at the end column.
 	 * 
 	 * @since 2.21
 	 */
@@ -116,11 +124,17 @@ public interface Issue {
 		public void setLineNumber(Integer lineNumber) {
 			this.lineNumber = lineNumber;
 		}
-		
+
+		/**
+		 * @since 2.21
+		 */
 		public Integer getLineNumberEnd() {
 			return lineNumberEnd;
 		}
-		
+
+		/**
+		 * @since 2.21
+		 */
 		public void setLineNumberEnd(Integer lineNumberEnd) {
 			this.lineNumberEnd = lineNumberEnd;
 		}
@@ -140,10 +154,16 @@ public interface Issue {
 			this.column = column;
 		}
 
+		/**
+		 * @since 2.21
+		 */
 		public Integer getColumnEnd() {
 			return columnEnd;
 		}
-		
+
+		/**
+		 * @since 2.21
+		 */
 		public void setColumnEnd(Integer columnEnd) {
 			this.columnEnd = columnEnd;
 		}


### PR DESCRIPTION
Currently, end line and end column information is not part of `Issue`, `IssueImpl`, `IssueLocation`, `AbstractDiagnostic`, and `ExceptionDiagnostic`. It is helpful to have this information in these classes, because otherwise (i.e. now in `LanguageServerImpl#toDiagnostic(Issue)`) this information has to be computed by loading the `Document` again.