### PR TITLE
[eclipse/xtext-core#1418] removed redundant superinterface from generated ca parsers

### DIFF
--- a/org.eclipse.xtext.ide.tests/testlang-src-gen/org/eclipse/xtext/ide/tests/testlanguage/ide/contentassist/antlr/PartialIndentationAwareUiTestLanguageContentAssistParser.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src-gen/org/eclipse/xtext/ide/tests/testlanguage/ide/contentassist/antlr/PartialIndentationAwareUiTestLanguageContentAssistParser.java
@@ -13,10 +13,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialIndentationAwareUiTestLanguageContentAssistParser extends IndentationAwareUiTestLanguageParser implements IPartialEditingContentAssistParser {
+public class PartialIndentationAwareUiTestLanguageContentAssistParser extends IndentationAwareUiTestLanguageParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.ide.tests/testlang-src-gen/org/eclipse/xtext/ide/tests/testlanguage/ide/contentassist/antlr/PartialPartialContentAssistTestLanguageContentAssistParser.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src-gen/org/eclipse/xtext/ide/tests/testlanguage/ide/contentassist/antlr/PartialPartialContentAssistTestLanguageContentAssistParser.java
@@ -13,10 +13,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialPartialContentAssistTestLanguageContentAssistParser extends PartialContentAssistTestLanguageParser implements IPartialEditingContentAssistParser {
+public class PartialPartialContentAssistTestLanguageContentAssistParser extends PartialContentAssistTestLanguageParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.ide.tests/testlang-src-gen/org/eclipse/xtext/ide/tests/testlanguage/ide/contentassist/antlr/PartialPartialSerializationTestLanguageContentAssistParser.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src-gen/org/eclipse/xtext/ide/tests/testlanguage/ide/contentassist/antlr/PartialPartialSerializationTestLanguageContentAssistParser.java
@@ -13,10 +13,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialPartialSerializationTestLanguageContentAssistParser extends PartialSerializationTestLanguageParser implements IPartialEditingContentAssistParser {
+public class PartialPartialSerializationTestLanguageContentAssistParser extends PartialSerializationTestLanguageParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.ide.tests/testlang-src-gen/org/eclipse/xtext/ide/tests/testlanguage/ide/contentassist/antlr/PartialRenameTestLanguageContentAssistParser.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src-gen/org/eclipse/xtext/ide/tests/testlanguage/ide/contentassist/antlr/PartialRenameTestLanguageContentAssistParser.java
@@ -13,10 +13,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialRenameTestLanguageContentAssistParser extends RenameTestLanguageParser implements IPartialEditingContentAssistParser {
+public class PartialRenameTestLanguageContentAssistParser extends RenameTestLanguageParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.ide.tests/testlang-src-gen/org/eclipse/xtext/ide/tests/testlanguage/ide/contentassist/antlr/PartialTestLanguageContentAssistParser.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src-gen/org/eclipse/xtext/ide/tests/testlanguage/ide/contentassist/antlr/PartialTestLanguageContentAssistParser.java
@@ -13,10 +13,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialTestLanguageContentAssistParser extends TestLanguageParser implements IPartialEditingContentAssistParser {
+public class PartialTestLanguageContentAssistParser extends TestLanguageParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.testlanguages.ide/src-gen/org/eclipse/xtext/testlanguages/fileAware/ide/contentassist/antlr/PartialFileAwareTestLanguageContentAssistParser.java
+++ b/org.eclipse.xtext.testlanguages.ide/src-gen/org/eclipse/xtext/testlanguages/fileAware/ide/contentassist/antlr/PartialFileAwareTestLanguageContentAssistParser.java
@@ -8,10 +8,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialFileAwareTestLanguageContentAssistParser extends FileAwareTestLanguageParser implements IPartialEditingContentAssistParser {
+public class PartialFileAwareTestLanguageContentAssistParser extends FileAwareTestLanguageParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.testlanguages.ide/src-gen/org/eclipse/xtext/testlanguages/nestedRefs/ide/contentassist/antlr/PartialNestedRefsTestLanguageContentAssistParser.java
+++ b/org.eclipse.xtext.testlanguages.ide/src-gen/org/eclipse/xtext/testlanguages/nestedRefs/ide/contentassist/antlr/PartialNestedRefsTestLanguageContentAssistParser.java
@@ -8,10 +8,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialNestedRefsTestLanguageContentAssistParser extends NestedRefsTestLanguageParser implements IPartialEditingContentAssistParser {
+public class PartialNestedRefsTestLanguageContentAssistParser extends NestedRefsTestLanguageParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.testlanguages.ide/src-gen/org/eclipse/xtext/testlanguages/noJdt/ide/contentassist/antlr/PartialNoJdtTestLanguageContentAssistParser.java
+++ b/org.eclipse.xtext.testlanguages.ide/src-gen/org/eclipse/xtext/testlanguages/noJdt/ide/contentassist/antlr/PartialNoJdtTestLanguageContentAssistParser.java
@@ -8,10 +8,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialNoJdtTestLanguageContentAssistParser extends NoJdtTestLanguageParser implements IPartialEditingContentAssistParser {
+public class PartialNoJdtTestLanguageContentAssistParser extends NoJdtTestLanguageParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.testlanguages.ide/src-gen/org/eclipse/xtext/testlanguages/xtextgrammar/ide/contentassist/antlr/PartialXtextGrammarTestLanguageContentAssistParser.java
+++ b/org.eclipse.xtext.testlanguages.ide/src-gen/org/eclipse/xtext/testlanguages/xtextgrammar/ide/contentassist/antlr/PartialXtextGrammarTestLanguageContentAssistParser.java
@@ -8,10 +8,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialXtextGrammarTestLanguageContentAssistParser extends XtextGrammarTestLanguageParser implements IPartialEditingContentAssistParser {
+public class PartialXtextGrammarTestLanguageContentAssistParser extends XtextGrammarTestLanguageParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/templates/CodetemplatesGeneratorFragment2.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/templates/CodetemplatesGeneratorFragment2.xtend
@@ -96,8 +96,7 @@ class CodetemplatesGeneratorFragment2 extends AbstractXtextGeneratorFragment {
 	}
 	
 	private def StringConcatenationClient getGenPartialContentAssistParser() '''
-		public class «grammar.partialContentAssistParserClass.simpleName» extends «caNaming.getParserClass(grammar)» implements «
-				"org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser".typeRef()» {
+		public class «grammar.partialContentAssistParserClass.simpleName» extends «caNaming.getParserClass(grammar)» {
 		
 			private «AbstractRule» rule;
 		

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/templates/CodetemplatesGeneratorFragment2.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/templates/CodetemplatesGeneratorFragment2.java
@@ -136,9 +136,6 @@ public class CodetemplatesGeneratorFragment2 extends AbstractXtextGeneratorFragm
         _builder.append(" extends ");
         TypeReference _parserClass = CodetemplatesGeneratorFragment2.this.caNaming.getParserClass(CodetemplatesGeneratorFragment2.this.getGrammar());
         _builder.append(_parserClass);
-        _builder.append(" implements ");
-        TypeReference _typeRef = TypeReference.typeRef("org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser");
-        _builder.append(_typeRef);
         _builder.append(" {");
         _builder.newLineIfNotEmpty();
         _builder.newLine();

--- a/org.eclipse.xtext.xtext.ide/src-gen/org/eclipse/xtext/xtext/ide/contentassist/antlr/PartialXtextContentAssistParser.java
+++ b/org.eclipse.xtext.xtext.ide/src-gen/org/eclipse/xtext/xtext/ide/contentassist/antlr/PartialXtextContentAssistParser.java
@@ -8,10 +8,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialXtextContentAssistParser extends XtextParser implements IPartialEditingContentAssistParser {
+public class PartialXtextContentAssistParser extends XtextParser {
 
 	private AbstractRule rule;
 


### PR DESCRIPTION
[eclipse/xtext-core#1418] removed redundant superinterface from generated ca parsers

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>