### PR TITLE
[eclipse/xtext#1452] add common JavaRuntimeVersion utility to avoid code duplication between modules

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/ManifestMergerTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/ManifestMergerTest.java
@@ -16,9 +16,8 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.util.MergeableManifest;
 import org.eclipse.xtext.util.StringInputStream;
 import org.eclipse.xtext.util.Strings;
@@ -37,25 +36,7 @@ import org.junit.runners.model.Statement;
 @SuppressWarnings("deprecation")
 public class ManifestMergerTest extends Assert {
 	private static final String NL = Strings.newLine();
-	
-	private static final boolean isJava16OrLater = determineJava16OrLater();
-	
-	private static boolean determineJava16OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 16;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
-	
+
 	@Rule
 	public MethodRule ignoreOnJava16OrLater = new MethodRule() {
 
@@ -65,7 +46,7 @@ public class ManifestMergerTest extends Assert {
 
 				@Override
 				public void evaluate() throws Throwable {
-					Assume.assumeFalse("Ignored on Java 16 and later", isJava16OrLater);
+					Assume.assumeFalse("Ignored on Java 16 and later", JavaRuntimeVersion.isJava16OrLater());
 					base.evaluate();
 				}
 			};

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/JavaRuntimeVersionTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/JavaRuntimeVersionTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * @author cdietrich - Initial contribution and API
+ */
+public class JavaRuntimeVersionTest {
+	
+	@Test
+	public void testDetermineJavaVersion() {
+		assertEquals(8, JavaRuntimeVersion.determineJavaVersion("1.8.0_302"));
+		assertEquals(11, JavaRuntimeVersion.determineJavaVersion("11.0.12"));
+		assertEquals(13, JavaRuntimeVersion.determineJavaVersion("13.0.2"));
+		assertEquals(14, JavaRuntimeVersion.determineJavaVersion("14"));
+		assertEquals(15, JavaRuntimeVersion.determineJavaVersion("15.0.2"));
+		assertEquals(16, JavaRuntimeVersion.determineJavaVersion("16.0.2"));
+		assertEquals(17, JavaRuntimeVersion.determineJavaVersion("17-beta"));
+		assertEquals(17, JavaRuntimeVersion.determineJavaVersion("17-ea"));
+	}
+
+}

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaRuntimeVersion.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/JavaRuntimeVersion.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * @author cdietrich - Initial contribution and API
+ * @since 2.26
+ */
+@Beta
+public class JavaRuntimeVersion {
+
+	public static void main(String[] args) {
+		System.out.println(JAVA_VERSION);
+	}
+
+	public static int JAVA_VERSION = determineJavaVersion();
+
+	public static boolean isJava11OrLater() {
+		return JAVA_VERSION >= 11;
+	}
+
+	public static boolean isJava12OrLater() {
+		return JAVA_VERSION >= 13;
+	}
+
+	public static boolean isJava13OrLater() {
+		return JAVA_VERSION >= 13;
+	}
+
+	public static boolean isJava14OrLater() {
+		return JAVA_VERSION >= 14;
+	}
+
+	public static boolean isJava15OrLater() {
+		return JAVA_VERSION >= 15;
+	}
+
+	public static boolean isJava16OrLater() {
+		return JAVA_VERSION >= 16;
+	}
+
+	public static boolean isJava17OrLater() {
+		return JAVA_VERSION >= 17;
+	}
+
+	private static int determineJavaVersion() {
+		String javaVersion = System.getProperty("java.version");
+		if (javaVersion == null) {
+			// fallback
+			return 8;
+		}
+		return determineJavaVersion(javaVersion);
+	}
+
+	static int determineJavaVersion(String javaVersion) {
+		if (javaVersion.startsWith("1.")) {
+			try {
+				Pattern p = Pattern.compile("1\\.(\\d+)(.)*");
+				Matcher matcher = p.matcher(javaVersion);
+				if (matcher.matches()) {
+					String first = matcher.group(1);
+					int version = Integer.parseInt(first);
+					return version;
+				}
+			} catch (NumberFormatException e) {
+				// ok
+			}
+			// fallback
+			return 8;
+		} else {
+			try {
+				Pattern p = Pattern.compile("(\\d+)(.)*");
+				Matcher matcher = p.matcher(javaVersion);
+				if (matcher.matches()) {
+					String first = matcher.group(1);
+					int version = Integer.parseInt(first);
+					return version;
+				}
+			} catch (NumberFormatException e) {
+				// ok
+			}
+			// fallback
+			return 11;
+		}
+	}
+
+}


### PR DESCRIPTION
[eclipse/xtext#1452] add common JavaRuntimeVersion utility to avoid code duplication between modules

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>