### PR TITLE
[#1458] made XtextResource.getParser more easily customizeable

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/XtextResource.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/XtextResource.java
@@ -174,9 +174,9 @@ public class XtextResource extends ResourceImpl {
 		setEncodingFromOptions(options);
 		IParseResult result;
 		if (entryPoint == null) {
-			result = parser.parse(createReader(inputStream));
+			result = getParser().parse(createReader(inputStream));
 		} else {
-			result = parser.parse(entryPoint, createReader(inputStream));
+			result = getParser().parse(entryPoint, createReader(inputStream));
 		}
 		updateInternalState(this.parseResult, result);
 	}
@@ -263,11 +263,11 @@ public class XtextResource extends ResourceImpl {
 			IParseResult newParseResult;
 			ParserRule oldEntryPoint = NodeModelUtils.getEntryParserRule(oldParseResult.getRootNode());
 			if (entryPoint == null || entryPoint == oldEntryPoint) {
-				newParseResult = parser.reparse(oldParseResult, replaceRegion);
+				newParseResult = getParser().reparse(oldParseResult, replaceRegion);
 			} else {
 				StringBuilder builder = new StringBuilder(oldParseResult.getRootNode().getText());
 				replaceRegion.applyTo(builder);
-				newParseResult = parser.parse(entryPoint, new StringReader(builder.toString()));
+				newParseResult = getParser().parse(entryPoint, new StringReader(builder.toString()));
 			}
 			updateInternalState(oldParseResult, newParseResult);
 		} finally {


### PR DESCRIPTION
[#1458] made XtextResource.getParser more easily customizeable
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>