### PR TITLE
[eclipse/xtext#1455] Resolve test failure in DocumentTest.

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/DocumentTest.xtend
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/DocumentTest.xtend
@@ -148,6 +148,10 @@ class DocumentTest {
         ccc''').getLineContent(1));
     }
 
+    @Test def void testGetLineContent_windows_line_endings() {
+        assertEquals('bbb', new Document(1, "aaa\r\nbbb\r\nccc").getLineContent(1));
+    }
+
     @Test def void testGetLineCount_empty() {
         assertEquals(1, new Document(1, '').lineCount);
     }

--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/DocumentTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/DocumentTest.java
@@ -220,6 +220,11 @@ public class DocumentTest {
   }
   
   @Test
+  public void testGetLineContent_windows_line_endings() {
+    Assert.assertEquals("bbb", new Document(Integer.valueOf(1), "aaa\r\nbbb\r\nccc").getLineContent(1));
+  }
+  
+  @Test
   public void testGetLineCount_empty() {
     Assert.assertEquals(1, new Document(Integer.valueOf(1), "").getLineCount());
   }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/Document.xtend
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/Document.xtend
@@ -84,7 +84,7 @@ import org.eclipse.lsp4j.TextDocumentContentChangeEvent
     }
 
     /**
-     * Returns with the text for a certain line without the trailing LF. Throws an {@link IndexOutOfBoundsException} if the zero-based {@code lineNumber}
+     * Returns with the text for a certain line without the trailing end line marker. Throws an {@link IndexOutOfBoundsException} if the zero-based {@code lineNumber}
      * argument is negative or exceeds the number of lines in the document.
      */
     def String getLineContent(int lineNumber) throws IndexOutOfBoundsException {
@@ -92,6 +92,7 @@ import org.eclipse.lsp4j.TextDocumentContentChangeEvent
             throw new IndexOutOfBoundsException(lineNumber + if (printSourceOnError) "" else (" text was : " + contents));
         }
         val char NL = '\n';
+        val char LF = '\r';
         val l = contents.length;
         val lineContent = new StringBuilder;
         var line = 0;
@@ -100,7 +101,7 @@ import org.eclipse.lsp4j.TextDocumentContentChangeEvent
                 return lineContent.toString;
             }
             val ch = contents.charAt(i);
-            if (line === lineNumber && ch !== NL) {
+            if (line === lineNumber && ch !== NL && ch !== LF) {
                 lineContent.append(ch);
             }
             if (ch === NL) {

--- a/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/Document.java
+++ b/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/server/Document.java
@@ -108,7 +108,7 @@ public class Document {
   }
   
   /**
-   * Returns with the text for a certain line without the trailing LF. Throws an {@link IndexOutOfBoundsException} if the zero-based {@code lineNumber}
+   * Returns with the text for a certain line without the trailing end line marker. Throws an {@link IndexOutOfBoundsException} if the zero-based {@code lineNumber}
    * argument is negative or exceeds the number of lines in the document.
    */
   public String getLineContent(final int lineNumber) throws IndexOutOfBoundsException {
@@ -123,6 +123,7 @@ public class Document {
       throw new IndexOutOfBoundsException(_plus);
     }
     final char NL = '\n';
+    final char LF = '\r';
     final int l = this.contents.length();
     final StringBuilder lineContent = new StringBuilder();
     int line = 0;
@@ -132,7 +133,7 @@ public class Document {
           return lineContent.toString();
         }
         final char ch = this.contents.charAt(i);
-        if (((line == lineNumber) && (ch != NL))) {
+        if ((((line == lineNumber) && (ch != NL)) && (ch != LF))) {
           lineContent.append(ch);
         }
         if ((ch == NL)) {

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
@@ -12,12 +12,12 @@ import com.google.inject.Inject
 import com.google.inject.Module
 import java.io.File
 import java.io.FileWriter
-import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.List
 import java.util.Map
 import java.util.concurrent.CompletableFuture
+import org.eclipse.emf.common.util.URI
 import org.eclipse.lsp4j.CodeAction
 import org.eclipse.lsp4j.CodeActionContext
 import org.eclipse.lsp4j.CodeActionParams
@@ -65,6 +65,7 @@ import org.eclipse.lsp4j.WorkspaceSymbolParams
 import org.eclipse.lsp4j.jsonrpc.Endpoint
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints
+import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.lsp4j.util.SemanticHighlightingTokens
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend.lib.annotations.Data
@@ -84,9 +85,9 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.eclipse.lsp4j.services.LanguageClient
 
 import static extension org.eclipse.lsp4j.util.Ranges.containsRange
+import static extension org.eclipse.xtext.util.Strings.*
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -174,7 +175,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 	}
 
 	protected def Path relativize(String uri) {
-		val path = Paths.get(new URI(uri))
+		val path = Paths.get(new java.net.URI(uri))
 		testRootPath.relativize(path)
 	}
 
@@ -210,7 +211,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 				uri = fileUri
 				languageId = langaugeId
 				version = 1
-				text = model
+				text = model.toUnixLineSeparator
 			]
 		])
 	}
@@ -416,7 +417,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 	protected dispatch def String toExpectation(WorkspaceEdit it) '''
 		changes :
 			«FOR entry : changes.entrySet»
-				«org.eclipse.emf.common.util.URI.createURI(entry.key).lastSegment» : «entry.value.toExpectation»
+				«URI.createURI(entry.key).lastSegment» : «entry.value.toExpectation»
 			«ENDFOR» 
 		documentChanges : 
 			«documentChanges.toExpectation»
@@ -435,7 +436,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 	'''
 
 	protected def dispatch String toExpectation(VersionedTextDocumentIdentifier v) 
-		'''«org.eclipse.emf.common.util.URI.createURI(v.uri).lastSegment» <«v.version»>'''
+		'''«URI.createURI(v.uri).lastSegment» <«v.version»>'''
 	
 	
 	

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
@@ -107,6 +107,7 @@ import org.eclipse.xtext.testing.WorkspaceSymbolConfiguration;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.Files;
 import org.eclipse.xtext.util.Modules2;
+import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
@@ -368,7 +369,7 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
         it_1.setUri(fileUri);
         it_1.setLanguageId(langaugeId);
         it_1.setVersion(1);
-        it_1.setText(model);
+        it_1.setText(Strings.toUnixLineSeparator(model));
       };
       TextDocumentItem _doubleArrow = ObjectExtensions.<TextDocumentItem>operator_doubleArrow(_textDocumentItem, _function_1);
       it.setTextDocument(_doubleArrow);


### PR DESCRIPTION
Document#getLineContent returns the '\r' of '\r\n' on windows. This
leads to a failing test. But the line content should explicitly NOT
return the newline marker. Hence fixing the implementation to fix the
test.

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>