### PR TITLE
clear caches on updateInternalState

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/resource/XtextResourceTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/resource/XtextResourceTest.java
@@ -141,4 +141,12 @@ public class XtextResourceTest extends AbstractXtextTests {
 		assertEquals(1, diag.getLength());
 	}
 
+	@Test public void testClearCache() throws Exception {
+		resource.update(0, 0, simpleModel);
+		Object cv1 = resource.getCache().get("justatest", resource, ()->new Object());
+		resource.update(0, 0, "");
+		Object cv2 = resource.getCache().get("justatest", resource, ()->new Object());
+		assertNotSame(cv1, cv2);
+	}
+
 }

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/OnChangeEvictingCache.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/OnChangeEvictingCache.java
@@ -55,7 +55,10 @@ public class OnChangeEvictingCache implements IResourceScopeCache {
 	 */
 	@Override
 	public void clear(Resource resource) {
-		getOrCreate(resource).clearValues();
+		CacheAdapter cacheAdapter = findCacheAdapter(resource);
+		if (cacheAdapter != null) {
+			cacheAdapter.clearValues();
+		}
 	}
 	
 	/**
@@ -108,13 +111,20 @@ public class OnChangeEvictingCache implements IResourceScopeCache {
 	 * @return the cache adapter for the given resource. Never <code>null</code>.
 	 */
 	public CacheAdapter getOrCreate(Resource resource) {
-		CacheAdapter adapter = (CacheAdapter) EcoreUtil.getAdapter(resource.eAdapters(), CacheAdapter.class);
+		CacheAdapter adapter = findCacheAdapter(resource);
 		if (adapter == null) {
 			adapter = createCacheAdapter();
 			resource.eAdapters().add(adapter);
 			adapter.setResource(resource);
 		}
 		return adapter;
+	}
+
+	/**
+	 * @since 2.26
+	 */
+	protected CacheAdapter findCacheAdapter(Resource resource) {
+		return (CacheAdapter) EcoreUtil.getAdapter(resource.eAdapters(), CacheAdapter.class);
 	}
 
 	/**

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/XtextResource.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/XtextResource.java
@@ -43,6 +43,7 @@ import org.eclipse.xtext.serializer.ISerializer;
 import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.util.IResourceScopeCache;
 import org.eclipse.xtext.util.LazyStringInputStream;
+import org.eclipse.xtext.util.OnChangeEvictingCache;
 import org.eclipse.xtext.util.ReplaceRegion;
 import org.eclipse.xtext.util.TextRegion;
 import org.eclipse.xtext.validation.IConcreteSyntaxValidator;
@@ -297,6 +298,7 @@ public class XtextResource extends ResourceImpl {
 		if (newRootASTElement != null && !containsRootElement(newRootASTElement))
 			getContents().add(0, newRootASTElement);
 		reattachModificationTracker(newRootASTElement);
+		clearCache();
 		clearErrorsAndWarnings();
 		addSyntaxErrors();
 		doLinking();
@@ -308,7 +310,17 @@ public class XtextResource extends ResourceImpl {
 	boolean containsRootElement(EObject newRootASTElement) {
 		return getContents().contains(newRootASTElement);
 	}
-	
+
+	/**
+	 * @since 2.26
+	 */
+	protected void clearCache() {
+		IResourceScopeCache cache = getCache();
+		if (cache instanceof OnChangeEvictingCache) {
+			cache.clear(this);
+		}
+	}
+
 	protected void clearErrorsAndWarnings() {
 		getWarnings().clear();
 		getErrors().clear();


### PR DESCRIPTION
clear caches on updateInternalState
Fixes eclipse/xtext-eclipse#1697
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>