### PR TITLE
[#1328] marked obsolete LineFilterOutputStream as deprecated

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/LineFilterOutputStreamTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/LineFilterOutputStreamTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 /**
  * @author Sebastian Zarnekow - Initial contribution and API
  */
+@SuppressWarnings("deprecation")
 public class LineFilterOutputStreamTest extends Assert {
 
 	private ByteArrayOutputStream result;

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/LineFilterOutputStream.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/LineFilterOutputStream.java
@@ -14,7 +14,10 @@ import java.io.OutputStream;
 /**
  * Filters any line, that contains the given pattern right from the beginning.
  * @author Sebastian Zarnekow - Initial contribution and API
+ * 
+ * @deprecated this class is obsolete and will be removed in a future release of Xtext.
  */
+@Deprecated
 public class LineFilterOutputStream extends FilterOutputStream {
 
 	private final byte[] pattern;


### PR DESCRIPTION
[#1328] marked obsolete LineFilterOutputStream as deprecated
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>