### PR TITLE
Convert EMFGeneratorFragment2.trimMultiLineComment to an instance method

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/EMFGeneratorFragment2Test.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/EMFGeneratorFragment2Test.xtend
@@ -16,6 +16,8 @@ import org.eclipse.xtext.xtext.generator.ecore.EMFGeneratorFragment2
  */
 class EMFGeneratorFragment2Test {
 
+	val extension EMFGeneratorFragment2 = new EMFGeneratorFragment2
+
 	@Test def void testTrimMultiLineString() {
 		assertTrim('foo','''
 			/*foo*/
@@ -75,6 +77,6 @@ class EMFGeneratorFragment2Test {
 	}
 
 	private def void assertTrim(String expected, String original) {
-		Assert.assertEquals(expected, EMFGeneratorFragment2.trimMultiLineComment(original))
+		Assert.assertEquals(expected, original.trimMultiLineComment)
 	}
 }

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/EMFGeneratorFragment2Test.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/EMFGeneratorFragment2Test.java
@@ -8,12 +8,16 @@
 package org.eclipse.xtext.xtext.generator;
 
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xtext.generator.ecore.EMFGeneratorFragment2;
 import org.junit.Assert;
 import org.junit.Test;
 
 @SuppressWarnings("all")
 public class EMFGeneratorFragment2Test {
+  @Extension
+  private final EMFGeneratorFragment2 _eMFGeneratorFragment2 = new EMFGeneratorFragment2();
+  
   @Test
   public void testTrimMultiLineString() {
     StringConcatenation _builder = new StringConcatenation();
@@ -130,6 +134,6 @@ public class EMFGeneratorFragment2Test {
   }
   
   private void assertTrim(final String expected, final String original) {
-    Assert.assertEquals(expected, EMFGeneratorFragment2.trimMultiLineComment(original));
+    Assert.assertEquals(expected, this._eMFGeneratorFragment2.trimMultiLineComment(original));
   }
 }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.xtend
@@ -623,7 +623,7 @@ class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
 		return genModel
 	}
 	
-	def static String trimMultiLineComment(String string) {
+	def String trimMultiLineComment(String string) {
 		return string.replace(' * ','').replaceAll("/\\*+\\s*|\\s*\\*+/", "").trim
 	}
 	

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ecore/EMFGeneratorFragment2.java
@@ -888,7 +888,7 @@ public class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
         String _fileHeader = this.codeConfig.getFileHeader();
         boolean _tripleNotEquals = (_fileHeader != null);
         if (_tripleNotEquals) {
-          genModel.setCopyrightText(EMFGeneratorFragment2.trimMultiLineComment(this.codeConfig.getFileHeader()));
+          genModel.setCopyrightText(this.trimMultiLineComment(this.codeConfig.getFileHeader()));
         }
       }
       genModelFile.getContents().add(genModel);
@@ -898,7 +898,7 @@ public class EMFGeneratorFragment2 extends AbstractXtextGeneratorFragment {
     }
   }
   
-  public static String trimMultiLineComment(final String string) {
+  public String trimMultiLineComment(final String string) {
     return string.replace(" * ", "").replaceAll("/\\*+\\s*|\\s*\\*+/", "").trim();
   }
   


### PR DESCRIPTION
- to be able to override that method in derived classes.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>