### PR TITLE
Fix typo in class name DocumentSymbolConfiguration

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/DocumentSymbolTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/DocumentSymbolTest.java
@@ -8,7 +8,7 @@
  */
 package org.eclipse.xtext.ide.tests.server;
 
-import org.eclipse.xtext.testing.DocumentSymbolConfiguraiton;
+import org.eclipse.xtext.testing.DocumentSymbolConfiguration;
 import org.junit.Test;
 
 /**
@@ -17,7 +17,7 @@ import org.junit.Test;
 public class DocumentSymbolTest extends AbstractTestLangLanguageServerTest {
 	@Test
 	public void testDocumentSymbol_01() {
-		testDocumentSymbol((DocumentSymbolConfiguraiton it) -> {
+		testDocumentSymbol((DocumentSymbolConfiguration it) -> {
 			String model =
 					"type Foo {\n" +
 					"	int bar\n" +

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/HierarchicalDocumentSymbolTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/HierarchicalDocumentSymbolTest.java
@@ -12,7 +12,7 @@ import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.DocumentSymbolCapabilities;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
-import org.eclipse.xtext.testing.DocumentSymbolConfiguraiton;
+import org.eclipse.xtext.testing.DocumentSymbolConfiguration;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Test;
 
@@ -29,7 +29,7 @@ public class HierarchicalDocumentSymbolTest extends AbstractTestLangLanguageServ
 
 	@Test
 	public void testDocumentSymbol_01() {
-		testDocumentSymbol((DocumentSymbolConfiguraiton it) -> {
+		testDocumentSymbol((DocumentSymbolConfiguration it) -> {
 			it.setInitializer(HierarchicalDocumentSymbolTest.INITIALIZER);
 			String model =
 					"type Foo {\n" +

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
@@ -613,20 +613,20 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		assertEquals(expectedDocumentHighlight, actualDocumentHighlight);
 	}
 
-	protected def void testDocumentSymbol((DocumentSymbolConfiguraiton)=>void configurator) {
-		val extension configuration = new DocumentSymbolConfiguraiton
+	protected def void testDocumentSymbol((DocumentSymbolConfiguration)=>void configurator) {
+		val extension configuration = new DocumentSymbolConfiguration
 		configuration.filePath = 'MyModel.' + fileExtension
 		configurator.apply(configuration)
 
 		val fileUri = initializeContext(configuration).uri
 		val symbolsFuture = languageServer.documentSymbol(new DocumentSymbolParams(new TextDocumentIdentifier(fileUri)))
 		val symbols = symbolsFuture.get
-		if (configuration.assertSymbols !== null) {
-			configuration.assertSymbols.apply(symbols)
+		if (configuration.getAssertSymbols !== null) {
+			configuration.getAssertSymbols.apply(symbols)
 		} else {
 			val unwrappedSymbols = symbols.map[if(hierarchicalDocumentSymbolSupport) getRight else getLeft]
 			val String actualSymbols = unwrappedSymbols.toExpectation
-			assertEquals(expectedSymbols, actualSymbols)
+			assertEquals(getExpectedSymbols, actualSymbols)
 		}
 	}
 

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/DocumentSymbolConfiguration.java
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/DocumentSymbolConfiguration.java
@@ -15,7 +15,7 @@ import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
-public class DocumentSymbolConfiguraiton extends TextDocumentConfiguration {
+public class DocumentSymbolConfiguration extends TextDocumentConfiguration {
 	private String expectedSymbols = "";
 
 	private Procedure1<? super List<Either<SymbolInformation, DocumentSymbol>>> assertSymbols = null;

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
@@ -1254,10 +1254,10 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
     }
   }
 
-  protected void testDocumentSymbol(final Procedure1<? super DocumentSymbolConfiguraiton> configurator) {
+  protected void testDocumentSymbol(final Procedure1<? super DocumentSymbolConfiguration> configurator) {
     try {
       @Extension
-      final DocumentSymbolConfiguraiton configuration = new DocumentSymbolConfiguraiton();
+      final DocumentSymbolConfiguration configuration = new DocumentSymbolConfiguration();
       configuration.setFilePath(("MyModel." + this.fileExtension));
       configurator.apply(configuration);
       final String fileUri = this.initializeContext(configuration).getUri();


### PR DESCRIPTION
Signed-off-by: Rubén Porras Campo <pcr@avaloq.com>