### PR TITLE
[#1318] added missing xtend.lib dependency to make sure AA can run

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/projectWizard/TemplateProjectWizardFragment.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/projectWizard/TemplateProjectWizardFragment.xtend
@@ -60,7 +60,8 @@ class TemplateProjectWizardFragment extends AbstractXtextGeneratorFragment {
 				"org.eclipse.core.resources",
 				"org.eclipse.ui",
 				"org.eclipse.ui.ide",
-				"org.eclipse.ui.forms"
+				"org.eclipse.ui.forms",
+				"org.eclipse.xtend.lib"
 			]
 			if (pluginProject) {
 				projectConfig.eclipsePlugin.manifest.requiredBundles += #[

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/projectWizard/TemplateProjectWizardFragment.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/projectWizard/TemplateProjectWizardFragment.java
@@ -83,7 +83,7 @@ public class TemplateProjectWizardFragment extends AbstractXtextGeneratorFragmen
     boolean _tripleNotEquals = (_manifest != null);
     if (_tripleNotEquals) {
       Set<String> _requiredBundles = this.getProjectConfig().getEclipsePlugin().getManifest().getRequiredBundles();
-      Iterables.<String>addAll(_requiredBundles, Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("org.eclipse.core.runtime", "org.eclipse.core.resources", "org.eclipse.ui", "org.eclipse.ui.ide", "org.eclipse.ui.forms")));
+      Iterables.<String>addAll(_requiredBundles, Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("org.eclipse.core.runtime", "org.eclipse.core.resources", "org.eclipse.ui", "org.eclipse.ui.ide", "org.eclipse.ui.forms", "org.eclipse.xtend.lib")));
       if (this.pluginProject) {
         Set<String> _requiredBundles_1 = this.getProjectConfig().getEclipsePlugin().getManifest().getRequiredBundles();
         Iterables.<String>addAll(_requiredBundles_1, Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("org.eclipse.jdt.core", "org.eclipse.pde.core")));


### PR DESCRIPTION
[#1318] added missing xtend.lib dependency to make sure AA can run
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>