### PR TITLE
[#897] Folding Support for LSP

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/editor/folding/AbstractFoldingRangeProviderTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/editor/folding/AbstractFoldingRangeProviderTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021 TypeFox GmbH (http://www.typefox.io) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.editor.folding;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.ide.editor.folding.FoldingRange;
+import org.eclipse.xtext.ide.editor.folding.IFoldingRangeProvider;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.testing.util.ParseHelper;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.junit.Assert;
+
+import com.google.inject.Inject;
+
+/**
+ * @author Mark Sujew - Initial contribution and API
+ */
+public abstract class AbstractFoldingRangeProviderTest<T extends EObject> {
+
+	@Inject
+	private IFoldingRangeProvider foldingRangeProvider;
+	@Inject
+	private ParseHelper<T> parseHelper;
+
+	protected void assertFoldingRanges(CharSequence content, FoldingRange... expectedRanges) {
+		XtextResource resource;
+		try {
+			resource = (XtextResource) parseHelper.parse(content).eResource();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		List<FoldingRange> foldingRanges = foldingRangeProvider.getFoldingRanges(resource, CancelIndicator.NullImpl)
+				.stream().collect(Collectors.toList());
+
+		Assert.assertEquals(expectedRanges.length, foldingRanges.size());
+		
+		for (int i = 0; i < foldingRanges.size(); i++) {
+			FoldingRange range = foldingRanges.get(i);
+			FoldingRange expected = expectedRanges[i];
+			Assert.assertEquals(expected.getOffset(), range.getOffset());
+			Assert.assertEquals(expected.getLength(), range.getLength());
+			Assert.assertEquals(expected.getKind(), range.getKind());
+		}
+	}
+}

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/editor/folding/FoldingRangeProviderTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/editor/folding/FoldingRangeProviderTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2021 TypeFox GmbH (http://www.typefox.io) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.editor.folding;
+
+import org.eclipse.xtext.ide.editor.folding.FoldingRange;
+import org.eclipse.xtext.ide.editor.folding.FoldingRangeKind;
+import org.eclipse.xtext.ide.tests.testlanguage.TestLanguageIdeInjectorProvider;
+import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.Model;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mark Sujew - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(TestLanguageIdeInjectorProvider.class)
+public class FoldingRangeProviderTest extends AbstractFoldingRangeProviderTest<Model> {
+
+	@Test
+	public void foldingRangesProvider() {
+		String actual = "package testLanguage {"
+				+ "\n"
+				+ "\n";
+		int commentIndex = actual.length();
+		
+		actual += "/*\n"
+				+ " * This s a multiline comment"
+				+ " */";
+		int commentLength = actual.length() - commentIndex;
+		
+		actual += "\n";
+		int typeIndex = actual.length();
+		
+		actual += "type myType {"
+				+ "\n" 
+				+ "}";
+		int typeLength = actual.length() - typeIndex;
+		actual += "\n}";
+		
+		assertFoldingRanges(actual, new FoldingRange(0, actual.length()), new FoldingRange(commentIndex, commentLength, FoldingRangeKind.COMMENT), new FoldingRange(typeIndex, typeLength));
+	}
+	
+}

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/FoldingTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/FoldingTest.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2021 TypeFox GmbH (http://www.typefox.io) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.server;
+
+import org.junit.Test;
+
+/**
+ * @author Mark Sujew - Initial contribution and API
+ */
+public class FoldingTest extends AbstractTestLangLanguageServerTest {
+
+	@Test
+	public void testFoldingService() {
+		testFolding(it -> {
+			it.setModel("/*\nMultiline Comment\n*/\ntype Foo {\nint bar\n}");
+			String expectedText = "[comment 0..2]\n[null 3..5]\n";
+			it.setExpectedFoldings(expectedText);
+		});
+	}
+	
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/DefaultFoldingRangeAcceptor.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/DefaultFoldingRangeAcceptor.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2021 Michael Clay and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.xtext.ide.editor.folding;
+
+import java.util.Collection;
+
+import org.eclipse.xtext.util.ITextRegion;
+
+/**
+ * @author Michael Clay - Initial contribution and API
+ * @author Sebastian Zarnekow - Introduced FoldedPosition
+ * @author Mark Sujew - Ported to IDE project
+ * 
+ * @since 2.26
+ */
+public class DefaultFoldingRangeAcceptor implements IFoldingRangeAcceptor {
+	private Collection<FoldingRange> result;
+
+	public DefaultFoldingRangeAcceptor(Collection<FoldingRange> result) {
+		this.result = result;
+	}
+
+	public Collection<FoldingRange> getFoldingRanges() {
+		return result;
+	}
+
+	@Override
+	public void accept(int offset, int length, FoldingRangeKind kind, boolean initiallyFolded,
+			ITextRegion visualPlaceholderRegion) {
+		result.add(createFoldingRange(offset, length, kind, initiallyFolded, visualPlaceholderRegion));
+	}
+
+	protected FoldingRange createFoldingRange(int offset, int length, FoldingRangeKind kind, boolean initiallyFolded,
+			ITextRegion visualPlaceholderRegion) {
+		return new FoldingRange(offset, length, kind, initiallyFolded, visualPlaceholderRegion);
+	}
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/DefaultFoldingRangeProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/DefaultFoldingRangeProvider.java
@@ -1,0 +1,202 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2021 Michael Clay and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.xtext.ide.editor.folding;
+
+import java.util.Collection;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.TerminalRule;
+import org.eclipse.xtext.documentation.impl.AbstractMultiLineCommentProvider;
+import org.eclipse.xtext.nodemodel.ICompositeNode;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.parser.IParseResult;
+import org.eclipse.xtext.resource.ILocationInFileProvider;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.util.ITextRegion;
+import org.eclipse.xtext.util.ITextRegionWithLineInformation;
+import org.eclipse.xtext.util.LineAndColumn;
+import org.eclipse.xtext.util.TextRegion;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+/**
+ * @author Michael Clay - Initial contribution and API
+ * @author Sebastian Zarnekow - Introduced FoldedRegion, use ILocationInFileProvider
+ * @author Mark Sujew - Ported to IDE project
+ * 
+ * @since 2.26
+ */
+public class DefaultFoldingRangeProvider implements IFoldingRangeProvider {
+
+	@Inject
+	private ILocationInFileProvider locationInFileProvider;
+
+	@Inject(optional = true)
+	@Named(AbstractMultiLineCommentProvider.RULE)
+	private String ruleName = "ML_COMMENT";
+
+	protected static final Pattern TEXT_PATTERN_IN_COMMENT = Pattern.compile("\\w");
+
+	@Override
+	public SortedSet<FoldingRange> getFoldingRanges(XtextResource xtextDocument, CancelIndicator cancelIndicator) {
+		SortedSet<FoldingRange> result = new TreeSet<>((a, b) -> Integer.compare(a.getOffset(), b.getOffset()));
+		IFoldingRangeAcceptor foldingRegionAcceptor = createAcceptor(xtextDocument, result);
+		computeObjectFolding(xtextDocument, foldingRegionAcceptor, cancelIndicator);
+		computeCommentFolding(xtextDocument, foldingRegionAcceptor);
+		return result;
+	}
+
+	protected void computeObjectFolding(XtextResource resource, IFoldingRangeAcceptor foldingRangeAcceptor,
+			CancelIndicator cancelIndicator) {
+		IParseResult parseResult = resource.getParseResult();
+		if (parseResult != null) {
+			EObject rootASTElement = parseResult.getRootASTElement();
+			if (rootASTElement != null) {
+				if (cancelIndicator.isCanceled())
+					throw new OperationCanceledException();
+				if (isHandled(rootASTElement)) {
+					acceptObjectFolding(rootASTElement, foldingRangeAcceptor);
+				}
+				if (shouldProcessContent(rootASTElement)) {
+					TreeIterator<EObject> allContents = rootASTElement.eAllContents();
+					while (allContents.hasNext()) {
+						if (cancelIndicator.isCanceled())
+							throw new OperationCanceledException();
+						EObject eObject = allContents.next();
+						if (isHandled(eObject)) {
+							acceptObjectFolding(eObject, foldingRangeAcceptor);
+						}
+						if (!shouldProcessContent(eObject)) {
+							allContents.prune();
+						}
+					}
+				}
+			}
+		}
+	}
+
+	protected void acceptObjectFolding(EObject eObject, IFoldingRangeAcceptor foldingRangeAcceptor) {
+		ITextRegion region = locationInFileProvider.getFullTextRegion(eObject);
+		if (region != null) {
+			INode eObjectNode = NodeModelUtils.getNode(eObject);
+			ITextRegion significant = buildSignificantRegion(locationInFileProvider.getSignificantTextRegion(eObject),
+					eObjectNode);
+			foldingRangeAcceptor.accept(region.getOffset(), region.getLength(), null, false, significant);
+		}
+	}
+
+	protected ITextRegion buildSignificantRegion(ITextRegion significantRegion, INode node) {
+		if (significantRegion == null || node == null) {
+			return null;
+		}
+		int offset = significantRegion.getOffset();
+		int endOffset = significantRegion.getOffset() + significantRegion.getLength();
+
+		int startLine;
+		int endLine;
+		if (significantRegion instanceof ITextRegionWithLineInformation) {
+			ITextRegionWithLineInformation lineInfoRegion = (ITextRegionWithLineInformation) significantRegion;
+			startLine = lineInfoRegion.getLineNumber();
+			endLine = lineInfoRegion.getEndLineNumber();
+		} else {
+			startLine = NodeModelUtils.getLineAndColumn(node, offset).getLine();
+			endLine = NodeModelUtils.getLineAndColumn(node, endOffset).getLine();
+		}
+
+		if (startLine != endLine) {
+			/*
+			 * The Eclipse IDE can only use the significant region if it starts and ends on the same line.
+			 * Therefore, we here calculate the index of the end of the line.
+			 */
+			for (int index = offset; index < endOffset; index++) {
+				LineAndColumn lineInfo = NodeModelUtils.getLineAndColumn(node, index);
+				if (lineInfo.getLine() != startLine) {
+					return new TextRegion(offset, index - offset - 1);
+				}
+			}
+		}
+		return significantRegion;
+	}
+
+	protected void computeCommentFolding(XtextResource resource, IFoldingRangeAcceptor foldingRangeAcceptor) {
+		IParseResult parseResult = resource.getParseResult();
+		if (parseResult != null) {
+			EObject rootASTElement = parseResult.getRootASTElement();
+			acceptCommentNodes(rootASTElement, foldingRangeAcceptor);
+		}
+	}
+
+	protected void acceptCommentNodes(EObject eObject, IFoldingRangeAcceptor foldingRangeAcceptor) {
+		ICompositeNode node = NodeModelUtils.getNode(eObject);
+		if (node != null) {
+			for (INode leafNode : node.getAsTreeIterable()) {
+				if (leafNode.getGrammarElement() instanceof TerminalRule
+						&& ruleName.equalsIgnoreCase(((TerminalRule) leafNode.getGrammarElement()).getName())) {
+					acceptCommentFolding(leafNode, foldingRangeAcceptor);
+				}
+			}
+		}
+	}
+
+	protected void acceptCommentFolding(INode commentNode, IFoldingRangeAcceptor foldingRangeAcceptor) {
+		int offset = commentNode.getOffset();
+		int length = commentNode.getLength();
+		Matcher matcher = getTextPatternInComment().matcher(commentNode.getText());
+		if (matcher.find()) {
+			TextRegion significant = new TextRegion(offset + matcher.start(), 0);
+			foldingRangeAcceptor.accept(offset, length, FoldingRangeKind.COMMENT, significant);
+		} else {
+			foldingRangeAcceptor.accept(offset, length, FoldingRangeKind.COMMENT);
+		}
+	}
+
+	protected IFoldingRangeAcceptor createAcceptor(XtextResource resource, Collection<FoldingRange> foldingRanges) {
+		return new DefaultFoldingRangeAcceptor(foldingRanges);
+	}
+
+	protected ILocationInFileProvider getLocationInFileProvider() {
+		return locationInFileProvider;
+	}
+
+	protected String getMultilineCommentRuleName() {
+		return ruleName;
+	}
+
+	/**
+	 * @return the regular expression that finds the first significant part of a multi line comment.
+	 */
+	protected Pattern getTextPatternInComment() {
+		return TEXT_PATTERN_IN_COMMENT;
+	}
+
+	/**
+	 * @return <code>true</code> if the object should be folded if it spans more than one line. Default is
+	 *         <code>false</code> if and only if the object is the root object of the resource.
+	 */
+	protected boolean isHandled(EObject eObject) {
+		return eObject.eContainer() != null;
+	}
+
+	/**
+	 * @return clients should return <code>false</code> to abort the traversal of the model.
+	 */
+	protected boolean shouldProcessContent(EObject object) {
+		return true;
+	}
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/FoldingRange.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/FoldingRange.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2021 TypeFox GmbH (http://www.typefox.io) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ide.editor.folding;
+
+import org.eclipse.xtext.util.ITextRegion;
+
+import com.google.common.base.Objects;
+
+/**
+ * Represents an abstraction for different folding implementations.
+ * Specifically Eclipse's <code>FoldingRegion</code> and the <code>FoldingRange</code> of the LSP specification.
+ * 
+ * @author Mark Sujew - Initial contribution and API
+ * 
+ * @since 2.26
+ */
+public class FoldingRange {
+
+	private final int offset;
+	private final int length;
+	private final FoldingRangeKind kind;
+	private final boolean initiallyFolded;
+	private final ITextRegion visualPlaceholderRegion;
+
+	public FoldingRange(int offset, int length) {
+		this(offset, length, null);
+	}
+
+	public FoldingRange(int offset, int length, FoldingRangeKind kind) {
+		this(offset, length, kind, false, null);
+	}
+
+	public FoldingRange(int offset, int length, FoldingRangeKind kind, boolean initiallyFolded,
+			ITextRegion visualPlaceholderRegion) {
+		this.offset = offset;
+		this.length = length;
+		this.kind = kind;
+		this.initiallyFolded = initiallyFolded;
+		this.visualPlaceholderRegion = visualPlaceholderRegion;
+	}
+	
+	public boolean isInitiallyFolded() {
+		return initiallyFolded;
+	}
+
+	public ITextRegion getVisualPlaceholderRegion() {
+		return visualPlaceholderRegion;
+	}
+
+	public FoldingRangeKind getKind() {
+		return kind;
+	}
+
+	public int getOffset() {
+		return offset;
+	}
+
+	public int getLength() {
+		return length;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (other instanceof FoldingRange) {
+			FoldingRange range = (FoldingRange) other;
+			return offset == range.offset && length == range.length && initiallyFolded == range.initiallyFolded
+					&& Objects.equal(kind, range.kind)
+					&& Objects.equal(visualPlaceholderRegion, range.visualPlaceholderRegion);
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(offset, length, initiallyFolded, kind, visualPlaceholderRegion);
+	}
+	
+	@Override
+	public String toString() {
+		StringBuilder content = new StringBuilder();
+		content.append("offset=").append(offset);
+		content.append(", length=").append(length);
+		content.append(", kind=").append(kind);
+		content.append(", initiallyFolded=").append(initiallyFolded);
+		return content.toString();
+	}
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/FoldingRangeKind.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/FoldingRangeKind.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 TypeFox GmbH (http://www.typefox.io) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ide.editor.folding;
+
+/**
+ * Contains the possible kinds of folding ranges defined by the LSP spec.
+ * 
+ * @author Mark Sujew - Initial contribution and API
+ * 
+ * @since 2.26
+ */
+public class FoldingRangeKind {
+	public static final FoldingRangeKind COMMENT = new FoldingRangeKind("comment");
+	public static final FoldingRangeKind IMPORTS = new FoldingRangeKind("imports");
+	public static final FoldingRangeKind REGION = new FoldingRangeKind("region");
+
+	private String kind;
+
+	private FoldingRangeKind(String kind) {
+		this.kind = kind;
+	}
+
+	@Override
+	public String toString() {
+		return kind;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (other instanceof FoldingRangeKind) {
+			return this.kind.equals(((FoldingRangeKind) other).kind);
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return kind.hashCode();
+	}
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/IFoldingRangeAcceptor.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/IFoldingRangeAcceptor.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2021 Michael Clay and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.xtext.ide.editor.folding;
+
+import org.eclipse.xtext.util.ITextRegion;
+
+/**
+ * @author Michael Clay - Initial contribution and API
+ * @author Sebastian Zarnekow - Distinguish between total and identifying region
+ * @author Mark Sujew - Ported to IDE project
+ * 
+ * @since 2.26
+ */
+public interface IFoldingRangeAcceptor {
+
+	default void accept(int offset, int length) {
+		accept(offset, length, false);
+	}
+
+	default void accept(int offset, int length, FoldingRangeKind kind) {
+		accept(offset, length, kind, null);
+	}
+
+	default void accept(int offset, int length, boolean initiallyFolded) {
+		accept(offset, length, null, initiallyFolded, null);
+	}
+
+	default void accept(int offset, int length, ITextRegion visualPlaceholderRegion) {
+		accept(offset, length, null, false, visualPlaceholderRegion);
+	}
+
+	default void accept(int offset, int length, FoldingRangeKind kind, ITextRegion visualPlaceholderRegion) {
+		accept(offset, length, kind, false, visualPlaceholderRegion);
+	}
+
+	void accept(int offset, int length, FoldingRangeKind kind, boolean initiallyFolded,
+			ITextRegion visualPlaceholderRegion);
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/IFoldingRangeProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/IFoldingRangeProvider.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2021 Michael Clay and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.xtext.ide.editor.folding;
+
+import java.util.SortedSet;
+
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.util.CancelIndicator;
+
+import com.google.inject.ImplementedBy;
+
+/**
+ * Compute the folding regions in the given document. This is a blocking action when opening the editor in e4, so
+ * clients should be careful to not resolve too many cross references in their implementation.
+ * 
+ * @author Michael Clay - Initial contribution and API
+ * @author Sebastian Zarnekow - Refactoring, introduced FoldedPosition
+ * @author Mark Sujew - Ported to IDE project
+ * 
+ * @since 2.26
+ */
+@ImplementedBy(DefaultFoldingRangeProvider.class)
+public interface IFoldingRangeProvider {
+
+	/**
+	 * @return the set of <code>FoldingRanges</code> for the given document
+	 */
+	SortedSet<FoldingRange> getFoldingRanges(XtextResource xtextDocument, CancelIndicator cancelIndicator);
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/folding/FoldingRangeService.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/folding/FoldingRangeService.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2021 TypeFox GmbH (http://www.typefox.io) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ide.server.folding;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.lsp4j.FoldingRange;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.xtext.ide.editor.folding.IFoldingRangeProvider;
+import org.eclipse.xtext.ide.server.Document;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.util.CancelIndicator;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * @author Mark Sujew - Initial contribution and API
+ * 
+ * @since 2.26
+ */
+@Singleton
+public class FoldingRangeService {
+
+	@Inject
+	private IFoldingRangeProvider foldingRangeProvider;
+
+	public List<FoldingRange> createFoldingRanges(Document document, XtextResource resource,
+			CancelIndicator cancelIndicator) {
+		return foldingRangeProvider.getFoldingRanges(resource, cancelIndicator).stream()
+				.map(range -> toFoldingRange(document, range)).filter(range -> isValidRange(range))
+				.collect(Collectors.toList());
+	}
+
+	protected FoldingRange toFoldingRange(Document document, org.eclipse.xtext.ide.editor.folding.FoldingRange range) {
+		int offset = range.getOffset();
+		int length = range.getLength();
+		int endOffset = offset + length;
+		Position start = document.getPosition(offset);
+		Position end = document.getPosition(endOffset);
+		FoldingRange result = new FoldingRange(start.getLine(), end.getLine());
+		if (range.getKind() != null) {
+			result.setKind(range.getKind().toString());
+		}
+		return result;
+	}
+
+	protected boolean isValidRange(FoldingRange range) {
+		return range.getStartLine() < range.getEndLine();
+	}
+}

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/FoldingConfiguration.java
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/FoldingConfiguration.java
@@ -1,0 +1,15 @@
+package org.eclipse.xtext.testing;
+
+public class FoldingConfiguration extends TextDocumentConfiguration {
+
+	private String expectedFoldings;
+
+	public String getExpectedFoldings() {
+		return expectedFoldings;
+	}
+
+	public void setExpectedFoldings(String expectedFoldings) {
+		this.expectedFoldings = expectedFoldings;
+	}
+	
+}


### PR DESCRIPTION
This solution should be easily adaptable for the eclipse/xtext-eclipse repo. The API is mostly based on the original implementation for Eclipse.

This should close #897 