### PR TITLE
[eclipse/xtext#1885] use 2021-03 in wizard

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJ11/mavenTychoJ11.parent/mavenTychoJ11.target/mavenTychoJ11.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJ11/mavenTychoJ11.parent/mavenTychoJ11.target/mavenTychoJ11.target.target
@@ -8,7 +8,7 @@
 			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/releases/2020-12"/>
+			<repository location="https://download.eclipse.org/releases/2021-03"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
@@ -62,7 +62,7 @@ class TargetPlatformProject extends ProjectDescriptor {
 					<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 					<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 					«IF config.javaVersion.isAtLeast(JavaVersion.JAVA11)»
-						<repository location="https://download.eclipse.org/releases/2020-12"/>
+						<repository location="https://download.eclipse.org/releases/2021-03"/>
 					«ELSE»
 						<!-- newer Eclipse versions need Java 11 to run the Maven Tycho build -->
 						<repository location="https://download.eclipse.org/releases/2020-06"/>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
@@ -112,7 +112,7 @@ public class TargetPlatformProject extends ProjectDescriptor {
       boolean _isAtLeast = this.getConfig().getJavaVersion().isAtLeast(JavaVersion.JAVA11);
       if (_isAtLeast) {
         _builder.append("\t\t\t");
-        _builder.append("<repository location=\"https://download.eclipse.org/releases/2020-12\"/>");
+        _builder.append("<repository location=\"https://download.eclipse.org/releases/2021-03\"/>");
         _builder.newLine();
       } else {
         _builder.append("\t\t\t");


### PR DESCRIPTION
[eclipse/xtext#1885] use 2021-03 in wizard
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>

DO NOT merge yet, as 2021-03 is not available yet