### PR TITLE
Make QualifiedName.USE_INTERNING writable (using reflection)

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/naming/QualifiedName.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/naming/QualifiedName.java
@@ -36,7 +36,7 @@ public class QualifiedName implements Comparable<QualifiedName> {
 
 	private QualifiedName lowerCase;
 
-	private static final boolean USE_INTERNING = Boolean.getBoolean("xtext.qn.interning");
+	private static boolean USE_INTERNING = Boolean.getBoolean("xtext.qn.interning");
 
 	/**
 	 * The single existing empty QualifiedName.


### PR DESCRIPTION
Make QualifiedName.USE_INTERNING writable (using reflection)
Fixes #1787

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>