### PR TITLE
Expose serialization methods on AbstractNode

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/AbstractNode.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/AbstractNode.java
@@ -360,13 +360,13 @@ public abstract class AbstractNode implements INode, BidiTreeIterable<INode> {
 		return prev != this;
 	}
 
-	enum NodeType {
+	protected enum NodeType {
 		CompositeNode, LeafNode, CompositeNodeWithSemanticElement, CompositeNodeWithSyntaxError, CompositeNodeWithSemanticElementAndSyntaxError, RootNode, HiddenLeafNode, HiddenLeafNodeWithSyntaxError, LeafNodeWithSyntaxError
 	}
 
-	abstract NodeType getNodeId();
+	protected abstract NodeType getNodeId();
 	
-	void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
+	protected void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
 		int length = SerializationUtil.readInt(in, true);
 
 		if (length > 0) {
@@ -390,7 +390,7 @@ public abstract class AbstractNode implements INode, BidiTreeIterable<INode> {
 		}
 	}
 
-	void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
+	protected void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
 		if (grammarElementOrArray instanceof EObject) {
 			EObject eObject = (EObject) grammarElementOrArray;
 			SerializationUtil.writeInt(out, 1, true);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/CompositeNode.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/CompositeNode.java
@@ -175,7 +175,7 @@ public class CompositeNode extends AbstractNode implements ICompositeNode {
 	private static final NodeType[] NODE_TYPE_VALUES = NodeType.values();
 	
 	@Override 
-	void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
+	protected void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
 		super.readData(in, context);
 
 		int childNodeCount = SerializationUtil.readInt(in, true);
@@ -244,7 +244,7 @@ public class CompositeNode extends AbstractNode implements ICompositeNode {
 	}
 	
 	@Override
-	void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
+	protected void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
 		super.write(out, scc);
 
 		int childNodeCount = getChildCount();
@@ -295,7 +295,7 @@ public class CompositeNode extends AbstractNode implements ICompositeNode {
 	}
 
 	@Override
-	NodeType getNodeId() {
+	protected NodeType getNodeId() {
 		return NodeType.CompositeNode;
 	}
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/CompositeNodeWithSemanticElement.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/CompositeNodeWithSemanticElement.java
@@ -70,7 +70,7 @@ public class CompositeNodeWithSemanticElement extends CompositeNode implements A
 	}
 
 	@Override
-	void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
+	protected void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
 		super.readData(in, context);
 
 		boolean isNull = in.readBoolean();
@@ -84,7 +84,7 @@ public class CompositeNodeWithSemanticElement extends CompositeNode implements A
 	}
 
 	@Override
-	void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
+	protected void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
 		super.write(out, scc);
 
 		boolean isNull = semanticElement == null;
@@ -98,7 +98,7 @@ public class CompositeNodeWithSemanticElement extends CompositeNode implements A
 	}
 
 	@Override
-	NodeType getNodeId() {
+	protected NodeType getNodeId() {
 		return NodeType.CompositeNodeWithSemanticElement;
 	}
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/CompositeNodeWithSemanticElementAndSyntaxError.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/CompositeNodeWithSemanticElementAndSyntaxError.java
@@ -36,20 +36,20 @@ public class CompositeNodeWithSemanticElementAndSyntaxError extends CompositeNod
 	}
 
 	@Override
-	void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
+	protected void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
 		super.readData(in, context);
 		syntaxErrorMessage = SerializationUtil.readSyntaxErrorMessage(in, context);
 		context.setHasErrors(true); 
 	}
 
 	@Override
-	void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
+	protected void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
 		super.write(out, scc);
 		SerializationUtil.writeSyntaxErrorMessage(out, scc, syntaxErrorMessage);
 	}
 
 	@Override
-	NodeType getNodeId() {
+	protected NodeType getNodeId() {
 		return NodeType.CompositeNodeWithSemanticElementAndSyntaxError; 
 	}
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/CompositeNodeWithSyntaxError.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/CompositeNodeWithSyntaxError.java
@@ -37,7 +37,7 @@ public class CompositeNodeWithSyntaxError extends CompositeNode {
 	}
 
 	@Override
-	void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
+	protected void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
 		super.readData(in, context);
 		
 		syntaxErrorMessage = SerializationUtil.readSyntaxErrorMessage(in, context); 
@@ -45,14 +45,14 @@ public class CompositeNodeWithSyntaxError extends CompositeNode {
 	}
 	
 	@Override
-	void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
+	protected void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
 		super.write(out, scc);
 
 		SerializationUtil.writeSyntaxErrorMessage(out, scc, syntaxErrorMessage); 
 	}
 	
 	@Override
-	NodeType getNodeId() {
+	protected NodeType getNodeId() {
 		return NodeType.CompositeNodeWithSyntaxError;
 	}
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/HiddenLeafNode.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/HiddenLeafNode.java
@@ -21,7 +21,7 @@ public class HiddenLeafNode extends LeafNode {
 	}
 	
 	@Override
-	NodeType getNodeId() {
+	protected NodeType getNodeId() {
 		return NodeType.HiddenLeafNode; 
 	}
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/HiddenLeafNodeWithSyntaxError.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/HiddenLeafNodeWithSyntaxError.java
@@ -36,7 +36,7 @@ public class HiddenLeafNodeWithSyntaxError extends HiddenLeafNode {
 	}
 
 	@Override
-	void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
+	protected void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
 		super.readData(in, context);
 		
 		syntaxErrorMessage = SerializationUtil.readSyntaxErrorMessage(in, context); 
@@ -44,14 +44,14 @@ public class HiddenLeafNodeWithSyntaxError extends HiddenLeafNode {
 	}
 
 	@Override
-	void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
+	protected void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
 		super.write(out, scc);
 
 		SerializationUtil.writeSyntaxErrorMessage(out, scc, syntaxErrorMessage); 
 	}
 	
 	@Override
-	NodeType getNodeId() {
+	protected NodeType getNodeId() {
 		return NodeType.HiddenLeafNodeWithSyntaxError;  
 	}
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/LeafNode.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/LeafNode.java
@@ -68,21 +68,21 @@ public class LeafNode extends AbstractNode implements ILeafNode {
 	}
 
 	@Override 
-	void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
+	protected void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
 		super.readData(in, context);
 		
 		totalLength = SerializationUtil.readInt(in, true);   
 	}
 	
 	@Override
-	void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
+	protected void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
 		super.write(out, scc);
 		
 		SerializationUtil.writeInt (out, totalLength, true); 
 	}
 
 	@Override
-	NodeType getNodeId() {
+	protected NodeType getNodeId() {
 		return NodeType.LeafNode;
 	}
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/LeafNodeWithSyntaxError.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/LeafNodeWithSyntaxError.java
@@ -36,20 +36,20 @@ public class LeafNodeWithSyntaxError extends LeafNode {
 	}
 
 	@Override
-	void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
+	protected void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
 		super.readData(in, context);
 		syntaxErrorMessage = SerializationUtil.readSyntaxErrorMessage(in, context);
 		context.setHasErrors(true);
 	}
 
 	@Override
-	void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
+	protected void write(DataOutputStream out, SerializationConversionContext scc) throws IOException {
 		super.write(out, scc);
 		SerializationUtil.writeSyntaxErrorMessage(out, scc, syntaxErrorMessage);
 	}
 	
 	@Override
-	NodeType getNodeId() {
+	protected NodeType getNodeId() {
 		return NodeType.LeafNodeWithSyntaxError;
 	}
 }

--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/RootNode.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/RootNode.java
@@ -153,7 +153,7 @@ public class RootNode extends CompositeNodeWithSemanticElementAndSyntaxError {
 	}
 	
 	@Override
-	void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
+	protected void readData(DataInputStream in, DeserializationConversionContext context) throws IOException {
 		super.readData(in, context);
 
 		basicSetCompleteContent(context.getCompleteContent());
@@ -196,7 +196,7 @@ public class RootNode extends CompositeNodeWithSemanticElementAndSyntaxError {
 	}
 
 	@Override
-	NodeType getNodeId() {
+	protected NodeType getNodeId() {
 		return NodeType.RootNode;
 	}
 


### PR DESCRIPTION
Signed-off-by: Mark Sujew <mark.sujew@typefox.io>

In one of our projects, we override the `NodeModelBuilder` to create custom leaf nodes (which don't inherit from the default `LeafNode` class). However, since the `NodeType` enum, and the `write`/`readData` methods were package private, we were not able to override them, even though the serializer needs them to be overriden.

This change just changes them to be accessible by downstream classes which directly inherit `AbstractNode`.