### PR TITLE
Update reference must convert the qualified name text

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/ReferenceUpdater.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/ReferenceUpdater.java
@@ -245,7 +245,7 @@ public class ReferenceUpdater implements IReferenceUpdater {
 		}
 		IScope scope = scopeProvider.getScope(updatable.getSourceEObject(), updatable.getEReference());
 		ISemanticRegion region = updatable.getReferenceRegion();
-		QualifiedName oldName = nameConverter.toQualifiedName(region.getText());
+		QualifiedName oldName = getQualifiedName(updatable);
 		IEObjectDescription oldDesc = scope.getSingleElement(oldName);
 		if (oldDesc != null && oldDesc.getEObjectOrProxy() == updatable.getTargetEObject()) {
 			return;


### PR DESCRIPTION
In case of STRING typed crossrefs `scope.getSingleElement(oldName)` will not work properly