### PR TITLE
Make use of already implemented flag indexOnly and set it in IProjectConfig

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/IndexOnlyProjectTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/IndexOnlyProjectTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2019 NumberFour AG (http://www.enfore.com) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,19 +29,19 @@ import java.io.File
  * @author Marcus Mews - Initial contribution and API
  */
 class IndexOnlyProjectTest extends AbstractTestLangLanguageServerTest {
-    
+
 	override Module getServerModule() {
 		Modules2.mixin(new ServerModule, [
 			bind(IWorkspaceConfigFactory).toInstance(new ProjectWorkspaceConfigFactory() {
 
 				override findProjects(WorkspaceConfig workspaceConfig, URI location) {
 					if (location !== null) {
-						val FileProjectConfig project = new FileProjectConfig(location, workspaceConfig){
+						val FileProjectConfig project = new FileProjectConfig(location, workspaceConfig) {
 							override boolean isIndexOnly() {
 								return true;
 							}
 						};
-						
+
 						project.addSourceFolder(".");
 						workspaceConfig.addProject(project);
 					}
@@ -49,7 +49,7 @@ class IndexOnlyProjectTest extends AbstractTestLangLanguageServerTest {
 			})
 		])
 	}
-	
+
 	/** Shows that the resource is indexed */
 	@Test
 	def void testIndexByUsingReferences() {
@@ -66,53 +66,53 @@ class IndexOnlyProjectTest extends AbstractTestLangLanguageServerTest {
 			'''
 		]
 	}
-	
+
 	/** Shows that the resource is not validated during initial build */
-    @Test
-    def void testInitializeBuildNoValidation() {
-        'MyType1.testlang'.writeFile( '''
-            type Test {
-                NonExisting foo
-            }
-        ''')
-    	initialize
-    	assertTrue(diagnostics.entrySet.join(','), diagnostics.empty)
-    }
-	
+	@Test
+	def void testInitializeBuildNoValidation() {
+		'MyType1.testlang'.writeFile( '''
+			type Test {
+			    NonExisting foo
+			}
+		''')
+		initialize
+		assertTrue(diagnostics.entrySet.join(','), diagnostics.empty)
+	}
+
 	/** Shows that the error-free resource is not generated during initial build */
-    @Test
-    def void testInitializeBuildNoGeneration() {
-        'MyType1.testlang'.writeFile( '''
-            type TestType {
-                int foo
-            }
-        ''')
-    	initialize
-    	
-    	val outputFile = new File(root, "src-gen/TestType.java");
-    	assertFalse(diagnostics.entrySet.join(','), outputFile.isFile)
-    }
-    
+	@Test
+	def void testInitializeBuildNoGeneration() {
+		'MyType1.testlang'.writeFile( '''
+			type TestType {
+			    int foo
+			}
+		''')
+		initialize
+
+		val outputFile = new File(root, "src-gen/TestType.java");
+		assertFalse(diagnostics.entrySet.join(','), outputFile.isFile)
+	}
+
 	/** Shows that the resource is not validated during incremental build */
-    @Test
-    def void testIncrementalBuildNoValidation() {
-        'MyType1.testlang'.writeFile( '''
-            type Test {
-                NonExisting foo
-            }
-        ''')
-    	initialize
-    	assertTrue(diagnostics.entrySet.join(','), diagnostics.empty)
-    	
-        val path = 'MyType2.testlang'.writeFile('''
-            type NonExisting {
-            }
-        ''')
-        
-    	languageServer.getWorkspaceService.didChangeWatchedFiles(
-    		new DidChangeWatchedFilesParams(#[new FileEvent(path, FileChangeType.Created)])
-    	)
-    	assertTrue(diagnostics.entrySet.join(','), diagnostics.empty)
-    }
+	@Test
+	def void testIncrementalBuildNoValidation() {
+		'MyType1.testlang'.writeFile( '''
+			type Test {
+			    NonExisting foo
+			}
+		''')
+		initialize
+		assertTrue(diagnostics.entrySet.join(','), diagnostics.empty)
+
+		val path = 'MyType2.testlang'.writeFile('''
+			type NonExisting {
+			}
+		''')
+
+		languageServer.getWorkspaceService.didChangeWatchedFiles(
+			new DidChangeWatchedFilesParams(#[new FileEvent(path, FileChangeType.Created)])
+		)
+		assertTrue(diagnostics.entrySet.join(','), diagnostics.empty)
+	}
 
 }

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/IndexOnlyProjectTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/IndexOnlyProjectTest.xtend
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.server
+
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams
+import org.eclipse.lsp4j.FileChangeType
+import org.eclipse.lsp4j.FileEvent
+import org.junit.Test
+
+import static org.junit.Assert.*
+import com.google.inject.Module
+import org.eclipse.xtext.util.Modules2
+import org.eclipse.xtext.ide.server.ServerModule
+import org.eclipse.xtext.ide.server.IWorkspaceConfigFactory
+import org.eclipse.xtext.ide.server.ProjectWorkspaceConfigFactory
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.workspace.WorkspaceConfig
+import org.eclipse.xtext.workspace.FileProjectConfig
+import java.io.File
+
+/**
+ * Checks functionality of method IProjectConfig#isIndexOnly()
+ * 
+ * @author Marcus Mews - Initial contribution and API
+ */
+class IndexOnlyProjectTest extends AbstractTestLangLanguageServerTest {
+    
+	override Module getServerModule() {
+		Modules2.mixin(new ServerModule, [
+			bind(IWorkspaceConfigFactory).toInstance(new ProjectWorkspaceConfigFactory() {
+
+				override findProjects(WorkspaceConfig workspaceConfig, URI location) {
+					if (location !== null) {
+						val FileProjectConfig project = new FileProjectConfig(location, workspaceConfig){
+							override boolean isIndexOnly() {
+								return true;
+							}
+						};
+						
+						project.addSourceFolder(".");
+						workspaceConfig.addProject(project);
+					}
+				}
+			})
+		])
+	}
+	
+	/** Shows that the resource is indexed */
+	@Test
+	def void testIndexByUsingReferences() {
+		testReferences[
+			model = '''
+				type Foo {}
+				type Bar {
+					Foo foo
+				}
+			'''
+			column = 'type F'.length
+			expectedReferences = '''
+				MyModel.testlang [[2, 1] .. [2, 4]]
+			'''
+		]
+	}
+	
+	/** Shows that the resource is not validated during initial build */
+    @Test
+    def void testInitializeBuildNoValidation() {
+        'MyType1.testlang'.writeFile( '''
+            type Test {
+                NonExisting foo
+            }
+        ''')
+    	initialize
+    	assertTrue(diagnostics.entrySet.join(','), diagnostics.empty)
+    }
+	
+	/** Shows that the error-free resource is not generated during initial build */
+    @Test
+    def void testInitializeBuildNoGeneration() {
+        'MyType1.testlang'.writeFile( '''
+            type TestType {
+                int foo
+            }
+        ''')
+    	initialize
+    	
+    	val outputFile = new File(root, "src-gen/TestType.java");
+    	assertFalse(diagnostics.entrySet.join(','), outputFile.isFile)
+    }
+    
+	/** Shows that the resource is not validated during incremental build */
+    @Test
+    def void testIncrementalBuildNoValidation() {
+        'MyType1.testlang'.writeFile( '''
+            type Test {
+                NonExisting foo
+            }
+        ''')
+    	initialize
+    	assertTrue(diagnostics.entrySet.join(','), diagnostics.empty)
+    	
+        val path = 'MyType2.testlang'.writeFile('''
+            type NonExisting {
+            }
+        ''')
+        
+    	languageServer.getWorkspaceService.didChangeWatchedFiles(
+    		new DidChangeWatchedFilesParams(#[new FileEvent(path, FileChangeType.Created)])
+    	)
+    	assertTrue(diagnostics.entrySet.join(','), diagnostics.empty)
+    }
+
+}

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/IndexOnlyProjectTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/IndexOnlyProjectTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2016, 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.tests.server;
+
+import com.google.inject.Binder;
+import com.google.inject.binder.AnnotatedBindingBuilder;
+import java.io.File;
+import java.util.Collections;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.FileChangeType;
+import org.eclipse.lsp4j.FileEvent;
+import org.eclipse.lsp4j.services.WorkspaceService;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.ide.server.IWorkspaceConfigFactory;
+import org.eclipse.xtext.ide.server.ProjectWorkspaceConfigFactory;
+import org.eclipse.xtext.ide.server.ServerModule;
+import org.eclipse.xtext.ide.tests.server.AbstractTestLangLanguageServerTest;
+import org.eclipse.xtext.testing.ReferenceTestConfiguration;
+import org.eclipse.xtext.util.Modules2;
+import org.eclipse.xtext.workspace.FileProjectConfig;
+import org.eclipse.xtext.workspace.WorkspaceConfig;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Checks functionality of method IProjectConfig#isIndexOnly()
+ * 
+ * @author Marcus Mews - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class IndexOnlyProjectTest extends AbstractTestLangLanguageServerTest {
+  @Override
+  public com.google.inject.Module getServerModule() {
+    ServerModule _serverModule = new ServerModule();
+    final com.google.inject.Module _function = (Binder it) -> {
+      AnnotatedBindingBuilder<IWorkspaceConfigFactory> _bind = it.<IWorkspaceConfigFactory>bind(IWorkspaceConfigFactory.class);
+      _bind.toInstance(new ProjectWorkspaceConfigFactory() {
+        @Override
+        public void findProjects(final WorkspaceConfig workspaceConfig, final URI location) {
+          if ((location != null)) {
+            final FileProjectConfig project = new FileProjectConfig(location, workspaceConfig) {
+              @Override
+              public boolean isIndexOnly() {
+                return true;
+              }
+            };
+            project.addSourceFolder(".");
+            workspaceConfig.addProject(project);
+          }
+        }
+      });
+    };
+    return Modules2.mixin(_serverModule, _function);
+  }
+  
+  /**
+   * Shows that the resource is indexed
+   */
+  @Test
+  public void testIndexByUsingReferences() {
+    final Procedure1<ReferenceTestConfiguration> _function = (ReferenceTestConfiguration it) -> {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("type Foo {}");
+      _builder.newLine();
+      _builder.append("type Bar {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("Foo foo");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      it.setModel(_builder.toString());
+      it.setColumn("type F".length());
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("MyModel.testlang [[2, 1] .. [2, 4]]");
+      _builder_1.newLine();
+      it.setExpectedReferences(_builder_1.toString());
+    };
+    this.testReferences(_function);
+  }
+  
+  /**
+   * Shows that the resource is not validated during initial build
+   */
+  @Test
+  public void testInitializeBuildNoValidation() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("type Test {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("NonExisting foo");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.writeFile("MyType1.testlang", _builder);
+    this.initialize();
+    Assert.assertTrue(IterableExtensions.join(this.getDiagnostics().entrySet(), ","), this.getDiagnostics().isEmpty());
+  }
+  
+  /**
+   * Shows that the error-free resource is not generated during initial build
+   */
+  @Test
+  public void testInitializeBuildNoGeneration() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("type TestType {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("int foo");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.writeFile("MyType1.testlang", _builder);
+    this.initialize();
+    final File outputFile = new File(this.root, "src-gen/TestType.java");
+    Assert.assertFalse(IterableExtensions.join(this.getDiagnostics().entrySet(), ","), outputFile.isFile());
+  }
+  
+  /**
+   * Shows that the resource is not validated during incremental build
+   */
+  @Test
+  public void testIncrementalBuildNoValidation() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("type Test {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("NonExisting foo");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.writeFile("MyType1.testlang", _builder);
+    this.initialize();
+    Assert.assertTrue(IterableExtensions.join(this.getDiagnostics().entrySet(), ","), this.getDiagnostics().isEmpty());
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("type NonExisting {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    final String path = this.writeFile("MyType2.testlang", _builder_1);
+    WorkspaceService _workspaceService = this.languageServer.getWorkspaceService();
+    FileEvent _fileEvent = new FileEvent(path, FileChangeType.Created);
+    DidChangeWatchedFilesParams _didChangeWatchedFilesParams = new DidChangeWatchedFilesParams(Collections.<FileEvent>unmodifiableList(CollectionLiterals.<FileEvent>newArrayList(_fileEvent)));
+    _workspaceService.didChangeWatchedFiles(_didChangeWatchedFilesParams);
+    Assert.assertTrue(IterableExtensions.join(this.getDiagnostics().entrySet(), ","), this.getDiagnostics().isEmpty());
+  }
+}

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/IndexOnlyProjectTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/IndexOnlyProjectTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2019 NumberFour AG (http://www.enfore.com) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ProjectManager.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ProjectManager.java
@@ -128,6 +128,7 @@ public class ProjectManager {
 			return true;
 		});
 		result.setCancelIndicator(cancelIndicator);
+		result.setIndexOnly(projectConfig.isIndexOnly());
 		return result;
 	}
 

--- a/org.eclipse.xtext/src/org/eclipse/xtext/workspace/IProjectConfig.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/workspace/IProjectConfig.java
@@ -42,7 +42,7 @@ public interface IProjectConfig {
 	 * During the build, projects are indexed, validated and compiled. The return of this method configures whether this
 	 * project is validated and compiled or not.
 	 * 
-	 * @return true iff this project is indexed only
+	 * @return true if this project is indexed only
 	 * 
 	 * @since 2.21
 	 */

--- a/org.eclipse.xtext/src/org/eclipse/xtext/workspace/IProjectConfig.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/workspace/IProjectConfig.java
@@ -37,4 +37,14 @@ public interface IProjectConfig {
 	 * @return the workspace config
 	 */
 	IWorkspaceConfig getWorkspaceConfig();
+
+	/**
+	 * During the build, projects are indexed, validated and compiled. The return of this method configures whether this
+	 * project is validated and compiled or not.
+	 * 
+	 * @return true iff this project is indexed only
+	 */
+	default boolean isIndexOnly() {
+		return false;
+	}
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/workspace/IProjectConfig.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/workspace/IProjectConfig.java
@@ -43,6 +43,8 @@ public interface IProjectConfig {
 	 * project is validated and compiled or not.
 	 * 
 	 * @return true iff this project is indexed only
+	 * 
+	 * @since 2.21
 	 */
 	default boolean isIndexOnly() {
 		return false;


### PR DESCRIPTION
Currently, the flag `indexOnly` from class `BuildRequest` is read in `IncrementalBuilder` but never set in production code (i.e. only set in some test code). This PR introduces the default interface method `IProjectConfig#isIndexOnly()` which can be overridden by client code. The result of this method will later be used to create the `BuildRequest` and then be respected by the incremental builder. This way, this flag allows e.g. library projects which neither have to be validated nor have to be generated.