### PR TITLE
Fixing a typo in javadoc of the OutputConfiguration class.

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/OutputConfiguration.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/OutputConfiguration.java
@@ -108,7 +108,7 @@ public class OutputConfiguration {
 	}
 
 	/**
-	 * whether the output directory should be created if t doesn't already exist.
+	 * whether the output directory should be created if it doesn't already exist.
 	 */
 	public void setCreateOutputDirectory(boolean createOutputDirectory) {
 		this.createOutputDirectory = createOutputDirectory;


### PR DESCRIPTION
Signed-off-by: miklossy <miklossy@itemis.de>