### PR TITLE
added missing org.eclipse.xtext.testlanguages.ide/.settings/org.eclipse.core.resources.prefs

### DIFF
--- a/org.eclipse.xtext.testlanguages.ide/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.xtext.testlanguages.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=ISO-8859-1


### PR DESCRIPTION
added missing org.eclipse.xtext.testlanguages.ide/.settings/org.eclipse.core.resources.prefs