### PR TITLE
Extend the Quickfix API to support semantic QFs that use the data

### DIFF
--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/quickfix/TestLanguageQuickFixProvider.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/quickfix/TestLanguageQuickFixProvider.java
@@ -8,9 +8,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.ide.tests.testlanguage.ide.quickfix;
 
-import java.util.Collections;
-
-import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.xtext.ide.editor.quickfix.AbstractDeclarativeIdeQuickfixProvider;
 import org.eclipse.xtext.ide.editor.quickfix.DiagnosticResolutionAcceptor;
 import org.eclipse.xtext.ide.editor.quickfix.QuickFix;
@@ -37,9 +34,8 @@ public class TestLanguageQuickFixProvider extends AbstractDeclarativeIdeQuickfix
 	
 	@QuickFix(TestLanguageValidator.INVALID_NAME)
 	public void textFixLowerCaseName(DiagnosticResolutionAcceptor acceptor) {
-		acceptor.accept(TEXT_QF_LABEL,  (diagnostic, obj, document) -> {
-			TextEdit textEdit = new TextEdit(diagnostic.getRange(), "type " + fixedName((TypeDeclaration) obj) + " {\n}");
-			return Collections.singletonList(textEdit);
-		});
+		acceptor.accept(TEXT_QF_LABEL,  (diagnostic, obj, document) -> 
+			createTextEdit(diagnostic, "type " + fixedName((TypeDeclaration) obj) + " {\n}")
+		);
 	}
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/AbstractDeclarativeIdeQuickfixProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/AbstractDeclarativeIdeQuickfixProvider.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.xtext.ide.server.codeActions.ICodeActionService2.Options;
 
 import com.google.common.annotations.Beta;
@@ -83,4 +84,18 @@ public class AbstractDeclarativeIdeQuickfixProvider implements IQuickFixProvider
 		return getResolutions(options, getFixMethods(diagnostic));
 	}
 
+	/**
+	 * Creates a singleton list with only one {@link TextEdit} that replaces the region of the diagnostic with the given
+	 * text
+	 * 
+	 * @param diagnostic
+	 *            the {@link Diagnostic}
+	 * @param text
+	 *            the text
+	 * @return a singleton list with only one {@link TextEdit}
+	 * @since 2.27
+	 */
+	protected List<TextEdit> createTextEdit(Diagnostic diagnostic, String text) {
+		return Collections.singletonList(new TextEdit(diagnostic.getRange(), text));
+	}
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/DiagnosticResolutionAcceptor.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/DiagnosticResolutionAcceptor.java
@@ -35,9 +35,19 @@ public class DiagnosticResolutionAcceptor {
 	}
 
 	public void accept(String label, IModification<EObject> modification) {
+		resolutions.add(new DiagnosticResolution(label, modificationContextFactory, (diagnostic, object) -> modification));
+	}
+
+	/**
+	 * @since 2.27
+	 */
+	public void accept(String label, ISemanticModification modification) {
 		resolutions.add(new DiagnosticResolution(label, modificationContextFactory, modification));
 	}
 
+	/**
+	 * @since 2.27
+	 */
 	public void accept(String label, ITextModification modification) {
 		resolutions.add(new DiagnosticResolution(label, modificationContextFactory, modification));
 	}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/ISemanticModification.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/ISemanticModification.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2022 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ide.editor.quickfix;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.xtext.ide.serializer.IChangeSerializer.IModification;
+
+/**
+ * @author Rubén Porras Campo - Initial contribution and API
+ *
+ * @since 2.27
+ */
+@FunctionalInterface
+public interface ISemanticModification {
+	/**
+	 *
+	 * Returns an {@link IModification} given a diagnostic and an object.
+	 *
+	 * @param diagnostic
+	 *            the {@link Diagnostic}
+	 * @param object
+	 *            the {@link EObject} after {@code diagnostic.getRange().getStart()}
+	 *
+	 * @return the {@link IModification}
+	 */
+	IModification<EObject> apply(Diagnostic diagnostic, EObject object);
+}


### PR DESCRIPTION
contained in the diagnostic.

Also, add one convenience method to create textual QFs which just
replace the region of the diagnostic with a new text.

Signed-off-by: Rubén Porras Campo <Ruben.PorrasCampo@avaloq.com>