### PR TITLE
[eclipse/xtext#1738] use java.text.SimpleDateFormat instead of com.ibm.icu.SimpleDateFormat

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/terminalrules/DefaultTerminalConverterTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/terminalrules/DefaultTerminalConverterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.parser.terminalrules;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.eclipse.xtext.parser.terminalrules.ecoreTerminalsTestLanguage.EcoreTerminalsTestLanguageFactory;
@@ -15,8 +16,6 @@ import org.eclipse.xtext.parser.terminalrules.ecoreTerminalsTestLanguage.Model;
 import org.eclipse.xtext.serializer.ISerializer;
 import org.eclipse.xtext.tests.AbstractXtextTests;
 import org.junit.Test;
-
-import com.ibm.icu.text.SimpleDateFormat;
 
 /**
  * @author Jan Koehnlein - Initial contribution and API


### PR DESCRIPTION
[eclipse/xtext#1738] use java.text.SimpleDateFormat instead of com.ibm.icu.SimpleDateFormat

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>