### PR TITLE
Make @InjectWith meta-annotation capable (fix #1789)

### DIFF
--- a/org.eclipse.xtext.testing/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testing/META-INF/MANIFEST.MF
@@ -29,7 +29,8 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
 Import-Package: org.apache.log4j;version="1.2.15",
  org.apache.log4j.spi;version="1.2.15",
  org.junit.jupiter.api;version="[5.0.0,6.0.0)";resolution:=optional,
- org.junit.jupiter.api.extension;version="[5.0.0,6.0.0)";resolution:=optional
+ org.junit.jupiter.api.extension;version="[5.0.0,6.0.0)";resolution:=optional,
+ org.junit.platform.commons.support;version="[1.0.0,2.0.0)";resolution:=optional
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.xtext.testing
 Eclipse-SourceReferences: eclipseSourceReferences

--- a/org.eclipse.xtext.testing/tests/org/eclipse/xtext/testing/tests/junit5/ComposedInject.java
+++ b/org.eclipse.xtext.testing/tests/org/eclipse/xtext/testing/tests/junit5/ComposedInject.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.testing.tests.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.eclipse.xtext.testing.IInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+/**
+ * Test for {@link InjectionExtension} meta annotation/composed annotation
+ * compatibility.
+ *
+ * @author Michael Keppler - Initial contribution and API
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE})
+@InjectWith(ComposedInject.MyInjectorProvider.class)
+@ExtendWith(InjectionExtension.class)
+public @interface ComposedInject {
+
+	public static final String INJECTED = "injected";
+
+	public static class MyInjectorProvider implements IInjectorProvider {
+
+		@Override
+		public Injector getInjector() {
+			return Guice.createInjector(binder -> binder.bind(String.class).toInstance(INJECTED));
+		}
+
+	}
+
+}

--- a/org.eclipse.xtext.testing/tests/org/eclipse/xtext/testing/tests/junit5/ComposedInjectAnnotationTest.java
+++ b/org.eclipse.xtext.testing/tests/org/eclipse/xtext/testing/tests/junit5/ComposedInjectAnnotationTest.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.testing.tests.junit5;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.Inject;
+
+/**
+ * Test for {@link InjectionExtension} meta annotation/composed annotation
+ * compatibility. It uses a composed annotation instead of the original
+ * {@code InjectWith} annotation.
+ *
+ * @author Michael Keppler - Initial contribution and API
+ */
+@ComposedInject
+public class ComposedInjectAnnotationTest {
+	@Inject
+	String toBeInjected = "";
+
+	@Test
+	public void didUseComposedInjectAnnotation() {
+		assertEquals(ComposedInject.INJECTED, toBeInjected);
+	}
+
+}


### PR DESCRIPTION
Use the JUnit Platform annotation retrieval to also look at super
interfaces, composed interfaces etc. of the test class.

JUnit Platform 1.y.z corresponds to JUnit Jupiter 5.y.z, that's why the
platform range [1,2) should fit well to the existing Jupiter range [5,6)
in the manifest.

Signed-off-by: Michael Keppler <Michael.Keppler@gmx.de>