### PR TITLE
[eclipse/xtext#1854] Move AssertableDiagnostics to xtext.testing.

### DIFF
--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/validation/AssertableDiagnostics.java
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/validation/AssertableDiagnostics.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Iterables;
 
 /**
  * @author Moritz Eysholdt - Initial contribution and API
+ * @since 2.26
  * 
  */
 public class AssertableDiagnostics {

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/validation/AssertableDiagnostics.java
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/validation/AssertableDiagnostics.java
@@ -6,7 +6,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package org.eclipse.xtext.validation;
+package org.eclipse.xtext.testing.validation;
 
 import static org.eclipse.emf.common.util.Diagnostic.*;
 
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map.Entry;
 
 import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.xtext.validation.AbstractValidationDiagnostic;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/AbstractConcreteSyntaxValidationTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/AbstractConcreteSyntaxValidationTest.java
@@ -14,8 +14,9 @@ import org.eclipse.emf.common.util.BasicDiagnostic;
 import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.xtext.testing.validation.AssertableDiagnostics;
+import org.eclipse.xtext.testing.validation.AssertableDiagnostics.DiagnosticPredicate;
 import org.eclipse.xtext.tests.AbstractXtextTests;
-import org.eclipse.xtext.validation.AssertableDiagnostics.DiagnosticPredicate;
 import org.eclipse.xtext.validation.IConcreteSyntaxValidator.DiagnosticChainAcceptor;
 import org.eclipse.xtext.validation.impl.ConcreteSyntaxDiagnosticProvider.ConcreteSyntaxFeatureDiagnostic;
 

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/AbstractValidatorTester.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/AbstractValidatorTester.java
@@ -14,6 +14,7 @@ import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.Diagnostician;
+import org.eclipse.xtext.testing.validation.AssertableDiagnostics;
 
 /**
  * @author Moritz Eysholdt - Initial contribution and API

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/ConcreteSyntaxValidationTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/ConcreteSyntaxValidationTest.java
@@ -8,7 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.validation;
 
-import static org.eclipse.xtext.validation.AssertableDiagnostics.*;
+import static org.eclipse.xtext.testing.validation.AssertableDiagnostics.*;
 import static org.eclipse.xtext.validation.IConcreteSyntaxDiagnosticProvider.*;
 
 import java.util.List;

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/DiagnosticTreeIterableTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/DiagnosticTreeIterableTest.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 
 import org.eclipse.emf.common.util.BasicDiagnostic;
 import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.xtext.testing.validation.AssertableDiagnostics;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/ValidatorTester.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/ValidatorTester.java
@@ -14,6 +14,7 @@ import org.eclipse.emf.ecore.EValidator;
 import org.eclipse.emf.ecore.impl.EValidatorRegistryImpl;
 import org.eclipse.emf.ecore.util.Diagnostician;
 import org.eclipse.xtext.Constants;
+import org.eclipse.xtext.testing.validation.AssertableDiagnostics;
 import org.eclipse.xtext.validation.AbstractDeclarativeValidator.State;
 
 import com.google.inject.Inject;

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/ValidatorTesterTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/ValidatorTesterTest.java
@@ -8,7 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.validation;
 
-import static org.eclipse.xtext.validation.AssertableDiagnostics.*;
+import static org.eclipse.xtext.testing.validation.AssertableDiagnostics.*;
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
[eclipse/xtext#1854] Move AssertableDiagnostics to xtext.testing
Signed-off-by: Edmundo Lopez Bobeda <edmundo@lopezbobeda.net>