### PR TITLE
Build of persisted state to run in parallel with work on dirty state.

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/DirtyDocumentTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/DirtyDocumentTest.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Avaloq Group AG (http://www.avaloq.com).
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ide.tests.server;
+
+import org.eclipse.lsp4j.Position;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.Iterables;
+
+/**
+ * @author Andrew Lamb - Initial contribution and API
+ * @since 2.29
+ */
+public class DirtyDocumentTest extends AbstractTestLangLanguageServerTest {
+	@Test
+	public void testClose() {
+		String testSource = 
+				"type Test {\n" +
+						"    NonExisting foo\n" +
+						"    Test bar\n" +
+				"}\n";
+		String testFile = writeFile("MyType1.testlang",
+				testSource);
+		initialize();
+		assertEquals("Couldn't resolve reference to TypeDeclaration 'NonExisting'.",
+				Iterables.getFirst(getDiagnostics().get(testFile), null).getMessage());
+		open(testFile, testSource);
+		edit(testFile, 2, new Position(1, 4), new Position(1, 15), "Test");
+		edit(testFile, 3, new Position(2, 4), new Position(2, 8), "Foo");
+		assertEquals("Couldn't resolve reference to TypeDeclaration 'Foo'.",
+				Iterables.getFirst(getDiagnostics().get(testFile), null).getMessage());
+		
+		// diagnostics revert after a dirty source is closed without saving.
+		close(testFile);
+		assertEquals("Couldn't resolve reference to TypeDeclaration 'NonExisting'.",
+				Iterables.getFirst(getDiagnostics().get(testFile), null).getMessage());
+	}
+
+	@Test
+	public void testReferenceInPersistedDocument() {
+		String testSource = 
+				"type Test {\n" +
+						"    Foo foo\n" +
+				"}\n";
+		String testFile = writeFile("MyType1.testlang",
+				testSource);
+		String fooBarSource = "type Foo {}\n";
+		String fooBarFile = writeFile("MyType2.testlang", fooBarSource);
+		initialize();
+		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(testFile), null));
+		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(fooBarFile), null));
+		open(fooBarFile, fooBarSource);
+		
+		// break reference in persisted source - diagnostic doesn't appear until after save.
+		edit(fooBarFile, 2, new Position(0, 5), new Position(0, 8), "Bar");
+		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(testFile), null));
+		save(fooBarFile);
+		assertEquals("Couldn't resolve reference to TypeDeclaration 'Foo'.",
+				Iterables.getFirst(getDiagnostics().get(testFile), null).getMessage());
+		
+		// fix reference in persisted source - diagnostic doesn't disappear until after save.
+		edit(fooBarFile, 3, new Position(0, 5), new Position(0, 8), "Foo");
+		assertEquals("Couldn't resolve reference to TypeDeclaration 'Foo'.",
+				Iterables.getFirst(getDiagnostics().get(testFile), null).getMessage());
+		save(fooBarFile);
+		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(testFile), null));
+	}
+
+	@Test
+	public void testReferenceInDirtyDocument() {
+		String testSource = 
+				"type Test {\n" +
+						"    Foo foo\n" +
+				"}\n";
+		String testFile = writeFile("MyType1.testlang",
+				testSource);
+		String fooBarSource = "type Foo {}\n";
+		String fooBarFile = writeFile("MyType2.testlang", fooBarSource);
+		initialize();
+		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(testFile), null));
+		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(fooBarFile), null));
+		open(testFile, testSource);
+		open(fooBarFile, fooBarSource);
+		
+		// create new type and refer to it from other source - no diagnostic for dirty source.
+		edit(fooBarFile, 2, new Position(0, 5), new Position(0, 8), "Bar");
+		edit(testFile, 2, new Position(1, 4), new Position(1, 7), "Bar");
+		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(testFile), null));
+		
+		// save the reference only - diagnostic because the new type is not persisted yet.
+		save(testFile);
+		assertEquals("Couldn't resolve reference to TypeDeclaration 'Bar'.",
+				Iterables.getFirst(getDiagnostics().get(testFile), null).getMessage());
+		
+		// save the new type - diagnostic disappears.
+		save(fooBarFile);
+		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(testFile), null));
+	}
+
+	@Test
+	public void testReferenceToPersistedDocument() {
+		String testSource = 
+				"type Test {\n" +
+						"    Foo foo\n" +
+				"}\n";
+		String testFile = writeFile("MyType1.testlang",
+				testSource);
+		String fooBarSource = "type Foo {}\n";
+		String fooBarFile = writeFile("MyType2.testlang", fooBarSource);
+		initialize();
+		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(testFile), null));
+		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(fooBarFile), null));
+		open(testFile, testSource);
+		open(fooBarFile, fooBarSource);
+		
+		// create new type and refer to it from other source - no diagnostic for dirty source.
+		edit(fooBarFile, 2, new Position(0, 5), new Position(0, 8), "Bar");
+		edit(testFile, 2, new Position(1, 4), new Position(1, 7), "Bar");
+		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(testFile), null));
+		
+		// save the new type only - no diagnostic for dirty source even though persisted version now refers to a non-existent type.
+		save(fooBarFile);
+		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(testFile), null));
+		
+		// close the dirty source without saving - diagnostic appears.
+		close(testFile);
+		assertEquals("Couldn't resolve reference to TypeDeclaration 'Foo'.",
+				Iterables.getFirst(getDiagnostics().get(testFile), null).getMessage());
+	}
+}

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/IndexOnlyProjectTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/IndexOnlyProjectTest.java
@@ -17,7 +17,6 @@ import org.eclipse.lsp4j.FileEvent;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.xtext.ide.server.IMultiRootWorkspaceConfigFactory;
 import org.eclipse.xtext.ide.server.MultiRootWorkspaceConfigFactory;
-import org.eclipse.xtext.ide.server.ServerModule;
 import org.eclipse.xtext.testing.ReferenceTestConfiguration;
 import org.eclipse.xtext.util.Modules2;
 import org.eclipse.xtext.workspace.FileProjectConfig;
@@ -38,7 +37,7 @@ import com.google.inject.Module;
 public class IndexOnlyProjectTest extends AbstractTestLangLanguageServerTest {
 	@Override
 	public com.google.inject.Module getServerModule() {
-		return Modules2.mixin(new ServerModule(), new Module() {
+		return Modules2.mixin(super.getServerModule(), new Module() {
 
 			@Override
 			public void configure(Binder binder) {

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/OpenDocumentTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/OpenDocumentTest.java
@@ -8,14 +8,10 @@
  */
 package org.eclipse.xtext.ide.tests.server;
 
-import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.FileChangeType;
 import org.eclipse.lsp4j.FileEvent;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
-import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -63,12 +59,7 @@ public class OpenDocumentTest extends AbstractTestLangLanguageServerTest {
 		open(firstFile, model);
 		assertEquals("Couldn't resolve reference to TypeDeclaration 'NonExisting'.",
 				Iterables.getFirst(getDiagnostics().get(firstFile), null).getMessage());
-		DidChangeTextDocumentParams didChangeTextDocumentParams = new DidChangeTextDocumentParams();
-		didChangeTextDocumentParams.setTextDocument(new VersionedTextDocumentIdentifier(firstFile, 2));
-		TextDocumentContentChangeEvent textDocumentContentChangeEvent = new TextDocumentContentChangeEvent("Test");
-		textDocumentContentChangeEvent.setRange(new Range(new Position(1, 4), new Position(1, 15)));
-		didChangeTextDocumentParams.setContentChanges(Lists.newArrayList(textDocumentContentChangeEvent));
-		languageServer.didChange(didChangeTextDocumentParams);
+		edit(firstFile, 2, new Position(1, 4), new Position(1, 15), "Test");
 		Assert.assertNull(Iterables.getFirst(getDiagnostics().get(firstFile), null));
 	}
 

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/concurrent/RequestManager.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/concurrent/RequestManager.java
@@ -23,13 +23,11 @@ import org.eclipse.xtext.xbase.lib.Functions.Function2;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
-import com.google.inject.Singleton;
 
 /**
  * @author kosyakov - Initial contribution and API
  * @since 2.11
  */
-@Singleton
 public class RequestManager {
 
 	private final ExecutorService parallel;

--- a/org.eclipse.xtext/src/org/eclipse/xtext/build/IncrementalBuilder.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/build/IncrementalBuilder.java
@@ -51,7 +51,6 @@ import org.eclipse.xtext.resource.persistence.StorageAwareResource;
 import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.RuntimeIOException;
-import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.IResourceValidator;
 import org.eclipse.xtext.validation.Issue;
 import org.eclipse.xtext.workspace.IProjectConfig;
@@ -350,7 +349,7 @@ public class IncrementalBuilder {
 			if (resourceValidator == null) {
 				return true;
 			}
-			List<Issue> validationResult = resourceValidator.validate(resource, CheckMode.ALL,
+			List<Issue> validationResult = resourceValidator.validate(resource, context.getValidationMode(),
 					request.getCancelIndicator());
 			return request.getAfterValidate().afterValidate(resource.getURI(), validationResult);
 		}
@@ -359,6 +358,9 @@ public class IncrementalBuilder {
 		 * Generate code for the given resource
 		 */
 		protected void generate(Resource resource, BuildRequest request, Source2GeneratedMapping newMappings) {
+			if (context.isDirtyBuild()) {
+				return;
+			}
 			IResourceServiceProvider serviceProvider = getResourceServiceProvider(resource);
 			Set<URI> previous = newMappings.deleteSource(resource.getURI());
 			URIBasedFileSystemAccess fileSystemAccess = createFileSystemAccess(serviceProvider, resource);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/build/Indexer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/build/Indexer.java
@@ -122,7 +122,7 @@ public class Indexer {
 		Set<IResourceDescription.Delta> allDeltas = new HashSet<>(deltas);
 		allDeltas.addAll(request.getExternalDeltas());
 		Set<URI> deltaSet = FluentIterable.from(deltas).transform(Delta::getUri).toSet();
-		List<URI> allAffected = FluentIterable.from(previousIndex.getAllResourceDescriptions())
+		List<URI> allAffected = FluentIterable.from(context.getPossibleyAffectedResourceDescriptions())
 				.transform(IResourceDescription::getURI).filter(it -> !deltaSet.contains(it)).filter(it -> {
 					IResourceServiceProvider resourceServiceProvider = context.getResourceServiceProvider(it);
 					if (resourceServiceProvider != null) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/impl/LocalLayeredResourceDescriptionsData.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/impl/LocalLayeredResourceDescriptionsData.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Avaloq Group AG (http://www.avaloq.com).
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.resource.impl;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.naming.QualifiedName;
+import org.eclipse.xtext.resource.IEObjectDescription;
+import org.eclipse.xtext.resource.IResourceDescription;
+
+import com.google.common.collect.Iterables;
+
+/**
+ * @author Andrew Lamb - Initial contribution and API
+ * @since 2.29
+ */
+public class LocalLayeredResourceDescriptionsData extends ResourceDescriptionsData {
+
+	  private final ResourceDescriptionsData globalData;
+
+	  private final Set<URI> addedDescriptions = new LinkedHashSet<>();
+	  private final Set<URI> removedDescriptions = new LinkedHashSet<>();
+
+	  public LocalLayeredResourceDescriptionsData(ResourceDescriptionsData globalData) {
+	    super(Collections.emptyList());
+	    this.globalData = globalData;
+	  }
+
+	  protected LocalLayeredResourceDescriptionsData(ResourceDescriptionsData globalData, Map<URI, IResourceDescription> resourceDescriptionMap, Map<QualifiedName, Object> lookupMap, Set<URI> removedDescriptions) {
+	    super(resourceDescriptionMap, lookupMap);
+	    this.globalData = globalData;
+	    addedDescriptions.addAll(resourceDescriptionMap.keySet());
+	    this.removedDescriptions.addAll(removedDescriptions);
+	  }
+
+	  protected ResourceDescriptionsData getGlobalData() {
+	    return globalData;
+	  }
+
+	  protected Map<URI, IResourceDescription> copyLocalDescriptionsMap() {
+	    Map<URI, IResourceDescription> descriptionsMap = new LinkedHashMap<>(addedDescriptions.size());
+	    addedDescriptions.forEach(addedUri -> descriptionsMap.computeIfAbsent(addedUri, this::getResourceDescription));
+	    return descriptionsMap;
+	  }
+
+	  protected Set<URI> copyRemovedDescriptions() {
+	    return new LinkedHashSet<>(removedDescriptions);
+	  }
+
+	  @Override
+	  public ResourceDescriptionsData copy() {
+	    return new LocalLayeredResourceDescriptionsData(globalData, copyLocalDescriptionsMap(), copyLookupMap(), copyRemovedDescriptions());
+	  }
+
+	  @Override
+	  public Iterable<IResourceDescription> getAllResourceDescriptions() {
+	    return Iterables.concat(super.getAllResourceDescriptions(), Iterables.filter(globalData.getAllResourceDescriptions(), description -> {
+	      return !isLocal(description.getURI());
+	    }));
+	  }
+
+	  @Override
+	  public IResourceDescription getResourceDescription(URI uri) {
+	    if (addedDescriptions.contains(uri)) {
+	      return super.getResourceDescription(uri);
+	    }
+	    if (!removedDescriptions.contains(uri)) {
+	      return globalData.getResourceDescription(uri);
+	    }
+	    return null;
+	  }
+
+	  @Override
+	  public void addDescription(URI uri, IResourceDescription newDescription) {
+	    super.addDescription(uri, newDescription);
+	    removedDescriptions.remove(uri);
+	    addedDescriptions.add(uri);
+	  }
+
+	  @Override
+	  public void removeDescription(URI uri) {
+	    super.removeDescription(uri);
+	    addedDescriptions.remove(uri);
+	    if (globalData.getResourceDescription(uri) != null) {
+	      removedDescriptions.add(uri);
+	    }
+	  }
+
+	  protected Iterable<IEObjectDescription> joinIterables(Iterable<IEObjectDescription> localDescriptions, Iterable<IEObjectDescription> globalDescriptions) {
+	    return Iterables.concat(localDescriptions, Iterables.filter(globalDescriptions, description -> {
+	      return !isLocal(description.getEObjectURI().trimFragment());
+	    }));
+	  }
+
+	  /**
+	   * Test if the given uri is part of the local layer.
+	   *
+	   * @param uri
+	   *          the uri to test.
+	   * @return {@code true} if the local layer contains the given uri, {@code false} otherwise.
+	   */
+	  public boolean isLocal(URI uri) {
+	    return addedDescriptions.contains(uri) || removedDescriptions.contains(uri);
+	  }
+
+	  /**
+	   * Get the resource descriptions from the local layer only.
+	   *
+	   * @return the resource descriptions from the local layer.
+	   */
+	  public Iterable<IResourceDescription> getLocalResourceDescriptions() {
+	    return Iterables.transform(addedDescriptions, this::getResourceDescription);
+	  }
+
+	  @Override
+	  public Iterable<IEObjectDescription> getExportedObjects(EClass type, QualifiedName qualifiedName, boolean ignoreCase) {
+	    return joinIterables(super.getExportedObjects(type, qualifiedName, ignoreCase), globalData.getExportedObjects(type, qualifiedName, ignoreCase));
+	  }
+
+	  @Override
+	  public boolean isEmpty() {
+	    return super.isEmpty() && globalData.getAllURIs().size() <= removedDescriptions.size();
+	  }
+
+	  @Override
+	  public Iterable<IEObjectDescription> getExportedObjects() {
+	    return joinIterables(super.getExportedObjects(), globalData.getExportedObjects());
+	  }
+
+	  @Override
+	  public Iterable<IEObjectDescription> getExportedObjectsByType(EClass type) {
+	    return joinIterables(super.getExportedObjectsByType(type), globalData.getExportedObjectsByType(type));
+	  }
+
+	  @Override
+	  public Iterable<IEObjectDescription> getExportedObjectsByObject(EObject object) {
+	    return joinIterables(super.getExportedObjectsByObject(object), globalData.getExportedObjectsByObject(object));
+	  }
+	}


### PR DESCRIPTION
Enable a build of the persisted state to run in parallel to work performed on the dirty state by splitting the index, the resource set, the content provider, and the request manager into persisted and dirty components.

Introduces a limited scope dirty build so that validations are performed for dirty editors and the effect of changes in one dirty editor can be seen in other dirty editors.