### PR TITLE
Log Exceptions thrown in futures created by the RequestManger

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.xtend
@@ -23,6 +23,8 @@ import org.junit.Test
 
 import static org.junit.Assert.*
 import org.junit.Assert
+import org.eclipse.xtext.ide.server.concurrent.WriteRequest
+import org.eclipse.xtext.ide.server.concurrent.ReadRequest
 
 /**
  * @author kosyakov - Initial contribution and API
@@ -48,7 +50,7 @@ class RequestManagerTest {
 
 	@Test(timeout = 1000)
 	def void testRunWriteLogExceptionNonCancellable() {
-		val logResult = LoggingTester.captureLogging(Level.ALL, RequestManager, [
+		val logResult = LoggingTester.captureLogging(Level.ALL, WriteRequest, [
 			val future = requestManager.runWrite([], [
 				throw new RuntimeException();
 			])
@@ -64,7 +66,7 @@ class RequestManagerTest {
 
 	@Test(timeout = 1000)
 	def void testRunWriteLogExceptionCancellable() {
-		val logResult = LoggingTester.captureLogging(Level.ALL, RequestManager, [
+		val logResult = LoggingTester.captureLogging(Level.ALL, WriteRequest, [
 			val future = requestManager.runWrite([
 				throw new RuntimeException();
 			], [])
@@ -80,7 +82,7 @@ class RequestManagerTest {
 
 	@Test(timeout = 1000, expected = ExecutionException)
 	def void testRunWriteCatchException() {
-		LoggingTester.captureLogging(Level.ALL, RequestManager, [
+		LoggingTester.captureLogging(Level.ALL, WriteRequest, [
 			val future = requestManager.runWrite([
 				throw new RuntimeException()
 			], [])
@@ -88,12 +90,12 @@ class RequestManagerTest {
 			assertEquals('Foo', future.get)
 		])
 		
-		Assert.fail
+		Assert.fail("unreachable")
 	}
 
 	@Test(timeout = 1000)
 	def void testRunReadLogException() {
-		val logResult = LoggingTester.captureLogging(Level.ALL, RequestManager, [
+		val logResult = LoggingTester.captureLogging(Level.ALL, ReadRequest, [
 			val future = requestManager.runRead([
 				throw new RuntimeException();
 			])
@@ -109,7 +111,7 @@ class RequestManagerTest {
 
 	@Test(timeout = 1000, expected = ExecutionException)
 	def void testRunReadCatchException() {
-		LoggingTester.captureLogging(Level.ALL, RequestManager, [
+		LoggingTester.captureLogging(Level.ALL, ReadRequest, [
 			val future = requestManager.runRead([
 				throw new RuntimeException()
 			])

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.xtend
@@ -47,7 +47,23 @@ class RequestManagerTest {
 	}
 
 	@Test(timeout = 1000)
-	def void testLogException() {
+	def void testRunWriteLogExceptionNonCancellable() {
+		val logResult = LoggingTester.captureLogging(Level.ALL, RequestManager, [
+			val future = requestManager.runWrite([], [
+				throw new RuntimeException();
+			])
+			
+			// join future to assert log later
+			try {
+				future.join
+			} catch (Exception e) {}
+		])
+		
+		logResult.assertLogEntry("Error during request:")
+	}
+
+	@Test(timeout = 1000)
+	def void testRunWriteLogExceptionCancellable() {
 		val logResult = LoggingTester.captureLogging(Level.ALL, RequestManager, [
 			val future = requestManager.runWrite([
 				throw new RuntimeException();
@@ -55,7 +71,7 @@ class RequestManagerTest {
 			
 			// join future to assert log later
 			try {
-				future.get
+				future.join
 			} catch (Exception e) {}
 		])
 		
@@ -63,11 +79,40 @@ class RequestManagerTest {
 	}
 
 	@Test(timeout = 1000, expected = ExecutionException)
-	def void testCatchException() {
+	def void testRunWriteCatchException() {
 		LoggingTester.captureLogging(Level.ALL, RequestManager, [
 			val future = requestManager.runWrite([
 				throw new RuntimeException()
 			], [])
+
+			assertEquals('Foo', future.get)
+		])
+		
+		Assert.fail
+	}
+
+	@Test(timeout = 1000)
+	def void testRunReadLogException() {
+		val logResult = LoggingTester.captureLogging(Level.ALL, RequestManager, [
+			val future = requestManager.runRead([
+				throw new RuntimeException();
+			])
+			
+			// join future to assert log later
+			try {
+				future.join
+			} catch (Exception e) {}
+		])
+		
+		logResult.assertLogEntry("Error during request:")
+	}
+
+	@Test(timeout = 1000, expected = ExecutionException)
+	def void testRunReadCatchException() {
+		LoggingTester.captureLogging(Level.ALL, RequestManager, [
+			val future = requestManager.runRead([
+				throw new RuntimeException()
+			])
 
 			assertEquals('Foo', future.get)
 		])

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.java
@@ -53,7 +53,30 @@ public class RequestManagerTest {
   }
   
   @Test(timeout = 1000)
-  public void testLogException() {
+  public void testRunWriteLogExceptionNonCancellable() {
+    final Runnable _function = () -> {
+      final Function0<Object> _function_1 = () -> {
+        return null;
+      };
+      final Function2<CancelIndicator, Object, Object> _function_2 = (CancelIndicator $0, Object $1) -> {
+        throw new RuntimeException();
+      };
+      final CompletableFuture<Object> future = this.requestManager.<Object, Object>runWrite(_function_1, _function_2);
+      try {
+        future.join();
+      } catch (final Throwable _t) {
+        if (_t instanceof Exception) {
+        } else {
+          throw Exceptions.sneakyThrow(_t);
+        }
+      }
+    };
+    final LoggingTester.LogCapture logResult = LoggingTester.captureLogging(Level.ALL, RequestManager.class, _function);
+    logResult.assertLogEntry("Error during request:");
+  }
+  
+  @Test(timeout = 1000)
+  public void testRunWriteLogExceptionCancellable() {
     final Runnable _function = () -> {
       final Function0<Object> _function_1 = () -> {
         throw new RuntimeException();
@@ -63,7 +86,7 @@ public class RequestManagerTest {
       };
       final CompletableFuture<Object> future = this.requestManager.<Object, Object>runWrite(_function_1, _function_2);
       try {
-        future.get();
+        future.join();
       } catch (final Throwable _t) {
         if (_t instanceof Exception) {
         } else {
@@ -76,7 +99,7 @@ public class RequestManagerTest {
   }
   
   @Test(timeout = 1000, expected = ExecutionException.class)
-  public void testCatchException() {
+  public void testRunWriteCatchException() {
     final Runnable _function = () -> {
       try {
         final Function0<Object> _function_1 = () -> {
@@ -86,6 +109,43 @@ public class RequestManagerTest {
           return null;
         };
         final CompletableFuture<Object> future = this.requestManager.<Object, Object>runWrite(_function_1, _function_2);
+        Assert.assertEquals("Foo", future.get());
+      } catch (Throwable _e) {
+        throw Exceptions.sneakyThrow(_e);
+      }
+    };
+    LoggingTester.captureLogging(Level.ALL, RequestManager.class, _function);
+    Assert.fail();
+  }
+  
+  @Test(timeout = 1000)
+  public void testRunReadLogException() {
+    final Runnable _function = () -> {
+      final Function1<CancelIndicator, Object> _function_1 = (CancelIndicator it) -> {
+        throw new RuntimeException();
+      };
+      final CompletableFuture<Object> future = this.requestManager.<Object>runRead(_function_1);
+      try {
+        future.join();
+      } catch (final Throwable _t) {
+        if (_t instanceof Exception) {
+        } else {
+          throw Exceptions.sneakyThrow(_t);
+        }
+      }
+    };
+    final LoggingTester.LogCapture logResult = LoggingTester.captureLogging(Level.ALL, RequestManager.class, _function);
+    logResult.assertLogEntry("Error during request:");
+  }
+  
+  @Test(timeout = 1000, expected = ExecutionException.class)
+  public void testRunReadCatchException() {
+    final Runnable _function = () -> {
+      try {
+        final Function1<CancelIndicator, Object> _function_1 = (CancelIndicator it) -> {
+          throw new RuntimeException();
+        };
+        final CompletableFuture<Object> future = this.requestManager.<Object>runRead(_function_1);
         Assert.assertEquals("Foo", future.get());
       } catch (Throwable _e) {
         throw Exceptions.sneakyThrow(_e);

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.java
@@ -15,7 +15,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.log4j.Level;
 import org.eclipse.xtext.ide.server.ServerModule;
+import org.eclipse.xtext.ide.server.concurrent.ReadRequest;
 import org.eclipse.xtext.ide.server.concurrent.RequestManager;
+import org.eclipse.xtext.ide.server.concurrent.WriteRequest;
 import org.eclipse.xtext.testing.logging.LoggingTester;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.xbase.lib.Exceptions;
@@ -71,7 +73,7 @@ public class RequestManagerTest {
         }
       }
     };
-    final LoggingTester.LogCapture logResult = LoggingTester.captureLogging(Level.ALL, RequestManager.class, _function);
+    final LoggingTester.LogCapture logResult = LoggingTester.captureLogging(Level.ALL, WriteRequest.class, _function);
     logResult.assertLogEntry("Error during request:");
   }
   
@@ -94,7 +96,7 @@ public class RequestManagerTest {
         }
       }
     };
-    final LoggingTester.LogCapture logResult = LoggingTester.captureLogging(Level.ALL, RequestManager.class, _function);
+    final LoggingTester.LogCapture logResult = LoggingTester.captureLogging(Level.ALL, WriteRequest.class, _function);
     logResult.assertLogEntry("Error during request:");
   }
   
@@ -114,8 +116,8 @@ public class RequestManagerTest {
         throw Exceptions.sneakyThrow(_e);
       }
     };
-    LoggingTester.captureLogging(Level.ALL, RequestManager.class, _function);
-    Assert.fail();
+    LoggingTester.captureLogging(Level.ALL, WriteRequest.class, _function);
+    Assert.fail("unreachable");
   }
   
   @Test(timeout = 1000)
@@ -134,7 +136,7 @@ public class RequestManagerTest {
         }
       }
     };
-    final LoggingTester.LogCapture logResult = LoggingTester.captureLogging(Level.ALL, RequestManager.class, _function);
+    final LoggingTester.LogCapture logResult = LoggingTester.captureLogging(Level.ALL, ReadRequest.class, _function);
     logResult.assertLogEntry("Error during request:");
   }
   
@@ -151,7 +153,7 @@ public class RequestManagerTest {
         throw Exceptions.sneakyThrow(_e);
       }
     };
-    LoggingTester.captureLogging(Level.ALL, RequestManager.class, _function);
+    LoggingTester.captureLogging(Level.ALL, ReadRequest.class, _function);
     Assert.fail();
   }
   

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/concurrent/RequestManager.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/concurrent/RequestManager.xtend
@@ -17,7 +17,6 @@ import org.apache.log4j.Logger
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import org.eclipse.xtext.service.OperationCanceledManager
 import org.eclipse.xtext.util.CancelIndicator
-import java.util.concurrent.CancellationException
 
 /**
  * 
@@ -61,7 +60,7 @@ class RequestManager {
 		queue.submit(request)
 		val future = request.get;
 		future.whenComplete[v, thr|
-			if (thr !== null && !isCancelException(thr) && !(thr instanceof CancellationException)) {
+			if (thr !== null && !isCancelException(thr)) {
 				LOG.error("Error during request: ", thr);
 			}
 		]

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/concurrent/AbstractRequest.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/concurrent/AbstractRequest.java
@@ -10,12 +10,19 @@ package org.eclipse.xtext.ide.server.concurrent;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.xtext.ide.server.concurrent.Cancellable;
 import org.eclipse.xtext.ide.server.concurrent.RequestCancelIndicator;
+import org.eclipse.xtext.ide.server.concurrent.RequestManager;
 
 @SuppressWarnings("all")
 public abstract class AbstractRequest<V extends Object> implements Runnable, Cancellable {
   protected final CompletableFuture<V> result = new CompletableFuture<V>();
   
   protected final RequestCancelIndicator cancelIndicator = new RequestCancelIndicator(this.result);
+  
+  protected final RequestManager requestManager;
+  
+  public AbstractRequest(final RequestManager requestManager) {
+    this.requestManager = requestManager;
+  }
   
   @Override
   public void cancel() {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/concurrent/ReadRequest.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/concurrent/ReadRequest.java
@@ -9,8 +9,10 @@ package org.eclipse.xtext.ide.server.concurrent;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
+import org.apache.log4j.Logger;
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 import org.eclipse.xtext.ide.server.concurrent.AbstractRequest;
+import org.eclipse.xtext.ide.server.concurrent.RequestManager;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
@@ -18,6 +20,8 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 @FinalFieldsConstructor
 @SuppressWarnings("all")
 public class ReadRequest<V extends Object> extends AbstractRequest<V> {
+  private static final Logger LOG = Logger.getLogger(ReadRequest.class);
+  
   private final Function1<? super CancelIndicator, ? extends V> cancellable;
   
   private final ExecutorService executor;
@@ -40,7 +44,14 @@ public class ReadRequest<V extends Object> extends AbstractRequest<V> {
       } catch (final Throwable _t) {
         if (_t instanceof Throwable) {
           final Throwable e = (Throwable)_t;
-          _xtrycatchfinallyexpression = this.result.completeExceptionally(e);
+          boolean _xblockexpression_1 = false;
+          {
+            if (((e != null) && (!this.requestManager.isCancelException(e)))) {
+              ReadRequest.LOG.error("Error during request: ", e);
+            }
+            _xblockexpression_1 = this.result.completeExceptionally(e);
+          }
+          _xtrycatchfinallyexpression = _xblockexpression_1;
         } else {
           throw Exceptions.sneakyThrow(_t);
         }
@@ -50,8 +61,8 @@ public class ReadRequest<V extends Object> extends AbstractRequest<V> {
     this.executor.<Boolean>submit(_function);
   }
   
-  public ReadRequest(final Function1<? super CancelIndicator, ? extends V> cancellable, final ExecutorService executor) {
-    super();
+  public ReadRequest(final RequestManager requestManager, final Function1<? super CancelIndicator, ? extends V> cancellable, final ExecutorService executor) {
+    super(requestManager);
     this.cancellable = cancellable;
     this.executor = executor;
   }

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/concurrent/RequestManager.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/concurrent/RequestManager.java
@@ -10,7 +10,6 @@ package org.eclipse.xtext.ide.server.concurrent;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import java.util.ArrayList;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
@@ -69,7 +68,7 @@ public class RequestManager {
     this.queue.submit(request);
     final CompletableFuture<V> future = request.get();
     final BiConsumer<V, Throwable> _function = (V v, Throwable thr) -> {
-      if ((((thr != null) && (!this.isCancelException(thr))) && (!(thr instanceof CancellationException)))) {
+      if (((thr != null) && (!this.isCancelException(thr)))) {
         RequestManager.LOG.error("Error during request: ", thr);
       }
     };

--- a/org.eclipse.xtext/src/org/eclipse/xtext/service/OperationCanceledManager.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/service/OperationCanceledManager.java
@@ -7,6 +7,8 @@
  */
 package org.eclipse.xtext.service;
 
+import java.util.concurrent.CancellationException;
+
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.xtext.util.CancelIndicator;
 
@@ -19,6 +21,9 @@ import org.eclipse.xtext.util.CancelIndicator;
  */
 public class OperationCanceledManager {
 	protected RuntimeException getPlatformOperationCanceledException(Throwable t) {
+		if (t instanceof CancellationException) {
+			return (RuntimeException) t;
+		}
 		if (t instanceof OperationCanceledException) {
 			return (RuntimeException) t;
 		}


### PR DESCRIPTION
The `LanguageServerImpl` uses the pattern of implementing methods from `org.eclipse.lsp4j` e.g. ` org.eclipse.lsp4j.services.TextDocumentService` and returns futures directly, see here:

```java
@Override
public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params) {
	return requestManager.runRead((cancelIndicator) -> codeAction(params, cancelIndicator));
}
```

When an exception is thrown during the call to `codeAction(...)` this exception gets visible when joining the future, e.g. by calling `future.get()`. Since `lsp4j` does not do this, those exceptions are lost and never show up. Hence, the `RequestManager` should anticipate this and log exceptions itself.
