### PR TITLE
Only return resolved cross references

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/DefinitionTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/DefinitionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2020 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2016, 2022 TypeFox GmbH (http://www.typefox.io) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -13,6 +13,9 @@ import org.junit.Test;
 
 /**
  * @author kosyakov - Initial contribution and API
+ * 
+ * Contributors: 
+ *   Rubén Porras Campo (Avaloq Evolution AG) - Add test for definitions on elements without identifiers.
  */
 public class DefinitionTest extends AbstractTestLangLanguageServerTest {
 	@Test
@@ -27,6 +30,51 @@ public class DefinitionTest extends AbstractTestLangLanguageServerTest {
 			cfg.setLine(2);
 			cfg.setColumn(3);
 			cfg.setExpectedDefinitions("MyModel.testlang [[0, 5] .. [0, 8]]\n");
+		});
+	}
+
+	@Test
+	public void testDefinition_02() {
+		testDefinition((DefinitionTestConfiguration cfg) -> {
+			String model = 
+					"type Foo {}\n" +
+					"type Bar {\n" +
+					"	Foo foo\n" +
+					"}";
+			cfg.setModel(model);
+			cfg.setLine(0);
+			cfg.setColumn(5);
+			cfg.setExpectedDefinitions("MyModel.testlang [[0, 5] .. [0, 8]]\n");
+		});
+	}
+
+	@Test
+	public void testDefinition_03() {
+		testDefinition((DefinitionTestConfiguration cfg) -> {
+			String model = 
+					"type Foo {} // One comment\n" +
+					"type Bar {\n" +
+					"	Foo foo\n" +
+					"}";
+			cfg.setModel(model);
+			cfg.setLine(0);
+			cfg.setColumn(15);
+			cfg.setExpectedDefinitions("");
+		});
+	}
+
+	@Test
+	public void testDefinition_04() {
+		testDefinition((DefinitionTestConfiguration cfg) -> {
+			String model = 
+					"type Foo {} // One comment\n" +
+					"type Bar {\n" +
+					"	Foo foo\n" +
+					"}";
+			cfg.setModel(model);
+			cfg.setLine(0);
+			cfg.setColumn(0);
+			cfg.setExpectedDefinitions("");
 		});
 	}
 }

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/rename/TestLanguageRenameService.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/rename/TestLanguageRenameService.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.ide.tests.testlanguage.rename;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.Keyword;
 import org.eclipse.xtext.ide.server.rename.RenameService2;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.naming.QualifiedName;
@@ -35,8 +36,8 @@ public class TestLanguageRenameService extends RenameService2 {
 					ICompositeNode rootNode = parseResult.getRootNode();
 					if (rootNode != null) {
 						ILeafNode leaf = NodeModelUtils.findLeafNodeAtOffset(rootNode, offset);
-						if (leaf != null && isIdentifier(leaf)) {
-							EObject element = eObjectAtOffsetHelper.resolveElementAt(xtextResource, offset);
+						if (leaf != null) {
+							EObject element = eObjectAtOffsetHelper.getElementWithNameAt(xtextResource, offset);
 							if (element != null) {
 								IQualifiedNameProvider nameProvider = xtextResource.getResourceServiceProvider()
 										.get(IQualifiedNameProvider.class);

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/DocumentSymbolService.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/DocumentSymbolService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2020 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2016, 2022 TypeFox GmbH (http://www.typefox.io) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -25,6 +25,9 @@ import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.xtext.CrossReference;
+import org.eclipse.xtext.Keyword;
+import org.eclipse.xtext.RuleCall;
 import org.eclipse.xtext.findReferences.IReferenceFinder;
 import org.eclipse.xtext.findReferences.ReferenceAcceptor;
 import org.eclipse.xtext.findReferences.TargetURICollector;
@@ -56,6 +59,10 @@ import com.google.inject.Singleton;
 
 /**
  * @author kosyakov - Initial contribution and API
+ *
+ * Contributors: 
+ *   Rubén Porras Campo (Avaloq Evolution AG) - Do not return definitions for elements without identifiers.
+ *
  * @since 2.11
  */
 @Singleton
@@ -101,10 +108,11 @@ public class DocumentSymbolService implements IDocumentSymbolService {
 
 	public List<? extends Location> getDefinitions(XtextResource resource, int offset,
 			IReferenceFinder.IResourceAccess resourceAccess, CancelIndicator cancelIndicator) {
-		EObject element = eObjectAtOffsetHelper.resolveElementAt(resource, offset);
+		EObject element = eObjectAtOffsetHelper.getElementWithNameAt(resource, offset);
 		if (element == null) {
 			return Collections.emptyList();
 		}
+		
 		List<Location> locations = new ArrayList<>();
 		TargetURIs targetURIs = collectTargetURIs(element);
 		for (URI targetURI : targetURIs) {


### PR DESCRIPTION
Otherwise the client will think some elements point to definitions which do not exist, and will for example jump to the beginnig of a comment or string when the user press Control-Click somewhere in one of these, which is very confusing.