### PR TITLE
rely on 'getScopeProvider()' instead of the corresponding field in 'IdeContentProposalProvider'

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/contentassist/IdeContentProposalProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/contentassist/IdeContentProposalProvider.java
@@ -140,7 +140,7 @@ public class IdeContentProposalProvider {
 			EReference eReference = GrammarUtil.getReference(reference, ((EClass) type));
 			EObject currentModel = context.getCurrentModel();
 			if (eReference != null && currentModel != null) {
-				IScope scope = scopeProvider.getScope(currentModel, eReference);
+				IScope scope = getScopeProvider().getScope(currentModel, eReference);
 				crossrefProposalProvider.lookupCrossReference(scope, reference, context, acceptor,
 						getCrossrefFilter(reference, context));
 			}


### PR DESCRIPTION
this way the employed scope provider can be replaced in a subclass