### PR TITLE
[eclipse/xtext#1738] removed no longer needed icu dependency

### DIFF
--- a/org.eclipse.xtext.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.tests/META-INF/MANIFEST.MF
@@ -26,8 +26,7 @@ Require-Bundle: org.eclipse.xtext,
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/simple.jar,
  .
-Import-Package: com.ibm.icu.text;version="4.0.0",
- org.apache.log4j;version="1.2.15",
+Import-Package: org.apache.log4j;version="1.2.15",
  org.hamcrest.core,
  org.junit;version="4.12.0",
  org.junit.rules;version="4.12.0",

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePlugin/org.xtext.example.eclipsePlugin/build.properties
@@ -15,5 +15,4 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.eclipsePluginP2/org.xtext.example.eclipsePluginP2/build.properties
@@ -15,5 +15,4 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full/build.properties
@@ -15,5 +15,4 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp/build.properties
@@ -15,5 +15,4 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar/build.properties
@@ -15,5 +15,4 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho/build.properties
@@ -15,5 +15,4 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9/build.properties
@@ -15,5 +15,4 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2/build.properties
@@ -15,5 +15,4 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j

--- a/org.eclipse.xtext.xtext.generator/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.generator/META-INF/MANIFEST.MF
@@ -19,8 +19,7 @@ Require-Bundle: org.eclipse.xtext;x-installation:=greedy,
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  de.itemis.xtext.antlr;bundle-version="2.0.0";resolution:=optional;visibility:=reexport,
  org.eclipse.jdt.core;bundle-version="3.13.102";resolution:=optional
-Import-Package: com.ibm.icu.text;version="4.0.0",
- org.apache.log4j;version="1.2.15"
+Import-Package: org.apache.log4j;version="1.2.15"
 Export-Package: org.eclipse.xtext.xtext.generator,
  org.eclipse.xtext.xtext.generator.builder;x-friends:="org.eclipse.xtext.xbase",
  org.eclipse.xtext.xtext.generator.ecore;x-friends:="org.eclipse.xtext.extras.tests,

--- a/org.eclipse.xtext.xtext.generator/build.gradle
+++ b/org.eclipse.xtext.xtext.generator/build.gradle
@@ -7,7 +7,6 @@ dependencies {
 	compile 'org.eclipse.emf:org.eclipse.emf.codegen.ecore'
 	compile 'org.eclipse.emf:org.eclipse.emf.mwe.utils'
 	compile 'org.eclipse.emf:org.eclipse.emf.mwe2.lib'
-	compile 'com.ibm.icu:icu4j'
 	compile 'org.eclipse.platform:org.eclipse.equinox.common'
 	optional 'org.eclipse.platform:org.eclipse.core.runtime'
 	optional 'org.eclipse.jdt:org.eclipse.jdt.core'

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
@@ -115,8 +115,7 @@ class RuntimeProjectDescriptor extends TestedProjectDescriptor {
 			"org.eclipse.emf.mwe2.lib",
 			"org.objectweb.asm",
 			"org.apache.commons.logging", 
-			"org.apache.log4j",
-			"com.ibm.icu"
+			"org.apache.log4j"
 		)
 		if (isFromExistingEcoreModels) {
 			if (config.ecore2Xtext.EPackageInfos.exists[genmodelURI.fileExtension == "xcore"]) {

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
@@ -181,8 +181,7 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
       "org.eclipse.emf.mwe2.lib", 
       "org.objectweb.asm", 
       "org.apache.commons.logging", 
-      "org.apache.log4j", 
-      "com.ibm.icu");
+      "org.apache.log4j");
     boolean _isFromExistingEcoreModels = this.isFromExistingEcoreModels();
     if (_isFromExistingEcoreModels) {
       final Function1<EPackageInfo, Boolean> _function = (EPackageInfo it) -> {


### PR DESCRIPTION
[eclipse/xtext#1738] removed no longer needed icu dependency
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>