### PR TITLE
Improve performance of StateBasedContainer

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/containers/StateBasedContainer.java
@@ -53,16 +53,12 @@ public class StateBasedContainer extends ResourceDescriptionsBasedContainer {
 	@Override
 	protected Iterable<IEObjectDescription> filterByURI(Iterable<IEObjectDescription> unfiltered) {
 		return Iterables.filter(unfiltered, new Predicate<IEObjectDescription>() {
-			private Collection<URI> contents = null;
+			private Collection<URI> contents = getState().getContents();
 
 			@Override
 			public boolean apply(IEObjectDescription input) {
-				if(contents == null) {
-					contents = getState().getContents();
-				}
 				URI resourceURI = input.getEObjectURI().trimFragment();
-				final boolean contains = contents.contains(resourceURI);
-				return contains;
+				return contents.contains(resourceURI);
 			}
 		});
 	}


### PR DESCRIPTION
Improve performance of StateBasedContainer by calling
state.getContents() only once.