### PR TITLE
Pin also emf.ecore

### DIFF
--- a/org.eclipse.xtext/build.gradle
+++ b/org.eclipse.xtext/build.gradle
@@ -8,8 +8,9 @@ dependencies {
 	api 'org.eclipse.platform:org.eclipse.equinox.common'
 	// remove me, once the following is fixed : https://bugs.eclipse.org/bugs/show_bug.cgi?id=510504
 	api 'org.eclipse.platform:org.eclipse.osgi'
-	api 'org.eclipse.emf:org.eclipse.emf.common'
+	api 'org.eclipse.emf:org.eclipse.emf.ecore'
 	api 'org.eclipse.emf:org.eclipse.emf.ecore.xmi'
+	api 'org.eclipse.emf:org.eclipse.emf.common'
 	api 'com.google.inject:guice'
 	api 'org.antlr:antlr-runtime'
 	optional 'org.eclipse.platform:org.eclipse.core.runtime'


### PR DESCRIPTION

See eclipse/xtext#2397
This is the same but for org.eclipse.xtext

Signed-off-by: Lorenzo Bettini lorenzo.bettini@gmail.com