### PR TITLE
[releng] Update Orbit URL to https://download.eclipse.org/tools/orbit/downloads/2020-12

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.target/org.xtext.example.full.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.target/org.xtext.example.full.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 			<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 		</location>
 	</locations>
 </target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.target/org.xtext.example.lsMavenTychoApp.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoApp/org.xtext.example.lsMavenTychoApp.parent/org.xtext.example.lsMavenTychoApp.target/org.xtext.example.lsMavenTychoApp.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 			<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 		</location>
 	</locations>
 </target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.target/org.xtext.example.lsMavenTychoFatjar.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.lsMavenTychoFatjar/org.xtext.example.lsMavenTychoFatjar.parent/org.xtext.example.lsMavenTychoFatjar.target/org.xtext.example.lsMavenTychoFatjar.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 			<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 		</location>
 	</locations>
 </target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.target/org.xtext.example.mavenTycho.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.target/org.xtext.example.mavenTycho.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 			<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 		</location>
 	</locations>
 </target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9.target/org.xtext.example.mavenTychoJ9.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoJ9/org.xtext.example.mavenTychoJ9.parent/org.xtext.example.mavenTychoJ9.target/org.xtext.example.mavenTychoJ9.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 			<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 		</location>
 	</locations>
 </target>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.target/org.xtext.example.mavenTychoP2.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.target/org.xtext.example.mavenTychoP2.target.target
@@ -25,7 +25,7 @@
 			<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 			<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 		</location>
 	</locations>
 </target>

--- a/releng/releng-target/xtext-core.target.target
+++ b/releng/releng-target/xtext-core.target.target
@@ -18,7 +18,7 @@
 			<repository location="https://download.eclipse.org/releases/oxygen/201804111000"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 			<unit id="org.junit" version="4.12.0.v201504281640"/>
 			<unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
 		</location>


### PR DESCRIPTION
This change was brought to you by your friendly Xtext Genie.