### PR TITLE
[eclipse/xtext#1652] Use https instead of git URL for SCM connection

### DIFF
--- a/gradle/maven-deployment.gradle
+++ b/gradle/maven-deployment.gradle
@@ -20,8 +20,8 @@ publishing {
                     }
                 }
                 scm {
-                    connection = "scm:git:git@github.com:eclipse/${rootProject.name}.git"
-                    developerConnection = "scm:git:git@github.com:eclipse/${rootProject.name}.git"
+                    connection = "scm:git:https://github.com/eclipse/${rootProject.name}.git"
+                    developerConnection = "scm:git:https://github.com/eclipse/${rootProject.name}.git"
                     url = "git@github.com:eclipse/${rootProject.name}.git"
                 }
                 // We need to wait until the project's own build file has been executed


### PR DESCRIPTION
[eclipse/xtext#1652] Use https instead of git URL for SCM connection
Harmonized newline at eof in gradle and poms

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>