### PR TITLE
https://github.com/eclipse/xtext/issues/1862 Guava 30.1.0

### DIFF
--- a/org.eclipse.xtext.util/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.util/META-INF/MANIFEST.MF
@@ -42,7 +42,7 @@ Export-Package: org.eclipse.xtext.util;
    org.eclipse.xtext.xtext.ui,
    org.eclipse.xtext.xbase"
 Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.20.0",
- com.google.guava;bundle-version="[27.1.0,28.0.0)";visibility:=reexport,
+ com.google.guava;bundle-version="[30.1.0,31.0.0)";visibility:=reexport,
  com.google.inject;bundle-version="3.0.0";visibility:=reexport,
  javax.inject;bundle-version="1.0.0";resolution:=optional;visibility:=reexport;x-installation:=greedy,
  org.eclipse.xtend.lib

--- a/releng/releng-target/xtext-core.target.target
+++ b/releng/releng-target/xtext-core.target.target
@@ -20,7 +20,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/2021-03"/>
 			<unit id="org.junit" version="4.12.0.v201504281640"/>
-			<unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
+			<unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
Update Google Guava version from 27.1.0 to 30.1.0

Signed-off-by: miklossy <miklossy@itemis.de>