### PR TITLE
[eclipse/xtext#1976] pin explicit transitive deps in xtext.xtext.gene…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,12 @@ pipeline {
         sh './2-maven-build.sh'
       }
     }
+
+    stage('Gradle generateTestLanguages') {
+      steps {
+        sh './gradlew generateTestLanguages -PuseJenkinsSnapshots=true'
+      }
+    }
   }
 
   post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,12 +56,6 @@ pipeline {
         sh './2-maven-build.sh'
       }
     }
-
-    stage('Gradle generateTestLanguages') {
-      steps {
-        sh './gradlew generateTestLanguages -PuseJenkinsSnapshots=true'
-      }
-    }
   }
 
   post {

--- a/org.eclipse.xtext.xtext.generator/build.gradle
+++ b/org.eclipse.xtext.xtext.generator/build.gradle
@@ -3,11 +3,36 @@ description = 'Generator for infrastructure of Xtext languages (supersedes org.e
 
 dependencies {
 	compile project(':org.eclipse.xtext')
+	// PIN transitive dependencies versions of org.eclipse.xtext.xtext.generator
+
+	// required by org.eclipse.core.runtime
+	compile 'org.eclipse.platform:org.eclipse.equinox.common'
+	compile 'org.eclipse.platform:org.eclipse.osgi'
+	compile 'org.eclipse.platform:org.eclipse.core.jobs'
+	compile 'org.eclipse.platform:org.eclipse.equinox.registry'
+	compile 'org.eclipse.platform:org.eclipse.equinox.preferences'
+	compile 'org.eclipse.platform:org.eclipse.core.contenttype'
+	compile 'org.eclipse.platform:org.eclipse.equinox.app'
+	// required by org.eclipse.core.resources
+	compile 'org.eclipse.platform:org.eclipse.core.expressions'
+	compile 'org.eclipse.platform:org.eclipse.core.filesystem'
+	// required by org.eclipse.text
+	compile 'org.eclipse.platform:org.eclipse.core.commands'
+	// required by org.eclipse.jdt.core
+	compile 'org.eclipse.platform:org.eclipse.text'
+	// required by org.eclipse.debug.core
+	compile 'org.eclipse.platform:org.eclipse.core.variables'
+	// required by org.eclipse.jdt.launching
+	compile 'org.eclipse.jdt:org.eclipse.jdt.debug'
+	compile 'org.eclipse.platform:org.eclipse.debug.core'
+	// required by org.eclipse.emf.codegen
+	compile 'org.eclipse.platform:org.eclipse.core.runtime'
+	compile 'org.eclipse.platform:org.eclipse.core.resources'
+	compile 'org.eclipse.jdt:org.eclipse.jdt.core'
+	compile 'org.eclipse.jdt:org.eclipse.jdt.launching'
+
 	compile 'org.eclipse.emf:org.eclipse.emf.codegen'
 	compile 'org.eclipse.emf:org.eclipse.emf.codegen.ecore'
 	compile 'org.eclipse.emf:org.eclipse.emf.mwe.utils'
 	compile 'org.eclipse.emf:org.eclipse.emf.mwe2.lib'
-	compile 'org.eclipse.platform:org.eclipse.equinox.common'
-	optional 'org.eclipse.platform:org.eclipse.core.runtime'
-	optional 'org.eclipse.jdt:org.eclipse.jdt.core'
 }

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -12,7 +12,7 @@
 		<tycho-version>1.7.0</tycho-version>
 		<root-dir>${basedir}/..</root-dir>
 		<JENKINS_URL>https://ci.eclipse.org/xtext</JENKINS_URL>
-		<upstreamBranch>master</upstreamBranch>
+		<upstreamBranch>lb_xtext_issue1976</upstreamBranch>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
This pins all transitive dependencies of org.eclipse.xtext.xtext.generator, in particular, the ones with version ranges (EMF, JDT and other platform dependencies) that are taken from org.eclipse.emf:org.eclipse.emf.codegen.

This should fix https://github.com/eclipse/xtext/issues/1976

(see also https://github.com/itemis/xtext-reference-projects/pull/188)

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>