### PR TITLE
Add API for textual Code Actions

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/editor/quickfix/AbstractIdeQuickfixTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/editor/quickfix/AbstractIdeQuickfixTest.java
@@ -200,14 +200,14 @@ public abstract class AbstractIdeQuickfixTest {
 
 		options.setCodeActionParams(codeActionParams);
 
-		List<DiagnosticResolution> actualIssueResolutions = IterableExtensions.sortBy(quickFixProvider.getResolutions(options, issue),
-				DiagnosticResolution::getLabel);
-		assertEquals("The number of quickfixes does not match!", expectedSorted.size(),
-				actualIssueResolutions.size());
+		for (QuickfixExpectation expectedIssueResolution: expectedSorted) {
+			List<DiagnosticResolution> actualIssueResolutions = 
+					quickFixProvider.getResolutions(options, issue).stream()
+					.filter(r -> r.getLabel().equals(expectedIssueResolution.getLabel()))
+					.collect(Collectors.toList());
+			assertEquals("More than one quickfix available!", 1, actualIssueResolutions.size());
 
-		for (int i = 0; i < actualIssueResolutions.size(); i++) {
-			DiagnosticResolution actualIssueResolution = actualIssueResolutions.get(i);
-			QuickfixExpectation expectedIssueResolution = expectedSorted.get(i);
+			DiagnosticResolution actualIssueResolution = actualIssueResolutions.get(0);
 
 			assertEquals(expectedIssueResolution.label, actualIssueResolution.getLabel());
 			assertEquals(expectedIssueResolution.description, actualIssueResolution.getLabel());

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/editor/quickfix/TestLanguageQuickfixTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/editor/quickfix/TestLanguageQuickfixTest.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.ide.tests.editor.quickfix;
 
 import org.eclipse.xtext.ide.tests.testlanguage.TestLanguageIdeInjectorProvider;
+import org.eclipse.xtext.ide.tests.testlanguage.ide.quickfix.TestLanguageQuickFixProvider;
 import org.eclipse.xtext.ide.tests.testlanguage.testLanguage.TestLanguagePackage;
 import org.eclipse.xtext.ide.tests.testlanguage.validation.TestLanguageValidator;
 import org.eclipse.xtext.testing.InjectWith;
@@ -24,21 +25,39 @@ import org.junit.runner.RunWith;
 public class TestLanguageQuickfixTest extends AbstractIdeQuickfixTest {
 
 	@Test
-	public void issueProducesTextualChange() {
+	public void issueProducesEMFChange() {
 
 		String actual = "package testLanguage {"
 				+ "\n"
 				+ "\n"
 				+ "type myType {"
-				+ "\n" +
-				"}\n"
+				+ "\n"
+				+ "}\n"
 				+ "}";
 
 		// quickfix replaces first char to Upper
 		// see: org.eclipse.xtext.ide.tests.testlanguage.ide.quickfix.TestLanguageQuickFixProvider.fixLowerCaseName(DiagnosticResolutionAcceptor)
 		String expected = actual.toString().replace("myType", "MyType");
 
-		assertQuickFixOn(actual, expected, "Change element name to first upper", TestLanguageValidator.INVALID_NAME, TestLanguagePackage.Literals.TYPE_DECLARATION);
+		assertQuickFixOn(actual, expected, TestLanguageQuickFixProvider.EMF_QF_LABEL, TestLanguageValidator.INVALID_NAME, TestLanguagePackage.Literals.TYPE_DECLARATION);
+	}
+
+	@Test
+	public void issueProducesTextualChange() {
+
+		String actual = "package testLanguage {"
+				+ "\n"
+				+ "\n"
+				+ "type myType {"
+				+ "\n"
+				+ "}\n"
+				+ "}";
+
+		// quickfix replaces first char to Upper
+		// see: org.eclipse.xtext.ide.tests.testlanguage.ide.quickfix.TestLanguageQuickFixProvider.textFixLowerCaseName(DiagnosticResolutionAcceptor)
+		String expected = actual.toString().replace("myType", "MyType");
+
+		assertQuickFixOn(actual, expected, TestLanguageQuickFixProvider.TEXT_QF_LABEL, TestLanguageValidator.INVALID_NAME, TestLanguagePackage.Literals.TYPE_DECLARATION);
 	}
 
 }

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/CodeActionTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/CodeActionTest.java
@@ -24,12 +24,20 @@ public class CodeActionTest extends AbstractTestLangLanguageServerTest {
 			it.setModel(model);
 			// contains quickfix and edit command
 			String expectedCodeActions =
-					"title : Change element name to first upper\n" +
+					"title : Change element name to first upper using object modification\n" +
 					"kind : quickfix\n" +
 					"command : \n" +
 					"codes : invalidName\n" +
 					"edit : changes :\n" +
 					"    MyModel.testlang : Foo [[0, 5] .. [0, 8]]\n" +
+					"documentChanges : \n" +
+					"title : Change element name to first upper using text replacement\n" +
+					"kind : quickfix\n" +
+					"command : \n" +
+					"codes : invalidName\n" +
+					"edit : changes :\n" +
+					"    MyModel.testlang : type Foo {\n" +
+					"    } [[0, 5] .. [0, 8]]\n" +
 					"documentChanges : \n" +
 					"command : my.textedit.command\n" +
 					"title : Make \'foo\' upper case (Command)\n" +

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/quickfix/TestLanguageQuickFixProvider.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/quickfix/TestLanguageQuickFixProvider.java
@@ -8,6 +8,9 @@
  *******************************************************************************/
 package org.eclipse.xtext.ide.tests.testlanguage.ide.quickfix;
 
+import java.util.Collections;
+
+import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.xtext.ide.editor.quickfix.AbstractDeclarativeIdeQuickfixProvider;
 import org.eclipse.xtext.ide.editor.quickfix.DiagnosticResolutionAcceptor;
 import org.eclipse.xtext.ide.editor.quickfix.QuickFix;
@@ -17,12 +20,26 @@ import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 public class TestLanguageQuickFixProvider extends AbstractDeclarativeIdeQuickfixProvider {
 
-	@QuickFix(TestLanguageValidator.INVALID_NAME)
-	public void fixLowerCaseName(DiagnosticResolutionAcceptor acceptor) {
-		acceptor.accept("Change element name to first upper", obj -> {
-			final TypeDeclaration element = (TypeDeclaration) obj;
-			element.setName(StringExtensions.toFirstUpper(element.getName()));
-		});
+	public static String EMF_QF_LABEL = "Change element name to first upper using object modification";
+	public static String TEXT_QF_LABEL = "Change element name to first upper using text replacement";
+
+	private String fixedName(TypeDeclaration declaration) {
+		return StringExtensions.toFirstUpper(declaration.getName());
 	}
 
+	@QuickFix(TestLanguageValidator.INVALID_NAME)
+	public void fixLowerCaseName(DiagnosticResolutionAcceptor acceptor) {
+		acceptor.accept(EMF_QF_LABEL, obj -> {
+			TypeDeclaration declaration = (TypeDeclaration) obj;
+			declaration.setName(fixedName(declaration));
+		});
+	}
+	
+	@QuickFix(TestLanguageValidator.INVALID_NAME)
+	public void textFixLowerCaseName(DiagnosticResolutionAcceptor acceptor) {
+		acceptor.accept(TEXT_QF_LABEL,  (diagnostic, obj, document) -> {
+			TextEdit textEdit = new TextEdit(diagnostic.getRange(), "type " + fixedName((TypeDeclaration) obj) + " {\n}");
+			return Collections.singletonList(textEdit);
+		});
+	}
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/AbstractDeclarativeIdeQuickfixProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/AbstractDeclarativeIdeQuickfixProvider.java
@@ -68,19 +68,19 @@ public class AbstractDeclarativeIdeQuickfixProvider implements IQuickFixProvider
 				.collect(Collectors.toList());
 	}
 
-	private Iterable<Method> getFixMethods(Diagnostic issue) {
-		if (Strings.isNullOrEmpty(issue.getCode().getLeft())) {
+	private Iterable<Method> getFixMethods(Diagnostic diagnostic) {
+		if (Strings.isNullOrEmpty(diagnostic.getCode().getLeft())) {
 			return Collections.emptyList();
 		}
-		return collectMethods(getClass(), issue.getCode().getLeft());
+		return collectMethods(getClass(), diagnostic.getCode().getLeft());
 	}
 
 	@Override
-	public List<DiagnosticResolution> getResolutions(Options options, Diagnostic issue) {
-		if (issue == null || issue.getCode() == null || issue.getMessage() == null || issue.getSeverity() == null) {
+	public List<DiagnosticResolution> getResolutions(Options options, Diagnostic diagnostic) {
+		if (diagnostic == null || diagnostic.getCode() == null || diagnostic.getMessage() == null || diagnostic.getSeverity() == null) {
 			return Collections.emptyList();
 		}
-		return getResolutions(options, getFixMethods(issue));
+		return getResolutions(options, getFixMethods(diagnostic));
 	}
 
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/DiagnosticResolution.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/DiagnosticResolution.java
@@ -3,7 +3,7 @@
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package org.eclipse.xtext.ide.editor.quickfix;
@@ -13,15 +13,20 @@ import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.xtext.ide.editor.quickfix.DiagnosticModificationContext.Factory;
 import org.eclipse.xtext.ide.serializer.IChangeSerializer;
 import org.eclipse.xtext.ide.serializer.IChangeSerializer.IModification;
+import org.eclipse.xtext.ide.server.Document;
 import org.eclipse.xtext.ide.server.ILanguageServerAccess;
+import org.eclipse.xtext.ide.server.TextEditAcceptor;
 import org.eclipse.xtext.ide.server.codeActions.ICodeActionService2.Options;
 import org.eclipse.xtext.ide.server.rename.ChangeConverter2;
 import org.eclipse.xtext.resource.EObjectAtOffsetHelper;
 import org.eclipse.xtext.resource.XtextResource;
+
+import com.google.common.collect.MoreCollectors;
 
 /**
  * @author Heinrich Weichert
@@ -34,11 +39,31 @@ public class DiagnosticResolution {
 
 	private IModification<EObject> modification;
 
+	private final ITextModification textModification;
+
 	private Factory factory;
 
 	private int relevance;
 
 	private Options options;
+
+	/**
+	 * @since 2.27
+	 */
+	public DiagnosticResolution(String label, Factory modificationContextFactory, ITextModification textModification) {
+		this(label, modificationContextFactory, textModification, 0);
+	}
+
+	/**
+	 * @since 2.27
+	 */
+	public DiagnosticResolution(String label, Factory modificationContextFactory, ITextModification textModification, int relevance) {
+		this.label = label;
+		this.factory = modificationContextFactory;
+		this.modification = null;
+		this.textModification = textModification;
+		this.relevance = relevance;
+	}
 
 	public DiagnosticResolution(String label, Factory modificationContextFactory, IModification<EObject> modification) {
 		this(label, modificationContextFactory, modification, 0);
@@ -49,6 +74,7 @@ public class DiagnosticResolution {
 		this.label = label;
 		this.factory = modificationContext;
 		this.modification = modification;
+		this.textModification = null;
 		this.relevance = relevance;
 	}
 
@@ -61,28 +87,31 @@ public class DiagnosticResolution {
 	}
 
 	public WorkspaceEdit apply() {
-		DiagnosticModificationContext modificationContext = factory.createModificationContext();
 		try {
 			XtextResource resource = options.getResource();
 			URI uri = resource.getURI();
-			ILanguageServerAccess access = options.getLanguageServerAccess();
-
-			WorkspaceEdit edit = new WorkspaceEdit();
-			ChangeConverter2 changeConverter = modificationContext.getConverterFactory().create(edit, access);
-
-			ResourceSet resourceSet = access.newLiveScopeResourceSet(uri);
-			XtextResource tmpResource = (XtextResource) resourceSet.getResource(uri, true);
 
 			CodeActionParams params = options.getCodeActionParams();
-
-			int offset = options.getDocument().getOffSet(params.getRange().getStart());
+			Document document = options.getDocument();
+			int offset = document.getOffSet(params.getRange().getStart());
 			EObjectAtOffsetHelper helper = new EObjectAtOffsetHelper();
+			ILanguageServerAccess access = options.getLanguageServerAccess();
+			ResourceSet resourceSet = access.newLiveScopeResourceSet(uri);
+			XtextResource tmpResource = (XtextResource) resourceSet.getResource(uri, true);
 			EObject obj = helper.resolveContainedElementAt(tmpResource, offset);
 
-			IChangeSerializer serializer = modificationContext.getSerializer();
-			serializer.addModification(obj, modification);
-			serializer.applyModifications(changeConverter);
-
+			WorkspaceEdit edit = new WorkspaceEdit();
+			if (modification != null) {
+				DiagnosticModificationContext modificationContext = factory.createModificationContext();
+				ChangeConverter2 changeConverter = modificationContext.getConverterFactory().create(edit, access);
+				IChangeSerializer serializer = modificationContext.getSerializer();
+				serializer.addModification(obj, modification);
+				serializer.applyModifications(changeConverter);
+			} else {
+				TextEditAcceptor textEditAcceptor = new TextEditAcceptor(edit, access);
+				Diagnostic diagnostic = params.getContext().getDiagnostics().stream().collect(MoreCollectors.onlyElement());
+				textEditAcceptor.accept(uri.toString(), document, textModification.apply(diagnostic, obj, document));
+			}
 			return edit;
 		} catch (Exception exc) {
 			throw new WrappedException(exc);

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/DiagnosticResolutionAcceptor.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/DiagnosticResolutionAcceptor.java
@@ -3,7 +3,7 @@
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package org.eclipse.xtext.ide.editor.quickfix;
@@ -21,11 +21,11 @@ import com.google.inject.Inject;
  * @author Heinrich Weichert
  *
  * @since 2.24
- * 
+ *
  */
 public class DiagnosticResolutionAcceptor {
 
-	private List<DiagnosticResolution> issues = new ArrayList<>();
+	private List<DiagnosticResolution> resolutions = new ArrayList<>();
 
 	private DiagnosticModificationContext.Factory modificationContextFactory;
 
@@ -35,12 +35,16 @@ public class DiagnosticResolutionAcceptor {
 	}
 
 	public void accept(String label, IModification<EObject> modification) {
-		issues.add(new DiagnosticResolution(label, modificationContextFactory, modification));
+		resolutions.add(new DiagnosticResolution(label, modificationContextFactory, modification));
+	}
+
+	public void accept(String label, ITextModification modification) {
+		resolutions.add(new DiagnosticResolution(label, modificationContextFactory, modification));
 	}
 
 	public List<DiagnosticResolution> getDiagnosticResolutions(Options options) {
-		issues.forEach(issue -> issue.configure(options));
-		return issues;
+		resolutions.forEach(resolution -> resolution.configure(options));
+		return resolutions;
 	}
 
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/IQuickFixProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/IQuickFixProvider.java
@@ -33,10 +33,10 @@ public interface IQuickFixProvider {
 	 *
 	 * @param options
 	 *            Contextual action options
-	 * @param issue
-	 *            EMF diagnostic issue
+	 * @param diagnostic
+	 *            the diagnostic
 	 * @return 0..n resolutions for the given issue
 	 */
-	List<DiagnosticResolution> getResolutions(Options options, Diagnostic issue);
+	List<DiagnosticResolution> getResolutions(Options options, Diagnostic diagnostic);
 
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/ITextModification.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/ITextModification.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ide.editor.quickfix;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.xtext.ide.server.Document;
+
+/**
+ * @author Rubén Porras Campo - Initial contribution and API
+ *
+ * @since 2.27
+ */
+@FunctionalInterface
+public interface ITextModification {
+	/**
+	 *
+	 * Returns a list of {@link TextEdit}s given a diagnostic, object and document.
+	 *
+	 * @param diagnostic
+	 *            the {@link Diagnostic}
+	 * @param object
+	 *            the {@link EObject} after {@code diagnostic.getRange().getStart()}
+	 * @param document
+	 *            the {@link Document} with the URI given in the diagnostic
+	 *
+	 * @return 0..n {@link TextEdit}
+	 */
+	List<TextEdit> apply(Diagnostic diagnostic, EObject object, Document document);
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/TextEditAcceptor.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/TextEditAcceptor.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2022 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ide.server;
+
+/**
+ * @author Rubén Porras Campo - Initial contribution and API, factored out of ChangeConverter2
+ *
+ * @since 2.27
+ */
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.WorkspaceEditCapabilities;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+public class TextEditAcceptor {
+	private final boolean useDocumentChanges;
+	private final WorkspaceEdit edit;
+
+	public TextEditAcceptor(WorkspaceEdit edit, ILanguageServerAccess access) {
+		this.edit = edit;
+
+		Boolean documentChanges = null;
+		if (access != null) {
+			InitializeParams initializeParams = access.getInitializeParams();
+			if (initializeParams != null) {
+				ClientCapabilities clientCapabilities = initializeParams.getCapabilities();
+				if (clientCapabilities != null) {
+					WorkspaceClientCapabilities workspaceClientCapabilities = clientCapabilities.getWorkspace();
+					if (workspaceClientCapabilities != null) {
+						WorkspaceEditCapabilities workspaceEditCapabilities = workspaceClientCapabilities.getWorkspaceEdit();
+						if (workspaceEditCapabilities != null) {
+							documentChanges = workspaceEditCapabilities.getDocumentChanges();
+						}
+					}
+				}
+			}
+		}
+		this.useDocumentChanges = documentChanges == Boolean.TRUE;
+		if (this.useDocumentChanges) {
+			this.edit.setDocumentChanges(new ArrayList<>());
+		} else {
+			this.edit.setChanges(new LinkedHashMap<>());
+		}
+	}
+
+	public void accept(String theUri, Document document, List<TextEdit> textEdits) {
+		if (useDocumentChanges) {
+			TextDocumentEdit textDocumentEdit = new TextDocumentEdit();
+			VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier();
+			versionedTextDocumentIdentifier.setUri(theUri);
+			versionedTextDocumentIdentifier.setVersion(document.getVersion());
+			textDocumentEdit.setTextDocument(versionedTextDocumentIdentifier);
+			textDocumentEdit.setEdits(textEdits);
+			edit.getDocumentChanges().add(Either.forLeft(textDocumentEdit));
+		} else {
+			edit.getChanges().put(theUri, textEdits);
+		}
+	}
+}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/ChangeConverter2.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/ChangeConverter2.java
@@ -3,7 +3,7 @@
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.xtext.ide.server.rename;
@@ -11,30 +11,22 @@ package org.eclipse.xtext.ide.server.rename;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.xmi.XMLResource;
-import org.eclipse.lsp4j.ClientCapabilities;
-import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
-import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceEdit;
-import org.eclipse.lsp4j.WorkspaceEditCapabilities;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtext.formatting2.regionaccess.ITextReplacement;
 import org.eclipse.xtext.ide.serializer.IEmfResourceChange;
 import org.eclipse.xtext.ide.serializer.ITextDocumentChange;
 import org.eclipse.xtext.ide.server.Document;
 import org.eclipse.xtext.ide.server.ILanguageServerAccess;
+import org.eclipse.xtext.ide.server.TextEditAcceptor;
 import org.eclipse.xtext.ide.server.UriExtensions;
 import org.eclipse.xtext.parser.IEncodingProvider;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
@@ -68,41 +60,16 @@ public class ChangeConverter2 implements IAcceptor<IEmfResourceChange> {
 
 	private UriExtensions uriExtensions;
 
-	private WorkspaceEdit edit;
-
 	private ILanguageServerAccess access;
 
-	private boolean useDocumentChanges;
+	private TextEditAcceptor textEditAcceptor;
 
 	protected ChangeConverter2(IResourceServiceProvider.Registry registry, WorkspaceEdit edit,
 			ILanguageServerAccess access, UriExtensions uriExtensions) {
 		this.registry = registry;
 		this.uriExtensions = uriExtensions;
-		this.edit = edit;
 		this.access = access;
-		Boolean documentChanges = null;
-		if (access != null) {
-			InitializeParams initializeParams = access.getInitializeParams();
-			if (initializeParams != null) {
-				ClientCapabilities clientCapabilities = initializeParams.getCapabilities();
-				if (clientCapabilities != null) {
-					WorkspaceClientCapabilities workspaceClientCapabilities = clientCapabilities.getWorkspace();
-					if (workspaceClientCapabilities != null) {
-						WorkspaceEditCapabilities workspaceEditCapabilities = workspaceClientCapabilities
-								.getWorkspaceEdit();
-						if (workspaceEditCapabilities != null) {
-							documentChanges = workspaceEditCapabilities.getDocumentChanges();
-						}
-					}
-				}
-			}
-		}
-		this.useDocumentChanges = documentChanges == Boolean.TRUE;
-		if (this.useDocumentChanges) {
-			this.edit.setDocumentChanges(new ArrayList<>());
-		} else {
-			this.edit.setChanges(new LinkedHashMap<>());
-		}
+		this.textEditAcceptor = new TextEditAcceptor(edit, access);
 	}
 
 	@Override
@@ -120,7 +87,8 @@ public class ChangeConverter2 implements IAcceptor<IEmfResourceChange> {
 				Document document = context.getDocument();
 				Range range = new Range(document.getPosition(0), document.getPosition(document.getContents().length()));
 				TextEdit textEdit = new TextEdit(range, newContent);
-				return addTextEdit(uri, document, textEdit);
+				addTextEdit(uri, document, textEdit);
+				return null;
 			}).get();
 		} catch (InterruptedException | ExecutionException | IOException e) {
 			throw Exceptions.sneakyThrow(e);
@@ -154,7 +122,8 @@ public class ChangeConverter2 implements IAcceptor<IEmfResourceChange> {
 								Range range = new Range(start, end);
 								return new TextEdit(range, replacement.getReplacementText());
 							});
-					return addTextEdit(uri, document, textEdits.toArray(new TextEdit[textEdits.size()]));
+					addTextEdit(uri, document, textEdits.toArray(new TextEdit[textEdits.size()]));
+					return null;
 				}).get();
 			}
 		} catch (InterruptedException | ExecutionException e) {
@@ -162,18 +131,8 @@ public class ChangeConverter2 implements IAcceptor<IEmfResourceChange> {
 		}
 	}
 
-	protected Object addTextEdit(String theUri, Document document, TextEdit... textEdits) {
-		if (useDocumentChanges) {
-			TextDocumentEdit textDocumentEdit = new TextDocumentEdit();
-			VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier();
-			versionedTextDocumentIdentifier.setUri(theUri);
-			versionedTextDocumentIdentifier.setVersion(document.getVersion());
-			textDocumentEdit.setTextDocument(versionedTextDocumentIdentifier);
-			textDocumentEdit.setEdits(Arrays.asList(textEdits));
-			return edit.getDocumentChanges().add(Either.forLeft(textDocumentEdit));
-		} else {
-			return edit.getChanges().put(theUri, Arrays.asList(textEdits));
-		}
+	protected void addTextEdit(String theUri, Document document, TextEdit... textEdits) {
+		textEditAcceptor.accept(theUri, document, Arrays.asList(textEdits));
 	}
 
 	protected void handleReplacements(IEmfResourceChange change) {


### PR DESCRIPTION
In addition, improve naming of variables in the existing API to use
diagnostics for org.eclipse.lsp4j.Diagnostic instead of issues and
errors, and resolutions for DiagnosticResolution instead of issues in
the DiagnosticResolutionAcceptor