### PR TITLE
Simplify the DefaultFoldingRangeProvider

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/DefaultFoldingRangeAcceptor.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/DefaultFoldingRangeAcceptor.java
@@ -11,8 +11,6 @@ package org.eclipse.xtext.ide.editor.folding;
 
 import java.util.Collection;
 
-import org.eclipse.xtext.util.ITextRegion;
-
 /**
  * @author Michael Clay - Initial contribution and API
  * @author Sebastian Zarnekow - Introduced FoldedPosition
@@ -21,7 +19,7 @@ import org.eclipse.xtext.util.ITextRegion;
  * @since 2.26
  */
 public class DefaultFoldingRangeAcceptor implements IFoldingRangeAcceptor {
-	private Collection<FoldingRange> result;
+	private final Collection<FoldingRange> result;
 
 	public DefaultFoldingRangeAcceptor(Collection<FoldingRange> result) {
 		this.result = result;
@@ -31,14 +29,12 @@ public class DefaultFoldingRangeAcceptor implements IFoldingRangeAcceptor {
 		return result;
 	}
 
-	@Override
-	public void accept(int offset, int length, FoldingRangeKind kind, boolean initiallyFolded,
-			ITextRegion visualPlaceholderRegion) {
-		result.add(createFoldingRange(offset, length, kind, initiallyFolded, visualPlaceholderRegion));
+	protected FoldingRange createFoldingRange(int offset, int length, FoldingRangeKind kind) {
+		return new FoldingRange(offset, length, kind);
 	}
-
-	protected FoldingRange createFoldingRange(int offset, int length, FoldingRangeKind kind, boolean initiallyFolded,
-			ITextRegion visualPlaceholderRegion) {
-		return new FoldingRange(offset, length, kind, initiallyFolded, visualPlaceholderRegion);
+	
+	@Override
+	public void accept(int offset, int length, FoldingRangeKind kind) {
+		result.add(createFoldingRange(offset, length, kind));
 	}
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/FoldingRange.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/FoldingRange.java
@@ -8,8 +8,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.ide.editor.folding;
 
-import org.eclipse.xtext.util.ITextRegion;
-
 import com.google.common.base.Objects;
 
 /**
@@ -25,32 +23,15 @@ public class FoldingRange {
 	private final int offset;
 	private final int length;
 	private final FoldingRangeKind kind;
-	private final boolean initiallyFolded;
-	private final ITextRegion visualPlaceholderRegion;
 
 	public FoldingRange(int offset, int length) {
 		this(offset, length, null);
 	}
 
 	public FoldingRange(int offset, int length, FoldingRangeKind kind) {
-		this(offset, length, kind, false, null);
-	}
-
-	public FoldingRange(int offset, int length, FoldingRangeKind kind, boolean initiallyFolded,
-			ITextRegion visualPlaceholderRegion) {
 		this.offset = offset;
 		this.length = length;
 		this.kind = kind;
-		this.initiallyFolded = initiallyFolded;
-		this.visualPlaceholderRegion = visualPlaceholderRegion;
-	}
-	
-	public boolean isInitiallyFolded() {
-		return initiallyFolded;
-	}
-
-	public ITextRegion getVisualPlaceholderRegion() {
-		return visualPlaceholderRegion;
 	}
 
 	public FoldingRangeKind getKind() {
@@ -69,16 +50,15 @@ public class FoldingRange {
 	public boolean equals(Object other) {
 		if (other instanceof FoldingRange) {
 			FoldingRange range = (FoldingRange) other;
-			return offset == range.offset && length == range.length && initiallyFolded == range.initiallyFolded
-					&& Objects.equal(kind, range.kind)
-					&& Objects.equal(visualPlaceholderRegion, range.visualPlaceholderRegion);
+			return offset == range.offset && length == range.length
+					&& Objects.equal(kind, range.kind);
 		}
 		return false;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hashCode(offset, length, initiallyFolded, kind, visualPlaceholderRegion);
+		return Objects.hashCode(offset, length, kind);
 	}
 	
 	@Override
@@ -87,7 +67,6 @@ public class FoldingRange {
 		content.append("offset=").append(offset);
 		content.append(", length=").append(length);
 		content.append(", kind=").append(kind);
-		content.append(", initiallyFolded=").append(initiallyFolded);
 		return content.toString();
 	}
 }

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/IFoldingRangeAcceptor.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/IFoldingRangeAcceptor.java
@@ -9,8 +9,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.ide.editor.folding;
 
-import org.eclipse.xtext.util.ITextRegion;
-
 /**
  * @author Michael Clay - Initial contribution and API
  * @author Sebastian Zarnekow - Distinguish between total and identifying region
@@ -20,26 +18,5 @@ import org.eclipse.xtext.util.ITextRegion;
  */
 public interface IFoldingRangeAcceptor {
 
-	default void accept(int offset, int length) {
-		accept(offset, length, false);
-	}
-
-	default void accept(int offset, int length, FoldingRangeKind kind) {
-		accept(offset, length, kind, null);
-	}
-
-	default void accept(int offset, int length, boolean initiallyFolded) {
-		accept(offset, length, null, initiallyFolded, null);
-	}
-
-	default void accept(int offset, int length, ITextRegion visualPlaceholderRegion) {
-		accept(offset, length, null, false, visualPlaceholderRegion);
-	}
-
-	default void accept(int offset, int length, FoldingRangeKind kind, ITextRegion visualPlaceholderRegion) {
-		accept(offset, length, kind, false, visualPlaceholderRegion);
-	}
-
-	void accept(int offset, int length, FoldingRangeKind kind, boolean initiallyFolded,
-			ITextRegion visualPlaceholderRegion);
+	void accept(int offset, int length, FoldingRangeKind kind);
 }


### PR DESCRIPTION
Simplify the DefaultFoldingRangeProvider, since LSP does not support the properties initiallyFolded and visualPlaceholderRegion there is no need to calculate them.

Signed-off-by: pcr <Ruben.PorrasCampo@avaloq.com>