### PR TITLE
[eclipse/xtext#1769] Removed jnlp image name from pod template

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ kind: Pod
 spec:
   containers:
   - name: jnlp
-    image: 'eclipsecbi/jenkins-jnlp-agent'
     args: ['\$(JENKINS_SECRET)', '\$(JENKINS_NAME)']
     resources:
       limits:


### PR DESCRIPTION
Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>