### PR TITLE
[#1272] Add missing 'See' prefix to the url in javadoc comments.

### DIFF
--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.xtend
@@ -206,11 +206,12 @@ class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
 			public class «grammar.descriptionLabelProviderClass.simpleName» extends «grammar.descriptionLabelProviderSuperClass» {
 			
 				// Labels and icons can be computed like this:
-				
+			//	@Override
 			//	public String text(IEObjectDescription ele) {
 			//		return ele.getName().toString();
 			//	}
-			//	 
+			//	
+			//	@Override
 			//	public String image(IEObjectDescription ele) {
 			//		return ele.getEClass().getName() + ".gif";
 			//	}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.xtend
@@ -150,7 +150,7 @@ class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
 			/**
 			 * Provides labels for IEObjectDescriptions and IResourceDescriptions.
 			 * 
-			 * https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
+			 * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
 			 */
 			class «grammar.descriptionLabelProviderClass.simpleName» extends «grammar.descriptionLabelProviderSuperClass» {
 			
@@ -201,7 +201,7 @@ class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
 			/**
 			 * Provides labels for IEObjectDescriptions and IResourceDescriptions.
 			 * 
-			 * https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
+			 * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
 			 */
 			public class «grammar.descriptionLabelProviderClass.simpleName» extends «grammar.descriptionLabelProviderSuperClass» {
 			

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.java
@@ -237,7 +237,7 @@ public class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
         _builder.append("* ");
         _builder.newLine();
         _builder.append(" ");
-        _builder.append("* https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider");
+        _builder.append("* See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider");
         _builder.newLine();
         _builder.append(" ");
         _builder.append("*/");
@@ -365,7 +365,7 @@ public class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
         _builder.append("* ");
         _builder.newLine();
         _builder.append(" ");
-        _builder.append("* https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider");
+        _builder.append("* See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider");
         _builder.newLine();
         _builder.append(" ");
         _builder.append("*/");

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.java
@@ -382,7 +382,7 @@ public class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
         _builder.append("\t");
         _builder.append("// Labels and icons can be computed like this:");
         _builder.newLine();
-        _builder.append("\t");
+        _builder.append("//\t@Override");
         _builder.newLine();
         _builder.append("//\tpublic String text(IEObjectDescription ele) {");
         _builder.newLine();
@@ -390,7 +390,9 @@ public class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
         _builder.newLine();
         _builder.append("//\t}");
         _builder.newLine();
-        _builder.append("//\t ");
+        _builder.append("//\t");
+        _builder.newLine();
+        _builder.append("//\t@Override");
         _builder.newLine();
         _builder.append("//\tpublic String image(IEObjectDescription ele) {");
         _builder.newLine();


### PR DESCRIPTION
Signed-off-by: Tamas Miklossy <miklossy@itemis.de>