### PR TITLE
Improve SemanticTokensFullConfiguration to avoid text comparison

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/IndexOnlyProjectTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/IndexOnlyProjectTest.java
@@ -49,18 +49,18 @@ public class IndexOnlyProjectTest extends AbstractTestLangLanguageServerTest {
 						String uri = null;
 						if (workspaceFolder != null) {
 							uri = workspaceFolder.getUri();
-						}
-						if (uri != null) {
-							FileProjectConfig project = new FileProjectConfig(
-									getUriExtensions().toUri(workspaceFolder.getUri()),
-									getUniqueProjectName(workspaceFolder.getName(), existingNames)) {
-								@Override
-								public boolean isIndexOnly() {
-									return true;
-								}
-							};
-							project.addSourceFolder(".");
-							workspaceConfig.addProject(project);
+							if (uri != null) {
+								FileProjectConfig project = new FileProjectConfig(
+										getUriExtensions().toUri(uri),
+										getUniqueProjectName(workspaceFolder.getName(), existingNames)) {
+									@Override
+									public boolean isIndexOnly() {
+										return true;
+									}
+								};
+								project.addSourceFolder(".");
+								workspaceConfig.addProject(project);
+							}
 						}
 					}
 				});

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/SemanticTokensTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/SemanticTokensTest.java
@@ -38,7 +38,7 @@ public class SemanticTokensTest extends AbstractTestLangLanguageServerTest {
 		expectedTokens.add(ImmutableList.of(3,0,4,1,0));
 		expectedTokens.add(ImmutableList.of(0,9,7,1,0));
 		
-		it.setExpectedText(expectedTokens.stream().flatMap(List::stream).map(i -> i.toString()).collect(Collectors.joining("\n")));
+		it.setExpected(expectedTokens.stream().flatMap(List::stream).collect(Collectors.toList()));
 		});
 	}
 }

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
@@ -504,7 +504,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 			textDocument = new TextDocumentIdentifier(filePath)
 		])
 
-		assertEquals(configuration.expectedText + "\n", result.get.data.toExpectation)
+		Assert.assertArrayEquals(configuration.expected.toArray, result.get.data.toArray)
 	}
 
 	protected def void testCodeAction((TestCodeActionConfiguration)=>void configurator) {

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/SemanticTokensFullConfiguration.java
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/SemanticTokensFullConfiguration.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.xtext.testing;
 
+import java.util.List;
+
 import com.google.common.annotations.Beta;
 
 /**
@@ -15,13 +17,13 @@ import com.google.common.annotations.Beta;
  */
 @Beta
 public class SemanticTokensFullConfiguration extends TextDocumentConfiguration {
-	private String expectedText = "";
+	private List<Integer> expected = null;
 
-	public String getExpectedText() {
-		return expectedText;
+	public List<Integer> getExpected() {
+		return expected;
 	}
 
-	public void setExpectedText(String expectedText) {
-		this.expectedText = expectedText;
+	public void setExpected(List<Integer> expected) {
+		this.expected = expected;
 	}
 }

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
@@ -1070,9 +1070,7 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
       };
       SemanticTokensParams _doubleArrow = ObjectExtensions.<SemanticTokensParams>operator_doubleArrow(_semanticTokensParams, _function);
       final CompletableFuture<SemanticTokens> result = this.languageServer.semanticTokensFull(_doubleArrow);
-      String _expectedText = configuration.getExpectedText();
-      String _plus = (_expectedText + "\n");
-      this.assertEquals(_plus, this.toExpectation(result.get().getData()));
+      Assert.assertArrayEquals(configuration.getExpected().toArray(), result.get().getData().toArray());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }


### PR DESCRIPTION
also, include a small fix to IndexOnlyProjectTest to avoid a "possible NPE" marker given by the JDT Null Pointer Analysis.

Signed-off-by: rubenporras <Ruben.PorrasCampo@avaloq.com>