### PR TITLE
removed obsolete org.eclipse.xtend.shared.ui.prefs

### DIFF
--- a/org.eclipse.xtext.tests/.settings/org.eclipse.xtend.shared.ui.prefs
+++ b/org.eclipse.xtext.tests/.settings/org.eclipse.xtend.shared.ui.prefs
@@ -1,3 +1,0 @@
-#Tue Apr 06 14:38:13 CEST 2010
-eclipse.preferences.version=1
-project.specific.metamodel=true

--- a/org.eclipse.xtext/.settings/org.eclipse.xtend.shared.ui.prefs
+++ b/org.eclipse.xtext/.settings/org.eclipse.xtend.shared.ui.prefs
@@ -1,4 +1,0 @@
-#Tue Feb 16 15:24:59 CET 2010
-eclipse.preferences.version=1
-metamodelContributor=org.eclipse.xtend.shared.ui.core.metamodel.jdt.javabean.JavaBeanMetamodelContributor,org.eclipse.xtend.typesystem.emf.ui.EmfMetamodelContributor
-project.specific.metamodel=true


### PR DESCRIPTION
removed obsolete org.eclipse.xtend.shared.ui.prefs
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>