### PR TITLE
[#622] Improved concurrency behavior of RequestManager

### DIFF
--- a/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.java
+++ b/org.eclipse.xtext.ide.tests/xtend-gen/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.java
@@ -8,17 +8,29 @@
  */
 package org.eclipse.xtext.ide.tests.server.concurrent;
 
+import com.google.common.base.Objects;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.log4j.Level;
 import org.eclipse.xtext.ide.server.ServerModule;
+import org.eclipse.xtext.ide.server.concurrent.AbstractRequest;
 import org.eclipse.xtext.ide.server.concurrent.ReadRequest;
 import org.eclipse.xtext.ide.server.concurrent.RequestManager;
 import org.eclipse.xtext.ide.server.concurrent.WriteRequest;
+import org.eclipse.xtext.service.OperationCanceledManager;
+import org.eclipse.xtext.testing.RepeatedTest;
 import org.eclipse.xtext.testing.logging.LoggingTester;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.xbase.lib.Exceptions;
@@ -28,7 +40,7 @@ import org.eclipse.xtext.xbase.lib.Functions.Function2;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -36,8 +48,17 @@ import org.junit.Test;
  */
 @SuppressWarnings("all")
 public class RequestManagerTest {
+  @Rule
+  public RepeatedTest.Rule rule = new RepeatedTest.Rule(false);
+  
   @Inject
   private RequestManager requestManager;
+  
+  @Inject
+  private Provider<ExecutorService> executorServiceProvider;
+  
+  @Inject
+  private Provider<OperationCanceledManager> cancelManagerProvider;
   
   private AtomicInteger sharedState;
   
@@ -158,6 +179,96 @@ public class RequestManagerTest {
     Assert.fail();
   }
   
+  @Test
+  public void testWriteWaitsForReadToFinish_01() throws Exception {
+    final AtomicBoolean marked = new AtomicBoolean(false);
+    final CountDownLatch countDownInRead = new CountDownLatch(1);
+    final CountDownLatch countDownInWrite = new CountDownLatch(1);
+    final CountDownLatch proceedWithWrite = new CountDownLatch(1);
+    final Function1<CancelIndicator, Object> _function = (CancelIndicator cancelIndicator) -> {
+      countDownInRead.countDown();
+      Uninterruptibles.awaitUninterruptibly(countDownInWrite);
+      marked.set(true);
+      proceedWithWrite.countDown();
+      return null;
+    };
+    final CompletableFuture<Object> reader = this.requestManager.<Object>runRead(_function);
+    Uninterruptibles.awaitUninterruptibly(countDownInRead);
+    final Function0<Object> _function_1 = () -> {
+      return null;
+    };
+    final Function2<CancelIndicator, Object, Object> _function_2 = (CancelIndicator cancelIndicator, Object ignored) -> {
+      Object _xblockexpression = null;
+      {
+        countDownInWrite.countDown();
+        Uninterruptibles.awaitUninterruptibly(proceedWithWrite);
+        Assert.assertTrue(marked.get());
+        _xblockexpression = null;
+      }
+      return _xblockexpression;
+    };
+    final CompletableFuture<Object> writer = this.requestManager.<Object, Object>runWrite(_function_1, _function_2);
+    try {
+      Uninterruptibles.<Object>getUninterruptibly(writer, 100, TimeUnit.MILLISECONDS);
+      Assert.fail("Expected timeout");
+    } catch (final Throwable _t) {
+      if (_t instanceof TimeoutException) {
+        Assert.assertFalse(marked.get());
+      } else {
+        throw Exceptions.sneakyThrow(_t);
+      }
+    }
+    countDownInWrite.countDown();
+    Uninterruptibles.<Object>getUninterruptibly(writer, 100, TimeUnit.MILLISECONDS);
+    Assert.assertTrue(reader.isDone());
+    Assert.assertFalse(reader.isCancelled());
+  }
+  
+  @Test
+  public void testWriteWaitsForReadToFinish_02() throws Exception {
+    final AtomicBoolean marked = new AtomicBoolean(false);
+    final CountDownLatch countDownInRead = new CountDownLatch(1);
+    final CountDownLatch countDownInWrite = new CountDownLatch(1);
+    final CountDownLatch proceedWithWrite = new CountDownLatch(1);
+    final Function1<CancelIndicator, Object> _function = (CancelIndicator cancelIndicator) -> {
+      countDownInRead.countDown();
+      Uninterruptibles.awaitUninterruptibly(countDownInWrite);
+      marked.set(true);
+      proceedWithWrite.countDown();
+      throw new CancellationException();
+    };
+    final CompletableFuture<Object> reader = this.requestManager.<Object>runRead(_function);
+    Uninterruptibles.awaitUninterruptibly(countDownInRead);
+    final Function0<Object> _function_1 = () -> {
+      return null;
+    };
+    final Function2<CancelIndicator, Object, Object> _function_2 = (CancelIndicator cancelIndicator, Object ignored) -> {
+      Object _xblockexpression = null;
+      {
+        countDownInWrite.countDown();
+        Uninterruptibles.awaitUninterruptibly(proceedWithWrite);
+        Assert.assertTrue(marked.get());
+        _xblockexpression = null;
+      }
+      return _xblockexpression;
+    };
+    final CompletableFuture<Object> writer = this.requestManager.<Object, Object>runWrite(_function_1, _function_2);
+    try {
+      Uninterruptibles.<Object>getUninterruptibly(writer, 100, TimeUnit.MILLISECONDS);
+      Assert.fail("Expected timeout");
+    } catch (final Throwable _t) {
+      if (_t instanceof TimeoutException) {
+        Assert.assertFalse(marked.get());
+      } else {
+        throw Exceptions.sneakyThrow(_t);
+      }
+    }
+    countDownInWrite.countDown();
+    Uninterruptibles.<Object>getUninterruptibly(writer, 100, TimeUnit.MILLISECONDS);
+    Assert.assertTrue(reader.isDone());
+    Assert.assertTrue(reader.isCancelled());
+  }
+  
   @Test(timeout = 1000)
   public void testRunRead() {
     try {
@@ -255,12 +366,19 @@ public class RequestManagerTest {
   }
   
   @Test(timeout = 1000)
-  @Ignore("https://github.com/eclipse/xtext-core/issues/622")
-  public void testRunWriteAfterRead() {
+  @RepeatedTest(times = 50)
+  public void testRunWriteAfterReadStarted() {
+    final CountDownLatch readStarted = new CountDownLatch(1);
     final Function1<CancelIndicator, Integer> _function = (CancelIndicator it) -> {
-      return Integer.valueOf(this.sharedState.incrementAndGet());
+      int _xblockexpression = (int) 0;
+      {
+        readStarted.countDown();
+        _xblockexpression = this.sharedState.incrementAndGet();
+      }
+      return Integer.valueOf(_xblockexpression);
     };
     this.requestManager.<Integer>runRead(_function);
+    Uninterruptibles.awaitUninterruptibly(readStarted);
     final Function0<Object> _function_1 = () -> {
       return null;
     };
@@ -274,6 +392,47 @@ public class RequestManagerTest {
     };
     this.requestManager.<Object, Integer>runWrite(_function_1, _function_2).join();
     Assert.assertEquals(2, this.sharedState.get());
+  }
+  
+  @Test(timeout = 1000)
+  @RepeatedTest(times = 50)
+  public void testRunWriteBeforeReadStarted() {
+    final CountDownLatch writeSubmitted = new CountDownLatch(1);
+    final AtomicBoolean firstWriteDone = new AtomicBoolean();
+    final Function0<Object> _function = () -> {
+      Object _xblockexpression = null;
+      {
+        Uninterruptibles.awaitUninterruptibly(writeSubmitted);
+        firstWriteDone.set(true);
+        _xblockexpression = null;
+      }
+      return _xblockexpression;
+    };
+    final Function2<CancelIndicator, Object, Integer> _function_1 = (CancelIndicator $0, Object $1) -> {
+      return Integer.valueOf(this.sharedState.incrementAndGet());
+    };
+    this.requestManager.<Object, Integer>runWrite(_function, _function_1);
+    final Function1<CancelIndicator, Integer> _function_2 = (CancelIndicator it) -> {
+      return Integer.valueOf(this.sharedState.incrementAndGet());
+    };
+    this.requestManager.<Integer>runRead(_function_2);
+    final Function0<Object> _function_3 = () -> {
+      return null;
+    };
+    final Function2<CancelIndicator, Object, Integer> _function_4 = (CancelIndicator $0, Object $1) -> {
+      int _xblockexpression = (int) 0;
+      {
+        Assert.assertEquals(0, this.sharedState.get());
+        Assert.assertTrue(firstWriteDone.get());
+        _xblockexpression = this.sharedState.incrementAndGet();
+      }
+      return Integer.valueOf(_xblockexpression);
+    };
+    final CompletableFuture<Integer> joinMe = this.requestManager.<Object, Integer>runWrite(_function_3, _function_4);
+    writeSubmitted.countDown();
+    joinMe.join();
+    Assert.assertTrue(firstWriteDone.get());
+    Assert.assertEquals(1, this.sharedState.get());
   }
   
   @Test(timeout = 1000)
@@ -302,6 +461,112 @@ public class RequestManagerTest {
       future.cancel(true);
       while ((!isCanceled.get())) {
         Thread.sleep(10);
+      }
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  /**
+   * The tests assumes an implementation of a Command that has access to the request manager
+   */
+  @Test(timeout = 5000)
+  @RepeatedTest(times = 50)
+  public void testReadCommandSubmitsWriteCommand() {
+    try {
+      final Thread mainThread = Thread.currentThread();
+      final CountDownLatch submittedFromMain = new CountDownLatch(1);
+      final CountDownLatch addedFromReader = new CountDownLatch(1);
+      final AtomicReference<Thread> readerThreadRef = new AtomicReference<Thread>();
+      ExecutorService _get = this.executorServiceProvider.get();
+      OperationCanceledManager _get_1 = this.cancelManagerProvider.get();
+      final RequestManager myRequestManager = new RequestManager(_get, _get_1) {
+        @Override
+        protected void addRequest(final AbstractRequest<?> request) {
+          if (((request instanceof WriteRequest) && Objects.equal(Thread.currentThread(), readerThreadRef.get()))) {
+            super.addRequest(request);
+            addedFromReader.countDown();
+            Uninterruptibles.awaitUninterruptibly(submittedFromMain, 100, TimeUnit.MILLISECONDS);
+          } else {
+            super.addRequest(request);
+          }
+        }
+        
+        @Override
+        protected void submitRequest(final AbstractRequest<?> request) {
+          if (((request instanceof WriteRequest) && Objects.equal(Thread.currentThread(), mainThread))) {
+            super.submitRequest(request);
+            submittedFromMain.countDown();
+          } else {
+            super.submitRequest(request);
+          }
+        }
+        
+        @Override
+        protected CompletableFuture<Void> cancel() {
+          CompletableFuture<Void> _xblockexpression = null;
+          {
+            Thread _currentThread = Thread.currentThread();
+            boolean _equals = Objects.equal(_currentThread, mainThread);
+            if (_equals) {
+              Uninterruptibles.awaitUninterruptibly(addedFromReader, 100, TimeUnit.MILLISECONDS);
+            }
+            _xblockexpression = super.cancel();
+          }
+          return _xblockexpression;
+        }
+      };
+      final CountDownLatch threadSet = new CountDownLatch(1);
+      final Function1<CancelIndicator, CompletableFuture<Object>> _function = (CancelIndicator it) -> {
+        readerThreadRef.set(Thread.currentThread());
+        threadSet.countDown();
+        final Function0<Object> _function_1 = () -> {
+          return null;
+        };
+        final Function2<CancelIndicator, Object, Object> _function_2 = (CancelIndicator $0, Object $1) -> {
+          return null;
+        };
+        return myRequestManager.<Object, Object>runWrite(_function_1, _function_2);
+      };
+      final CompletableFuture<CompletableFuture<Object>> readResult = myRequestManager.<CompletableFuture<Object>>runRead(_function);
+      Uninterruptibles.awaitUninterruptibly(threadSet);
+      Assert.assertNotNull(readerThreadRef.get());
+      final Function0<Object> _function_1 = () -> {
+        return null;
+      };
+      final Function2<CancelIndicator, Object, Object> _function_2 = (CancelIndicator $0, Object $1) -> {
+        return null;
+      };
+      final CompletableFuture<Object> writeResult = myRequestManager.<Object, Object>runWrite(_function_1, _function_2);
+      final CompletableFuture<Object> writeFromReader = readResult.get();
+      try {
+        writeFromReader.get();
+        try {
+          writeResult.get();
+        } catch (final Throwable _t) {
+          if (_t instanceof CancellationException) {
+            Assert.assertTrue(writeFromReader.isDone());
+            Assert.assertTrue(writeResult.isDone());
+            boolean _isCancelled = writeFromReader.isCancelled();
+            boolean _isCancelled_1 = writeResult.isCancelled();
+            boolean _notEquals = (_isCancelled != _isCancelled_1);
+            Assert.assertTrue(_notEquals);
+          } else {
+            throw Exceptions.sneakyThrow(_t);
+          }
+        }
+      } catch (final Throwable _t) {
+        if (_t instanceof CancellationException) {
+          writeResult.get();
+          Assert.assertTrue(writeFromReader.isDone());
+          Assert.assertTrue(writeResult.isDone());
+          boolean _isCancelled = writeFromReader.isCancelled();
+          boolean _isCancelled_1 = writeResult.isCancelled();
+          boolean _notEquals = (_isCancelled != _isCancelled_1);
+          Assert.assertTrue(_notEquals);
+        } else {
+          throw Exceptions.sneakyThrow(_t);
+        }
       }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/concurrent/AbstractRequest.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/concurrent/AbstractRequest.java
@@ -10,6 +10,8 @@ package org.eclipse.xtext.ide.server.concurrent;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.log4j.Logger;
+
 /**
  * Abstract base type for read and write requests.
  * 
@@ -17,10 +19,23 @@ import java.util.concurrent.CompletableFuture;
  * @since 2.11
  */
 public abstract class AbstractRequest<V> implements Runnable, Cancellable {
+	
+	private class ResultFuture extends CompletableFuture<V> {
+		@Override
+		public boolean cancel(boolean mayInterruptIfRunning) {
+			AbstractRequest.this.cancel(mayInterruptIfRunning);
+			return isCancelled();
+		}
+
+		void doCancel(boolean mayInterruptIfRunning) {
+			super.cancel(mayInterruptIfRunning);
+		}
+	}
+	
 	/**
-	 * The underyling future.
+	 * The underlying future.
 	 */
-	protected final CompletableFuture<V> result;
+	protected final ResultFuture result;
 
 	/**
 	 * The current cancel indicator.
@@ -34,19 +49,46 @@ public abstract class AbstractRequest<V> implements Runnable, Cancellable {
 
 	protected AbstractRequest(RequestManager requestManager) {
 		this.requestManager = requestManager;
-		this.result = new CompletableFuture<>();
-		this.cancelIndicator = new RequestCancelIndicator(this.result);
+		this.result = new ResultFuture();
+		this.cancelIndicator = new RequestCancelIndicator(this);
 	}
 
+	protected void cancelResult(boolean mayInterruptIfRunning) {
+		result.doCancel(mayInterruptIfRunning);
+	}
+
+	protected boolean isDone() {
+		return result.isDone();
+	}
+
+	protected void complete(V value) {
+		result.complete(value);
+	}
+	
+	protected abstract Logger getLogger();
+
+	protected void logAndCompleteExceptionally(Throwable t) {
+		if (!requestManager.isCancelException(t)) {
+			getLogger().error("Error during request: ", t);
+			result.completeExceptionally(t);
+		} else {
+			cancelResult(true);
+		}
+	}
+
+	protected void cancel(boolean mayInterruptIfRunning) {
+		cancelIndicator.doCancel();
+	}
+	
 	@Override
-	public void cancel() {
-		cancelIndicator.cancel();
+	public final void cancel() {
+		cancel(true);
 	}
 
 	/**
 	 * Return the underlying future.
 	 */
 	public CompletableFuture<V> get() {
-		return result;
+		return this.result;
 	}
 }


### PR DESCRIPTION
The request manager was prone to races when a runnable was already in progress and a new write request was submitted in parallel. The runnable future would immediately be considered to be cancelled but the runnable would still continue to be processed.

Also there was a chance of deadlocks when a custom LSP command used the request manager to submit a modifying write request.

closes #622 