### PR TITLE
Replace and transfer look ahead with offset

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/NodeModelBuilder.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/NodeModelBuilder.java
@@ -273,16 +273,17 @@ public class NodeModelBuilder {
 		}
 	}
 	
-	public void replaceAndTransferLookAhead(INode oldNode, INode newRootNode) {
+	private AbstractNode doReplaceAndTransferLookAhead(INode oldNode, INode newRootNode) {
 		AbstractNode newNode = ((CompositeNode) newRootNode).basicGetFirstChild();
 		replaceWithoutChildren((AbstractNode) oldNode, newNode);
 		if (oldNode instanceof ICompositeNode && newNode instanceof CompositeNode) {
 			CompositeNode newCompositeNode = (CompositeNode) newNode;
 			newCompositeNode.basicSetLookAhead(((ICompositeNode) oldNode).getLookAhead());
 		}
-		ICompositeNode root = newNode.getRootNode();
-		BidiTreeIterator<AbstractNode> iterator = ((AbstractNode) root).basicIterator();
-		int offset = 0;
+		return newNode;
+	}
+
+	private void setLeafNodesTotalOffset(int offset, BidiTreeIterator<AbstractNode> iterator) {
 		while(iterator.hasNext()) {
 			AbstractNode node = iterator.next();
 			if (node instanceof LeafNode) {
@@ -290,6 +291,20 @@ public class NodeModelBuilder {
 				offset += node.getTotalLength();
 			}
 		}
+	}
+
+	public void replaceAndTransferLookAhead(INode oldNode, INode newRootNode) {
+		AbstractNode newNode = doReplaceAndTransferLookAhead(oldNode, newRootNode);
+		ICompositeNode root = newNode.getRootNode();
+		setLeafNodesTotalOffset(0, ((AbstractNode) root).basicIterator());
+	}
+
+	/**
+	 * @since 2.26
+	 */
+	 public void replaceAndTransferLookAheadKeepingOffset(INode oldNode, INode newRootNode) {
+		AbstractNode newNode = doReplaceAndTransferLookAhead(oldNode, newRootNode);
+		setLeafNodesTotalOffset(oldNode.getTotalOffset(), newNode.basicIterator());
 	}
 
 	protected void replaceWithoutChildren(AbstractNode oldNode, AbstractNode newNode) {


### PR DESCRIPTION
NodeModelBuilder when adjusting offsets performs it for the whole node
model starting from the root. This is necessary for partial reparse as
the offsets of the following nodes could change.

For parser delegation, that a node corresponding to a terminal rule is
is replaced by new root node (where the node corresponding to the
terminal has been parsed by a different language inside a value
converter), doing the full adjustments leads to a big overhead with
large number of delegations, since the initial offset is know, the
replacement is done directly in the node which needs reparsing and does
not start from the root.

For this use case, we create a new method which keeps the offset of the
old node and iterates over just the tree under from the new node.