### PR TITLE
API cleanup after Xtend2Java

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/persistence/ResourceStorageLoadable.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/persistence/ResourceStorageLoadable.java
@@ -83,9 +83,8 @@ public class ResourceStorageLoadable {
 		}.loadResource(resource);
 	}
 
-	protected Object handleLoadEObject(InternalEObject loaded, BinaryResourceImpl.EObjectInputStream input)
+	protected void handleLoadEObject(InternalEObject loaded, BinaryResourceImpl.EObjectInputStream input)
 			throws IOException {
-		return null;
 	}
 
 	protected void readResourceDescription(StorageAwareResource resource, InputStream inputStream) throws IOException {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/persistence/ResourceStorageWritable.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/persistence/ResourceStorageWritable.java
@@ -104,9 +104,8 @@ public class ResourceStorageWritable {
 		}
 	}
 
-	protected Object beforeSaveEObject(InternalEObject object, BinaryResourceImpl.EObjectOutputStream writable)
+	protected void beforeSaveEObject(InternalEObject object, BinaryResourceImpl.EObjectOutputStream writable)
 			throws IOException {
-		return null;
 	}
 
 	protected void handleSaveEObject(InternalEObject object, BinaryResourceImpl.EObjectOutputStream out)


### PR DESCRIPTION
The methods in question had a return type `Object` but the return value was never used.
Updated to return `void` instead.