### PR TITLE
[eclipse/xtext#1651] made error handling in StorageAwareResource null-safe

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/persistence/StorageAwareResource.xtend
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/persistence/StorageAwareResource.xtend
@@ -44,8 +44,8 @@ class StorageAwareResource extends LazyLinkingResource {
 				return;
 			} catch(IOException e) {
 				// revert the resource into a clean state
-				contents.clear
-				eAdapters.clear
+				contents?.clear
+				eAdapters?.clear
 				unload
 			}
 		}

--- a/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/resource/persistence/StorageAwareResource.java
+++ b/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/resource/persistence/StorageAwareResource.java
@@ -68,8 +68,12 @@ public class StorageAwareResource extends LazyLinkingResource {
         return;
       } catch (final Throwable _t) {
         if (_t instanceof IOException) {
-          this.contents.clear();
-          this.eAdapters.clear();
+          if (this.contents!=null) {
+            this.contents.clear();
+          }
+          if (this.eAdapters!=null) {
+            this.eAdapters.clear();
+          }
           this.unload();
         } else {
           throw Exceptions.sneakyThrow(_t);


### PR DESCRIPTION
[eclipse/xtext#1651] made error handling in StorageAwareResource null-safe
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>