### PR TITLE
[eclipse/xtext-eclipse#1874] remove no longer needed lifecycle mapping for tycho 2.7.4+

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJ11/mavenTychoJ11.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJ11/mavenTychoJ11.parent/pom.xml
@@ -175,67 +175,6 @@
 										<ignore></ignore>
 									</action>
 								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
-											org.eclipse.tycho
-										</groupId>
-										<artifactId>
-											tycho-compiler-plugin
-										</artifactId>
-										<versionRange>
-											[0.23.1,)
-										</versionRange>
-										<goals>
-											<goal>compile</goal>
-											<goal>testCompile</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
-											org.eclipse.tycho
-										</groupId>
-										<artifactId>
-											tycho-packaging-plugin
-										</artifactId>
-										<versionRange>
-											[0.23.1,)
-										</versionRange>
-										<goals>
-											<goal>build-qualifier</goal>
-											<goal>build-qualifier-aggregator</goal>
-											<goal>validate-id</goal>
-											<goal>validate-version</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
-											org.eclipse.tycho
-										</groupId>
-										<artifactId>
-											target-platform-configuration
-										</artifactId>
-										<versionRange>
-											[2.4.0,)
-										</versionRange>
-										<goals>
-											<goal>target-platform</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
 							</pluginExecutions>
 						</lifecycleMappingMetadata>
 					</configuration>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
@@ -435,7 +435,7 @@ class ParentProjectDescriptor extends ProjectDescriptor {
 													<ignore></ignore>
 												</action>
 											</pluginExecution>
-											«IF config.needsTychoBuild»
+											«IF config.needsTychoBuild && !config.javaVersion.isAtLeast(JavaVersion.JAVA11)»
 												<pluginExecution>
 													<pluginExecutionFilter>
 														<groupId>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
@@ -1397,8 +1397,7 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append("</pluginExecution>");
       _builder.newLine();
       {
-        boolean _needsTychoBuild_4 = this.getConfig().needsTychoBuild();
-        if (_needsTychoBuild_4) {
+        if ((this.getConfig().needsTychoBuild() && (!this.getConfig().getJavaVersion().isAtLeast(JavaVersion.JAVA11)))) {
           _builder.append("\t\t\t\t\t\t\t");
           _builder.append("<pluginExecution>");
           _builder.newLine();
@@ -1652,8 +1651,8 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append("</plugin>");
       _builder.newLine();
       {
-        boolean _needsTychoBuild_5 = this.getConfig().needsTychoBuild();
-        if (_needsTychoBuild_5) {
+        boolean _needsTychoBuild_4 = this.getConfig().needsTychoBuild();
+        if (_needsTychoBuild_4) {
           _builder.append("\t\t\t");
           _builder.append("<plugin>");
           _builder.newLine();
@@ -1807,8 +1806,8 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append("</repository>");
       _builder.newLine();
       {
-        boolean _needsTychoBuild_6 = this.getConfig().needsTychoBuild();
-        if (_needsTychoBuild_6) {
+        boolean _needsTychoBuild_5 = this.getConfig().needsTychoBuild();
+        if (_needsTychoBuild_5) {
           _builder.append("\t");
           _builder.append("<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent ");
           _builder.newLine();
@@ -1990,8 +1989,8 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append("</pluginRepository>");
       _builder.newLine();
       {
-        boolean _needsTychoBuild_7 = this.getConfig().needsTychoBuild();
-        if (_needsTychoBuild_7) {
+        boolean _needsTychoBuild_6 = this.getConfig().needsTychoBuild();
+        if (_needsTychoBuild_6) {
           _builder.append("\t");
           _builder.append("<pluginRepository>");
           _builder.newLine();


### PR DESCRIPTION
[eclipse/xtext#2492] remove no longer needed lifecycle mapping for tycho 2.7.4+