### PR TITLE
Improve code actions performance by loading the document on demand

### DIFF
--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/server/CodeActionService.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/server/CodeActionService.java
@@ -46,17 +46,20 @@ public class CodeActionService extends QuickFixCodeActionService {
 	private IChangeSerializer serializer;
 
 	@Override
-	public List<Either<Command, CodeAction>> getCodeActions(ICodeActionService2.Options options) {
-		List<Either<Command, CodeAction>> actions = super.getCodeActions(options);
-		for (Diagnostic d : options.getCodeActionParams().getContext().getDiagnostics()) {
-			Object code = d.getCode().get();
-			if (TestLanguageValidator.INVALID_NAME.equals(code)) {
-				actions.add(Either.forLeft(fixInvalidName(d, options)));
-			} else if (TestLanguageValidator.UNSORTED_MEMBERS.equals(code)) {
-				actions.add(Either.forRight(fixUnsortedMembers(d, options)));
-			}
+	protected List<Either<Command, CodeAction>> getCodeActions(Options options, Diagnostic diagnostic) {
+		Object code = diagnostic.getCode().get();
+		List<Either<Command, CodeAction>> codeActions = super.getCodeActions(options, diagnostic);
+		if (TestLanguageValidator.INVALID_NAME.equals(code)) {
+			codeActions.add(Either.forLeft(fixInvalidName(diagnostic, options)));
+		} else if (TestLanguageValidator.UNSORTED_MEMBERS.equals(code)) {
+			codeActions.add(Either.forRight(fixUnsortedMembers(diagnostic, options)));
 		}
-		return actions;
+		return codeActions;
+	}
+
+	@Override
+	protected boolean handlesDiagnostic(Diagnostic diagnostic) {
+		return true;
 	}
 
 	private Command fixInvalidName(Diagnostic d, ICodeActionService2.Options options) {

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/DiagnosticResolution.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/DiagnosticResolution.java
@@ -11,6 +11,7 @@ package org.eclipse.xtext.ide.editor.quickfix;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Diagnostic;
@@ -104,7 +105,7 @@ public class DiagnosticResolution {
 
 	public WorkspaceEdit apply() {
 		try {
-			XtextResource resource = options.getResource();
+			Resource resource = options.getResource();
 			URI uri = resource.getURI();
 
 			CodeActionParams params = options.getCodeActionParams();

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/IQuickFixProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/quickfix/IQuickFixProvider.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2020 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2020, 2022 TypeFox GmbH (http://www.typefox.io) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package org.eclipse.xtext.ide.editor.quickfix;
@@ -21,8 +21,11 @@ import com.google.common.annotations.Beta;
  * The textual edit can be composed by calling DiagnosticResolution#apply().
  *
  * @author Heinrich Weichert
- * 
+ *
  * @since 2.24
+ * 
+ * Contributors: 
+ *   Rubén Porras Campo (Avaloq Evolution AG) - Add method to get fix methods.
  */
 @Beta
 public interface IQuickFixProvider {
@@ -39,4 +42,18 @@ public interface IQuickFixProvider {
 	 */
 	List<DiagnosticResolution> getResolutions(Options options, Diagnostic diagnostic);
 
+	
+	/**
+	 *
+	 * If the provider handles (it has code to produce resolutions for) the given diagnostic.
+	 *
+	 * @param diagnostic
+	 *            the diagnostic
+	 * @return true if the provider handles the given diagnostic
+	 * 
+	 * @since 2.28
+	 */
+	default boolean handlesDiagnostic(Diagnostic diagnostic) {
+		return true;
+	}
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ILanguageServerAccess.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ILanguageServerAccess.java
@@ -112,6 +112,13 @@ public interface ILanguageServerAccess {
 	<T extends Object> CompletableFuture<T> doRead(String uri, Function<ILanguageServerAccess.Context, T> function);
 
 	/**
+	 * Provides access to a {@link WorkspaceManager}.
+	 * 
+	 * @since 2.28
+	 */
+	<T extends Object> T doSyncRead(String uri, Function<ILanguageServerAccess.Context, T> function);
+
+	/**
 	 * Provides read access to the Xtext index.
 	 * 
 	 * @since 2.18

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/WorkspaceManager.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/WorkspaceManager.java
@@ -38,6 +38,8 @@ import org.eclipse.xtext.resource.impl.ChunkedResourceDescriptions;
 import org.eclipse.xtext.resource.impl.ProjectDescription;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsData;
 import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.util.Pair;
+import org.eclipse.xtext.util.Tuples;
 import org.eclipse.xtext.validation.Issue;
 import org.eclipse.xtext.workspace.IProjectConfig;
 import org.eclipse.xtext.workspace.IWorkspaceConfig;
@@ -448,16 +450,29 @@ public class WorkspaceManager {
 	 * Find the resource and the document with the given URI and performa a read operation.
 	 */
 	public <T> T doRead(URI uri, Function2<? super Document, ? super XtextResource, ? extends T> work) {
-		URI resourceURI = uri.trimFragment();
-		ProjectManager projectMnr = getProjectManager(resourceURI);
-		if (projectMnr != null) {
-			XtextResource resource = (XtextResource) projectMnr.getResource(resourceURI);
-			Document doc = getDocument(resource);
+		Pair<? super Document, ? super XtextResource> pair = read(uri);
+		if (pair != null) {
+			Document doc = (Document) pair.getFirst();
+			XtextResource resource = (XtextResource) pair.getSecond();
 			return work.apply(doc, resource);
 		}
 		return work.apply(null, null);
 	}
 
+	/**
+	 * Find the resource and the document with the given URI.
+	 */
+	public Pair<? super Document, ? super XtextResource> read(URI uri) {
+		URI resourceURI = uri.trimFragment();
+		ProjectManager projectMnr = getProjectManager(resourceURI);
+		if (projectMnr != null) {
+			XtextResource resource = (XtextResource) projectMnr.getResource(resourceURI);
+			Document doc = getDocument(resource);
+			return Tuples.pair(doc, resource);
+		}
+		return null;
+	}
+	
 	/**
 	 * Find the document for the given resource.
 	 *

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/codeActions/ICodeActionService2.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/codeActions/ICodeActionService2.java
@@ -1,33 +1,39 @@
 /**
- * Copyright (c) 2017, 2020 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2017, 2022 TypeFox GmbH (http://www.typefox.io) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.xtext.ide.server.codeActions;
 
 import java.util.List;
 
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtext.ide.server.Document;
 import org.eclipse.xtext.ide.server.ILanguageServerAccess;
-import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.util.CancelIndicator;
 
 /**
  * @author Jan Koehnlein
+ * 
  * @since 2.18
+ * 
+ * Contributors: 
+ *   Rubén Porras Campo (Avaloq Evolution AG) - Add method to get fix methods.
  */
 public interface ICodeActionService2 {
 	class Options {
 		private Document document;
 
-		private XtextResource resource;
+		private Resource resource;
+		
+		private String uri;
 
 		private ILanguageServerAccess languageServerAccess;
 
@@ -43,11 +49,11 @@ public interface ICodeActionService2 {
 			this.document = document;
 		}
 
-		public XtextResource getResource() {
+		public Resource getResource() {
 			return resource;
 		}
 
-		public void setResource(XtextResource resource) {
+		public void setResource(Resource resource) {
 			this.resource = resource;
 		}
 
@@ -73,6 +79,20 @@ public interface ICodeActionService2 {
 
 		public void setCancelIndicator(CancelIndicator cancelIndicator) {
 			this.cancelIndicator = cancelIndicator;
+		}
+
+		/**
+		 * @since 2.28
+		 */
+		public String getURI() {
+			return uri;
+		}
+
+		/**
+		 * @since 2.28
+		 */
+		public void setURI(String uri) {
+			this.uri = uri;
 		}
 	}
 


### PR DESCRIPTION
only if there are fix methods for the given diagnostic. This might saves
the resource load operation, which can be expensive.