### PR TITLE
[eclipse/xtext#2099] added missing org.eclipse.jdt.core.prefs

### DIFF
--- a/org.eclipse.xtext.ide.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.ide.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.source=1.8


### PR DESCRIPTION
[eclipse/xtext#2099] added missing org.eclipse.jdt.core.prefs