### PR TITLE
[eclipse/xtext#1738] avoid usage of icu.Transliterator

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/GrammarAccessExtensionsTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/GrammarAccessExtensionsTest.java
@@ -29,6 +29,7 @@ public class GrammarAccessExtensionsTest {
 		Assert.assertEquals("CommercialAtApostrophe", grammarAccessExtensions.toJavaIdentifier("@\'", false));
 		Assert.assertEquals("Grün", grammarAccessExtensions.toJavaIdentifier("Grün", true));
 		Assert.assertEquals("DollarSign", grammarAccessExtensions.toJavaIdentifier("$", true));
+		Assert.assertEquals("ColonExclamationMarkQuestionMark", grammarAccessExtensions.toJavaIdentifier(":!?", true));
 		Assert.assertEquals("_", grammarAccessExtensions.toJavaIdentifier("_", true));
 	}
 

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -12,7 +12,6 @@ import com.google.common.collect.Maps
 import com.google.inject.Binder
 import com.google.inject.Guice
 import com.google.inject.Inject
-import com.ibm.icu.text.Transliterator
 import java.util.ArrayList
 import java.util.List
 import java.util.Map
@@ -68,8 +67,6 @@ class GrammarAccessExtensions {
 		"\\" -> "backslash"
 	};
 	val Map<String, ISerializer> xtextSerializerByLineDelimiter = Maps.newHashMapWithExpectedSize(2)
-	
-	val transliterator = Transliterator.getInstance('Any-Name')
 	
 	@Inject CodeConfig codeConfig
 	
@@ -139,8 +136,7 @@ class GrammarAccessExtensions {
 	 * Returns the Unicode string name for a character.
 	 */
 	def String getUnicodeName(char character) {
-		val transliterated = transliterator.transliterate(String.valueOf(character))
-		return transliterated.substring('\\N{'.length, transliterated.length - '}'.length)
+		Character.getName(character)
 	}
 
 	private def String toJavaIdentifierSegmentInt(String text, boolean isFirst, boolean uppercaseFirst) {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -15,7 +15,6 @@ import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.ibm.icu.text.Transliterator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -95,8 +94,6 @@ public class GrammarAccessExtensions {
   private static Map<String, String> SPECIAL_CHARS = Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(Pair.<String, String>of("\b", "backspace"), Pair.<String, String>of("\f", "formFeed"), Pair.<String, String>of("\n", "lineFeed"), Pair.<String, String>of("\r", "carriageReturn"), Pair.<String, String>of("\t", "tab"), Pair.<String, String>of("\\", "backslash")));
   
   private final Map<String, ISerializer> xtextSerializerByLineDelimiter = Maps.<String, ISerializer>newHashMapWithExpectedSize(2);
-  
-  private final Transliterator transliterator = Transliterator.getInstance("Any-Name");
   
   @Inject
   private CodeConfig codeConfig;
@@ -201,12 +198,7 @@ public class GrammarAccessExtensions {
    * Returns the Unicode string name for a character.
    */
   public String getUnicodeName(final char character) {
-    final String transliterated = this.transliterator.transliterate(String.valueOf(character));
-    int _length = "\\N{".length();
-    int _length_1 = transliterated.length();
-    int _length_2 = "}".length();
-    int _minus = (_length_1 - _length_2);
-    return transliterated.substring(_length, _minus);
+    return Character.getName(character);
   }
   
   private String toJavaIdentifierSegmentInt(final String text, final boolean isFirst, final boolean uppercaseFirst) {


### PR DESCRIPTION
[eclipse/xtext#1738] avoid usage of icu.Transliterator
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>