### PR TITLE
filter hidden nodes for value conversion of enums. 

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/ecoreInference/Xtext2EcoreTransformerTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/ecoreInference/Xtext2EcoreTransformerTest.java
@@ -1555,7 +1555,7 @@ public class Xtext2EcoreTransformerTest extends AbstractXtextTests {
 		String grammarAsString = "grammar test with org.eclipse.xtext.common.Terminals\n" +
 				"generate myDsl 'uri'\n" +
 				"Model: element=Element;\n" +
-				"enum Element : ^false='false' | true='true';\n";
+				"enum Element : //das ist ein test\n^false='false' | true='true';\n";
 		XtextResource resource = getResourceFromString(grammarAsString);
 		Grammar g = (Grammar) resource.getContents().get(0);
 		EnumRule enumRule = (EnumRule) g.getRules().get(1);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/xtext/ecoreInference/Xtext2EcoreTransformer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/xtext/ecoreInference/Xtext2EcoreTransformer.java
@@ -343,7 +343,7 @@ public class Xtext2EcoreTransformer {
 						if (nodes.size() > 1)
 							throw new IllegalStateException("Unexpected nodes found: " + nodes);
 						INode node = nodes.get(0);
-						String text = node.getText().trim().replace("^", "");
+						String text = NodeModelUtils.getTokenText(node).replace("^", "");
 						EEnumLiteral literal = null;
 						if (rule.getType().getMetamodel() instanceof ReferencedMetamodel) {
 							literal = returnType.getEEnumLiteral(text);


### PR DESCRIPTION
filter hidden nodes for value conversion of enums. 
Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=574721

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>