### PR TITLE
Always write binary models

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/build/IncrementalBuilder.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/build/IncrementalBuilder.java
@@ -311,10 +311,6 @@ public class IncrementalBuilder {
 		 */
 		protected void generate(Resource resource, BuildRequest request, Source2GeneratedMapping newMappings) {
 			IResourceServiceProvider serviceProvider = getResourceServiceProvider(resource);
-			GeneratorDelegate generator = serviceProvider.get(GeneratorDelegate.class);
-			if (generator == null) {
-				return;
-			}
 			Set<URI> previous = newMappings.deleteSource(resource.getURI());
 			URIBasedFileSystemAccess fileSystemAccess = createFileSystemAccess(serviceProvider, resource);
 			fileSystemAccess.setBeforeWrite((uri, outputCfgName, contents) -> {
@@ -338,6 +334,7 @@ public class IncrementalBuilder {
 			}
 			GeneratorContext generatorContext = new GeneratorContext();
 			generatorContext.setCancelIndicator(request.getCancelIndicator());
+			GeneratorDelegate generator = serviceProvider.get(GeneratorDelegate.class);
 			generator.generate(resource, fileSystemAccess, generatorContext);
 			XtextResourceSet resourceSet = request.getResourceSet();
 			for (URI noLongerCreated : previous) {


### PR DESCRIPTION
Write binary models even if no GeneratorDelegate is provided. The binary models can be used when demand-loading resources during the incremental build, regardless of if there is a GeneratorDelegate, thus, persist them at the beginnig of the generate method.