### PR TITLE
[#1345] Improve EMFGeneratorFragment2 fileHeader handling.

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/EMFGeneratorFragment2Test.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/EMFGeneratorFragment2Test.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2020 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.xtext.xtext.generator.ecore.EMFGeneratorFragment2
 /**
  */
 class EMFGeneratorFragment2Test {
-	
+
 	@Test def void testTrimMultiLineString() {
 		assertTrim('foo','''
 			/*foo*/
@@ -44,9 +44,37 @@ class EMFGeneratorFragment2Test {
 			/* foo */
 		''')
 		assertTrim('foo','foo')
+		assertTrim('''
+		Copyright (c) 2011, 2019 itemis AG (http://www.itemis.eu) and others.
+		All rights reserved. This program and the accompanying materials
+		are made available under the terms of the Eclipse Public License v1.0
+		which accompanies this distribution, and is available at
+		http://www.eclipse.org/legal/epl-v10.html''',
+		'''
+		/**
+		 * Copyright (c) 2011, 2019 itemis AG (http://www.itemis.eu) and others.
+		 * All rights reserved. This program and the accompanying materials
+		 * are made available under the terms of the Eclipse Public License v1.0
+		 * which accompanies this distribution, and is available at
+		 * http://www.eclipse.org/legal/epl-v10.html
+		 */''')
+		assertTrim('''
+		Copyright (c) 2015, 2019 itemis AG (http://www.itemis.eu) and others.
+		All rights reserved. This program and the accompanying materials
+		are made available under the terms of the Eclipse Public License v1.0
+		which accompanies this distribution, and is available at
+		http://www.eclipse.org/legal/epl-v10.html''',
+		'''
+		/*******************************************************************************
+		 * Copyright (c) 2015, 2019 itemis AG (http://www.itemis.eu) and others.
+		 * All rights reserved. This program and the accompanying materials
+		 * are made available under the terms of the Eclipse Public License v1.0
+		 * which accompanies this distribution, and is available at
+		 * http://www.eclipse.org/legal/epl-v10.html
+		 *******************************************************************************/''')
 	}
-	
-	def void assertTrim(String expected, String original) {
+
+	private def void assertTrim(String expected, String original) {
 		Assert.assertEquals(expected, EMFGeneratorFragment2.trimMultiLineComment(original))
 	}
 }

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/EMFGeneratorFragment2Test.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/EMFGeneratorFragment2Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2020 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -65,9 +65,71 @@ public class EMFGeneratorFragment2Test {
     _builder_5.newLine();
     this.assertTrim("foo", _builder_5.toString());
     this.assertTrim("foo", "foo");
+    StringConcatenation _builder_6 = new StringConcatenation();
+    _builder_6.append("Copyright (c) 2011, 2019 itemis AG (http://www.itemis.eu) and others.");
+    _builder_6.newLine();
+    _builder_6.append("All rights reserved. This program and the accompanying materials");
+    _builder_6.newLine();
+    _builder_6.append("are made available under the terms of the Eclipse Public License v1.0");
+    _builder_6.newLine();
+    _builder_6.append("which accompanies this distribution, and is available at");
+    _builder_6.newLine();
+    _builder_6.append("http://www.eclipse.org/legal/epl-v10.html");
+    StringConcatenation _builder_7 = new StringConcatenation();
+    _builder_7.append("/**");
+    _builder_7.newLine();
+    _builder_7.append(" ");
+    _builder_7.append("* Copyright (c) 2011, 2019 itemis AG (http://www.itemis.eu) and others.");
+    _builder_7.newLine();
+    _builder_7.append(" ");
+    _builder_7.append("* All rights reserved. This program and the accompanying materials");
+    _builder_7.newLine();
+    _builder_7.append(" ");
+    _builder_7.append("* are made available under the terms of the Eclipse Public License v1.0");
+    _builder_7.newLine();
+    _builder_7.append(" ");
+    _builder_7.append("* which accompanies this distribution, and is available at");
+    _builder_7.newLine();
+    _builder_7.append(" ");
+    _builder_7.append("* http://www.eclipse.org/legal/epl-v10.html");
+    _builder_7.newLine();
+    _builder_7.append(" ");
+    _builder_7.append("*/");
+    this.assertTrim(_builder_6.toString(), _builder_7.toString());
+    StringConcatenation _builder_8 = new StringConcatenation();
+    _builder_8.append("Copyright (c) 2015, 2019 itemis AG (http://www.itemis.eu) and others.");
+    _builder_8.newLine();
+    _builder_8.append("All rights reserved. This program and the accompanying materials");
+    _builder_8.newLine();
+    _builder_8.append("are made available under the terms of the Eclipse Public License v1.0");
+    _builder_8.newLine();
+    _builder_8.append("which accompanies this distribution, and is available at");
+    _builder_8.newLine();
+    _builder_8.append("http://www.eclipse.org/legal/epl-v10.html");
+    StringConcatenation _builder_9 = new StringConcatenation();
+    _builder_9.append("/*******************************************************************************");
+    _builder_9.newLine();
+    _builder_9.append(" ");
+    _builder_9.append("* Copyright (c) 2015, 2019 itemis AG (http://www.itemis.eu) and others.");
+    _builder_9.newLine();
+    _builder_9.append(" ");
+    _builder_9.append("* All rights reserved. This program and the accompanying materials");
+    _builder_9.newLine();
+    _builder_9.append(" ");
+    _builder_9.append("* are made available under the terms of the Eclipse Public License v1.0");
+    _builder_9.newLine();
+    _builder_9.append(" ");
+    _builder_9.append("* which accompanies this distribution, and is available at");
+    _builder_9.newLine();
+    _builder_9.append(" ");
+    _builder_9.append("* http://www.eclipse.org/legal/epl-v10.html");
+    _builder_9.newLine();
+    _builder_9.append(" ");
+    _builder_9.append("*******************************************************************************/");
+    this.assertTrim(_builder_8.toString(), _builder_9.toString());
   }
   
-  public void assertTrim(final String expected, final String original) {
+  private void assertTrim(final String expected, final String original) {
     Assert.assertEquals(expected, EMFGeneratorFragment2.trimMultiLineComment(original));
   }
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2020 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -624,7 +624,7 @@ class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
 	}
 	
 	def static String trimMultiLineComment(String string) {
-		return string.replace('*/','').replace('/*','').replace(' * ','').trim
+		return string.replace(' * ','').replaceAll("/\\*+\\s*|\\s*\\*+/", "").trim
 	}
 	
 	protected def Set<EPackage> getReferencedEPackages(List<EPackage> packs) {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2020 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -899,7 +899,7 @@ public class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
   }
   
   public static String trimMultiLineComment(final String string) {
-    return string.replace("*/", "").replace("/*", "").replace(" * ", "").trim();
+    return string.replace(" * ", "").replaceAll("/\\*+\\s*|\\s*\\*+/", "").trim();
   }
   
   protected Set<EPackage> getReferencedEPackages(final List<EPackage> packs) {


### PR DESCRIPTION
- Improve the trimMultiLineComment method to properly handle the /**,
/*******, **/ and ****************/ symbols.
- Implement corresponding EmfGeneratorFragment2Test test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>