### PR TITLE
[eclipse/xtext#1916] Upgrade GSON to 2.8.6

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/full/full.parent/full.target/full.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/full/full.parent/full.target/full.target.target
@@ -20,7 +20,7 @@
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
+			<unit id="com.google.gson" version="2.8.6.v20201231-1626"/>
 			<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
 			<unit id="org.junit" version="4.12.0.v201504281640"/>
 			<unit id="org.objectweb.asm" version="9.0.0.v20201001-1419"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoApp/lsMavenTychoApp.parent/lsMavenTychoApp.target/lsMavenTychoApp.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoApp/lsMavenTychoApp.parent/lsMavenTychoApp.target/lsMavenTychoApp.target.target
@@ -20,7 +20,7 @@
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
+			<unit id="com.google.gson" version="2.8.6.v20201231-1626"/>
 			<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
 			<unit id="org.junit" version="4.12.0.v201504281640"/>
 			<unit id="org.objectweb.asm" version="9.0.0.v20201001-1419"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoFatjar/lsMavenTychoFatjar.parent/lsMavenTychoFatjar.target/lsMavenTychoFatjar.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoFatjar/lsMavenTychoFatjar.parent/lsMavenTychoFatjar.target/lsMavenTychoFatjar.target.target
@@ -20,7 +20,7 @@
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
+			<unit id="com.google.gson" version="2.8.6.v20201231-1626"/>
 			<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
 			<unit id="org.junit" version="4.12.0.v201504281640"/>
 			<unit id="org.objectweb.asm" version="9.0.0.v20201001-1419"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTycho/mavenTycho.parent/mavenTycho.target/mavenTycho.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTycho/mavenTycho.parent/mavenTycho.target/mavenTycho.target.target
@@ -20,7 +20,7 @@
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
+			<unit id="com.google.gson" version="2.8.6.v20201231-1626"/>
 			<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
 			<unit id="org.junit" version="4.12.0.v201504281640"/>
 			<unit id="org.objectweb.asm" version="9.0.0.v20201001-1419"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJ11/mavenTychoJ11.parent/mavenTychoJ11.target/mavenTychoJ11.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJ11/mavenTychoJ11.parent/mavenTychoJ11.target/mavenTychoJ11.target.target
@@ -19,7 +19,7 @@
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
+			<unit id="com.google.gson" version="2.8.6.v20201231-1626"/>
 			<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
 			<unit id="org.junit" version="4.12.0.v201504281640"/>
 			<unit id="org.junit.jupiter.api" version="5.7.0.v20201026-1537"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2/mavenTychoP2.parent/mavenTychoP2.target/mavenTychoP2.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2/mavenTychoP2.parent/mavenTychoP2.target/mavenTychoP2.target.target
@@ -20,7 +20,7 @@
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
+			<unit id="com.google.gson" version="2.8.6.v20201231-1626"/>
 			<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
 			<unit id="org.junit" version="4.12.0.v201504281640"/>
 			<unit id="org.objectweb.asm" version="9.0.0.v20201001-1419"/>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
@@ -87,7 +87,7 @@ class TargetPlatformProject extends ProjectDescriptor {
 					«ENDIF»
 				</location>
 				<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-					<unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
+					<unit id="com.google.gson" version="2.8.6.v20201231-1626"/>
 					<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
 					<unit id="org.junit" version="4.12.0.v201504281640"/>
 					«IF config.junitVersion == JUnitVersion.JUNIT_5»

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
@@ -188,7 +188,7 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.append("<location includeAllPlatforms=\"false\" includeConfigurePhase=\"false\" includeMode=\"planner\" includeSource=\"true\" type=\"InstallableUnit\">");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"com.google.gson\" version=\"2.8.2.v20180104-1110\"/>");
+    _builder.append("<unit id=\"com.google.gson\" version=\"2.8.6.v20201231-1626\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
     _builder.append("<unit id=\"org.antlr.runtime\" version=\"3.2.0.v201101311130\"/>");


### PR DESCRIPTION
Following platform upgrade of GSON from Bug#569966.

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>