### PR TITLE
[eclipse/xtext#1953] print  broken zip file when traversing archive fails

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/mwe/PathTraverser.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/mwe/PathTraverser.java
@@ -70,7 +70,7 @@ public class PathTraverser {
 				zipFile.close();
 			}
 		} catch (Exception e) {
-			throw new WrappedException(e);
+			throw new WrappedException("Error traversing archive " + file, e);
 		}
 	}
 


### PR DESCRIPTION
[eclipse/xtext#1953] print  broken zip file when traversing archive fails

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>