### PR TITLE
[eclipse/xtext#1995] switch from adoptopenjdk to termurin and provide java 17 jdk

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
   parameters {
     // see https://wiki.eclipse.org/Jenkins#JDK
     choice(name: 'JDK_VERSION', description: 'Which JDK should be used?', choices: [
-       'adoptopenjdk-hotspot-jdk8-latest', 'adoptopenjdk-hotspot-jdk11-latest', 'adoptopenjdk-hotspot-jdk16-latest'
+       'temurin-jdk8-latest', 'temurin-jdk11-latest', 'temurin-jdk17-latest'
     ])
     booleanParam(
       name: 'TRIGGER_DOWNSTREAM_BUILD', 


### PR DESCRIPTION
[eclipse/xtext#1995] switch from adoptopenjdk to termurin and provide java 17 jdk

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>