### PR TITLE
Fix hidden region formatting priorities (fix #1798)

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/HiddenRegionFormatting.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/HiddenRegionFormatting.java
@@ -107,7 +107,7 @@ public class HiddenRegionFormatting implements IHiddenRegionFormatting {
 
 	@Override
 	public void mergeValuesFrom(IHiddenRegionFormatting other) throws ConflictingFormattingException {
-		int strategy = other.getPriority() - getPriority();
+		int strategy = Integer.compare(other.getPriority(), getPriority());
 		setSpace(merge(getSpace(), other.getSpace(), strategy, "space"));
 		setNewLinesMin(merge(getNewLineMin(), other.getNewLineMin(), strategy, "newLineMin"));
 		setNewLinesDefault(merge(getNewLineDefault(), other.getNewLineDefault(), strategy, "newLineDefault"));
@@ -115,6 +115,7 @@ public class HiddenRegionFormatting implements IHiddenRegionFormatting {
 		setAutowrap(merge(getAutowrap(), other.getAutowrap(), strategy, "autowrap"));
 		setOnAutowrap(merge(getOnAutowrap(), other.getOnAutowrap(), strategy, "onAutowrap"));
 		setNoIndentation(merge(getNoIndentation(), other.getNoIndentation(), strategy, "noIndentation"));
+		setPriority(merge(getPriority(), other.getPriority(), strategy, "priority"));
 
 		if (getIndentationIncrease() != null && other.getIndentationIncrease() != null)
 			setIndentationIncrease(getIndentationIncrease() + other.getIndentationIncrease());

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/HiddenRegionFormattingMerger.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/HiddenRegionFormattingMerger.java
@@ -14,6 +14,8 @@ import org.eclipse.xtext.formatting2.AbstractFormatter2;
 import org.eclipse.xtext.formatting2.IHiddenRegionFormatting;
 import org.eclipse.xtext.formatting2.IMerger;
 
+import com.google.common.collect.Lists;
+
 /**
  * @author Moritz Eysholdt - Initial contribution and API
  */
@@ -28,13 +30,16 @@ public class HiddenRegionFormattingMerger implements IMerger<IHiddenRegionFormat
 
 	@Override
 	public IHiddenRegionFormatting merge(List<? extends IHiddenRegionFormatting> conflicting) {
+		// If there are only 2 conflicts,
+		// usages of this method expect the second value to be updated to the merge result
+		// TODO: Fix those usages so they no longer expect this method to edit its input
 		if (conflicting.size() == 2) {
-			// TODO: don't do this
 			conflicting.get(1).mergeValuesFrom(conflicting.get(0));
 			return conflicting.get(1);
 		}
 		IHiddenRegionFormatting result = formatter.createHiddenRegionFormatting();
-		for (IHiddenRegionFormatting conflict : conflicting)
+		// Reversed so the merging order is consistent with the special case above
+		for (IHiddenRegionFormatting conflict : Lists.reverse(conflicting))
 			result.mergeValuesFrom(conflict);
 		return result;
 	}


### PR DESCRIPTION
mergeValuesFrom in HiddenRegionFormatting now updates the priority
The calculation of strategy can no longer cause overflows

Signed-off-by: Lawrence Goossens <lawrence.goossens@sigasi.com>