### PR TITLE
[eclipse/xtext#1976] pin explicit transitive deps in xtext.xtext.generator

### DIFF
--- a/org.eclipse.xtext.xtext.generator/build.gradle
+++ b/org.eclipse.xtext.xtext.generator/build.gradle
@@ -8,6 +8,33 @@ dependencies {
 	api 'org.eclipse.emf:org.eclipse.emf.mwe.utils'
 	api 'org.eclipse.emf:org.eclipse.emf.mwe2.lib'
 	api 'org.eclipse.platform:org.eclipse.equinox.common'
-	optional 'org.eclipse.platform:org.eclipse.core.runtime'
-	optional 'org.eclipse.jdt:org.eclipse.jdt.core'
+	api 'org.eclipse.platform:org.eclipse.core.runtime'
+
+	// PIN transitive dependencies versions of org.eclipse.xtext.xtext.generator
+
+	// required by org.eclipse.core.runtime
+	api 'org.eclipse.platform:org.eclipse.equinox.common'
+	api 'org.eclipse.platform:org.eclipse.osgi'
+	api 'org.eclipse.platform:org.eclipse.core.jobs'
+	api 'org.eclipse.platform:org.eclipse.equinox.registry'
+	api 'org.eclipse.platform:org.eclipse.equinox.preferences'
+	api 'org.eclipse.platform:org.eclipse.core.contenttype'
+	api 'org.eclipse.platform:org.eclipse.equinox.app'
+	// required by org.eclipse.core.resources
+	api 'org.eclipse.platform:org.eclipse.core.expressions'
+	api 'org.eclipse.platform:org.eclipse.core.filesystem'
+	// required by org.eclipse.text
+	api 'org.eclipse.platform:org.eclipse.core.commands'
+	// required by org.eclipse.jdt.core
+	api 'org.eclipse.platform:org.eclipse.text'
+	// required by org.eclipse.debug.core
+	api 'org.eclipse.platform:org.eclipse.core.variables'
+	// required by org.eclipse.jdt.launching
+	api 'org.eclipse.jdt:org.eclipse.jdt.debug'
+	api 'org.eclipse.platform:org.eclipse.debug.core'
+	// required by org.eclipse.emf.codegen
+	api 'org.eclipse.platform:org.eclipse.core.runtime'
+	api 'org.eclipse.platform:org.eclipse.core.resources'
+	api 'org.eclipse.jdt:org.eclipse.jdt.core'
+	api 'org.eclipse.jdt:org.eclipse.jdt.launching'
 }


### PR DESCRIPTION
[eclipse/xtext#1976] pin explicit transitive deps in xtext.xtext.generator

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>